### PR TITLE
PDB parse_element_string fix, error on fully uppercase element strings

### DIFF
--- a/src/fileformats/PDB.jl
+++ b/src/fileformats/PDB.jl
@@ -12,7 +12,7 @@ function parse_element_string(es::String)
         result = Elements.Unknown
     else
         try
-            result = parse(Elements, es)
+            result = parse(Elements, titlecase(es))
         catch e
             @warn "BiochemicalAlgorithms::PDB::parse_element_string: could not parse element from $(es); returning Unknown"
         end


### PR DESCRIPTION
It was erroring on MG, ZN and some other element strings. Quick fix for element strings of length 2 => First letter uppercase, second lower case.