### PR TITLE
Jl/enum naming

### DIFF
--- a/src/core/atom.jl
+++ b/src/core/atom.jl
@@ -3,7 +3,7 @@ export Atom, AtomProperties
 const Atom{T} = @NamedTuple begin
     number::Int
     name::String
-    element::Element
+    element::ElementType
     atomtype::String
     r::Vector3{T}
     v::Vector3{T}

--- a/src/core/element.jl
+++ b/src/core/element.jl
@@ -1,6 +1,6 @@
 using EnumX
 
-export Elements, Element
+export Elements, ElementType
 
 @enumx Elements begin
   H = 1
@@ -124,6 +124,6 @@ export Elements, Element
   Unknown = 255
 end
 
-const Element = Elements.T
+const ElementType = Elements.T
 
 Base.parse(Elements, s) = getproperty(Elements, Symbol(s))

--- a/src/fileformats/pubchem_json.jl
+++ b/src/fileformats/pubchem_json.jl
@@ -1,6 +1,6 @@
 export load_pubchem_json
 
-using BiochemicalAlgorithms: Molecule, Atom, BondOrder, BondOrderType, Bond, Elements, Element, Vector3
+using BiochemicalAlgorithms: Molecule, Atom, BondOrder, BondOrderType, Bond, Elements, ElementType, Vector3
 
 using StructTypes
 using JSON3
@@ -530,7 +530,7 @@ function load_pubchem_json(fname::String, T=Float32)
                             name="",
                             element = isnothing(compound.atoms.element) 
                                 ? Elements.Unknown 
-                                : Element(Int(compound.atoms.element[i])),
+                                : ElementType(Int(compound.atoms.element[i])),
                             atomtype = isnothing(compound.atoms.label)
                                 ? ""
                                 : compound.atoms.label[i].value, # does the label contain the atom type?
@@ -560,6 +560,6 @@ function load_pubchem_json(fname::String, T=Float32)
             end
         end
     end
-
+    
     mol
 end


### PR DESCRIPTION
Suggestion for renaming enum ElementType analog to enum BondOrder:
```
@enumx BondOrder begin
    Single = 1
    Double = 2
    Triple = 3
    Quadruple = 4
    Unknown = 100
end
```
defined at: 
https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/blob/2c0ff151a5a4ac6b8f90372e7858ce0a0b7914d4/src/core/bond.jl#L13