### PR TITLE
CI: Limit DCO checks to PRs and manual triggers

### DIFF
--- a/.github/workflows/DCO.yml
+++ b/.github/workflows/DCO.yml
@@ -1,7 +1,7 @@
 name: DCO check
 on:
   pull_request:
-  push:
+  workflow_dispatch:
 jobs:
   dco-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should reduce noise/hassle in forks of this repository that do not or do not yet implement our DCO policy but still wish to use the other Github actions
