### PR TITLE
ah/amberff fixes

### DIFF
--- a/src/forcefields/common/bend_component.jl
+++ b/src/forcefields/common/bend_component.jl
@@ -48,8 +48,8 @@ function setup!(qbc::QuadraticBendComponent{T}) where {T<:Real}
 
     bends = Vector{QuadraticAngleBend}()
 
-    for atom in atoms(ff.system)
-        bs = collect(bonds(atom))
+    for atom in eachatom(ff.system)
+        bs = bonds(atom)
 
         for i in eachindex(bs)
             bond_1 = bs[i]

--- a/src/forcefields/common/forcefield.jl
+++ b/src/forcefields/common/forcefield.jl
@@ -82,7 +82,7 @@ function assign_typenames_and_charges!(ff::ForceField{T}) where {T<:Real}
     # clear the list of unassigned_atoms
     empty!(ff.unassigned_atoms)
 
-    for atom in atoms(ff.system)
+    for atom in eachatom(ff.system)
         if !_try_assign!(
                 ff.atom_type_templates, 
                 get_full_name(atom), 

--- a/src/forcefields/common/nonbonded_component.jl
+++ b/src/forcefields/common/nonbonded_component.jl
@@ -254,7 +254,7 @@ function _setup_hydrogenbonds!(nbc::NonBondedComponent{T}) where {T<:Real}
     hydrogen_bonds_df.B .*= T(hbond_B_factor)
 
     hydrogen_bond_combinations_cache = Dict(
-        (I=r.I, J=r.J,) => (A=r.A, B_ij=r.B) 
+        (I=r.I, J=r.J,) => (A=r.A, B=r.B) 
             for r in eachrow(hydrogen_bonds_df)
     )
 
@@ -425,12 +425,11 @@ function update!(nbc::NonBondedComponent{T}) where {T<:Real}
             )
 
             if !ismissing(h_params)
-                params = only(params)
                 push!(
                     hydrogen_bonds,
                     LennardJonesInteraction{T, 12, 10}(
-                        params.A,
-                        params.B,
+                        only(h_params.A),
+                        only(h_params.B),
                         T(lj_candidate[3]),
                         T(1.0),
                         atom_1,

--- a/src/forcefields/common/stretch_component.jl
+++ b/src/forcefields/common/stretch_component.jl
@@ -48,7 +48,7 @@ function setup!(qsc::QuadraticStretchComponent{T}) where {T}
     stretches = Vector{QuadraticBondStretch}(undef, nbonds(ff.system))
 
     # iterate over all bonds in the system
-    for (i, bond) in enumerate(bonds(ff.system))
+    for (i, bond) in enumerate(eachbond(ff.system))
         a1 = atom_by_idx(parent_system(ff.system), bond.a1)
         a2 = atom_by_idx(parent_system(ff.system), bond.a2)
 

--- a/src/preprocessing/fragmentDB.jl
+++ b/src/preprocessing/fragmentDB.jl
@@ -385,13 +385,14 @@ function get_reference_fragment(f::Fragment{T}, fdb::FragmentDB) where {T<:Real}
     # DBFragments don't know anything about flags, they only know properties
     # so we mix them together here
     f_props = merge(f.properties, Dict{Symbol, Any}(flag => true for flag in f.flags))
+    is_true(x) = typeof(x) === Bool && x
 
     # iterate over all variants of the fragment and compare the properties
     for var in db_fragment.variants
         var_props = Dict(Symbol(p.name) => p.value for p in var.properties)
 
         # count the difference in the number of set properties
-        property_difference = abs(length(findall(identity, f_props)) - length(findall(identity, var_props)))
+        property_difference = abs(length(findall(is_true, f_props)) - length(findall(is_true, var_props)))
 
         # and count the properties fragment and variant have in common
         number_of_properties = length(f_props ∩ var_props)

--- a/src/preprocessing/reconstruct_fragments.jl
+++ b/src/preprocessing/reconstruct_fragments.jl
@@ -15,7 +15,7 @@ function _get_two_reference_atoms(ref_center_atom::DBAtom{T}, allowed::Set{DBAto
     # or we are running out of fresh atoms
 
     (current, atom_list_rest) = Iterators.peel(atom_list)
-    while length(atom_list) < 3 && !isnothing(current)
+    while length(atom_list) < 3
         for bond in bonds(current, ref)
             next_atom = get_partner(bond, current, ref)
 
@@ -28,6 +28,7 @@ function _get_two_reference_atoms(ref_center_atom::DBAtom{T}, allowed::Set{DBAto
         end
         
         # try the bonds of the next atom in the list
+        isempty(atom_list_rest) && break
         (current, atom_list_rest) = Iterators.peel(atom_list_rest)
     end
 


### PR DESCRIPTION
**Work around FragmentDB errors w/ non-bool fragment properties**
FragmentDB implicitly assumed all fragment properties to have boolean values, leading to errors when non-bool properties were present.

**Fix end-of-iterator check w/ reconstruct_fragments!**
The previous implementation tested only whether the current DBAtom was
`nothing`, which should be impossible at this point. While
Iterators.peel does return `nothing` when the iterator is empty, the
result cannot be assigned to a tuple as it is the only return value in
this case:

MWE showing the error:
```julia
v = [:A]
(c, vr) = Iterators.peel(v)   # ok
#Iterators.peel(vr)           # ok
(c, vr) = Iterators.peel(vr)  # error
```