### PR TITLE
Prefer `nothing` over `missing` for absent foreign keys in `Atom`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 
 [compat]
-AutoHashEquals = "0.2, 1"
+AutoHashEquals = "0.2, 1, 2"
 BioStructures = "1, 2"
 BioSymbols = "4, 5"
 DataFrames = "1"

--- a/src/core/atom.jl
+++ b/src/core/atom.jl
@@ -89,11 +89,11 @@ function Atom(
     flags::Flags = Flags();
     frame_id::Int = 1,
     # private kwargs
-    molecule_id::MaybeInt = missing,
-    chain_id::MaybeInt = missing,
-    fragment_id::MaybeInt = missing,
-    nucleotide_id::MaybeInt = missing,
-    residue_id::MaybeInt = missing
+    molecule_id::MaybeInt = nothing,
+    chain_id::MaybeInt = nothing,
+    fragment_id::MaybeInt = nothing,
+    nucleotide_id::MaybeInt = nothing,
+    residue_id::MaybeInt = nothing
 ) where T
     idx = _next_idx(sys)
     push!(sys._atoms, (idx, number, element, name, atom_type, r, v, F, formal_charge, charge, radius,
@@ -170,31 +170,31 @@ end
 @inline parent_system(atom::Atom) = parent(atom)
 
 @inline function parent_molecule(atom::Atom) 
-    ismissing(atom._row.molecule_id) ?
+    isnothing(atom._row.molecule_id) ?
         nothing :
         molecule_by_idx(parent(atom), atom._row.molecule_id)
 end
 
 @inline function parent_chain(atom::Atom)
-    ismissing(atom._row.chain_id) ?
+    isnothing(atom._row.chain_id) ?
         nothing :
         chain_by_idx(atom._sys, atom._row.chain_id)
 end
 
 @inline function parent_fragment(atom::Atom)
-    ismissing(atom._row.fragment_id) ?
+    isnothing(atom._row.fragment_id) ?
         nothing :
         fragment_by_idx(parent(atom), atom._row.fragment_id)
 end
 
 @inline function parent_nucleotide(atom::Atom)
-    ismissing(atom._row.nucleotide_id) ?
+    isnothing(atom._row.nucleotide_id) ?
         nothing :
         nucleotide_by_idx(parent(atom), atom._row.nucleotide_id)
 end
 
 @inline function parent_residue(atom::Atom)
-    ismissing(atom._row.residue_id) ?
+    isnothing(atom._row.residue_id) ?
         nothing :
         residue_by_idx(parent(atom), atom._row.residue_id)
 end
@@ -219,25 +219,25 @@ end
 """
     $(TYPEDSIGNATURES)
 
-Returns a raw `DataFrame` for all of the given system's atoms matching the given criteria (value or
-`missing`). Fields given as `nothing` are ignored. The returned `DataFrame` contains all public and
-private atom fields.
+Returns a raw `DataFrame` for all of the given system's atoms matching the given criteria. Fields
+given as `nothing` are ignored. Use `Some(nothing)` if the field should be explicitly checked for
+a value of `nothing`. The returned `DataFrame` contains all public and private atom fields.
 """
 function _atoms(sys::System{T};
-    frame_id::Union{Nothing, Int} = 1,
-    molecule_id::Union{Nothing, MaybeInt} = nothing,
-    chain_id::Union{Nothing, MaybeInt} = nothing,
-    fragment_id::Union{Nothing, MaybeInt} = nothing,
-    nucleotide_id::Union{Nothing, MaybeInt} = nothing,
-    residue_id::Union{Nothing, MaybeInt} = nothing
+    frame_id::MaybeInt = 1,
+    molecule_id::Union{MaybeInt, Some{Nothing}} = nothing,
+    chain_id::Union{MaybeInt, Some{Nothing}} = nothing,
+    fragment_id::Union{MaybeInt, Some{Nothing}} = nothing,
+    nucleotide_id::Union{MaybeInt, Some{Nothing}} = nothing,
+    residue_id::Union{MaybeInt, Some{Nothing}} = nothing
 ) where T
     cols = Tuple{Symbol, MaybeInt}[]
     isnothing(frame_id)      || push!(cols, (:frame_id, frame_id))
-    isnothing(molecule_id)   || push!(cols, (:molecule_id, molecule_id))
-    isnothing(chain_id)      || push!(cols, (:chain_id, chain_id))
-    isnothing(fragment_id)   || push!(cols, (:fragment_id, fragment_id))
-    isnothing(nucleotide_id) || push!(cols, (:nucleotide_id, nucleotide_id))
-    isnothing(residue_id)    || push!(cols, (:residue_id, residue_id))
+    isnothing(molecule_id)   || push!(cols, (:molecule_id, something(molecule_id)))
+    isnothing(chain_id)      || push!(cols, (:chain_id, something(chain_id)))
+    isnothing(fragment_id)   || push!(cols, (:fragment_id, something(fragment_id)))
+    isnothing(nucleotide_id) || push!(cols, (:nucleotide_id, something(nucleotide_id)))
+    isnothing(residue_id)    || push!(cols, (:residue_id, something(residue_id)))
 
     get(
         groupby(sys._atoms, getindex.(cols, 1)),
@@ -258,7 +258,7 @@ end
 Returns a `Vector{Atom{T}}` containing all atoms of the given atom container.
 
 # Supported keyword arguments
- - `frame_id::Union{Nothing, Int} = 1`: \
+ - `frame_id::MaybeInt = 1`: \
 Any value other than `nothing` limits the result to atoms matching this frame ID.
 """
 @inline function atoms(sys::System; kwargs...)
@@ -277,7 +277,7 @@ end
 Returns a `SubDataFrame` containing all atoms of the given atom container.
 
 # Supported keyword arguments
- - `frame_id::Union{Nothing, Int} = 1`: \
+ - `frame_id::MaybeInt = 1`: \
 Any value other than `nothing` limits the result to atoms matching this frame ID.
 """
 @inline function atoms_df(sys::System{T}; kwargs...) where T
@@ -296,7 +296,7 @@ end
 Returns an `Atom{T}` generator for all atoms of the given atom container.
 
 # Supported keyword arguments
- - `frame_id::Union{Nothing, Int} = 1`: \
+ - `frame_id::MaybeInt = 1`: \
 Any value other than `nothing` limits the result to atoms matching this frame ID.
 
 # Example
@@ -322,7 +322,7 @@ end
 Returns the number of atoms in the given atom container.
 
 # Supported keyword arguments
- - `frame_id::Union{Nothing, Int} = 1`: \
+ - `frame_id::MaybeInt = 1`: \
 Any value other than `nothing` limits the result to atoms matching this frame ID.
 """
 @inline function natoms(sys::System; kwargs...)
@@ -393,11 +393,11 @@ automatically assigned a new `idx`.
 """
 function Base.push!(sys::System{T}, atom::AtomTuple{T};
     frame_id::Int = 1,
-    molecule_id::MaybeInt = missing,
-    chain_id::MaybeInt = missing,
-    fragment_id::MaybeInt = missing,
-    nucleotide_id::MaybeInt = missing,
-    residue_id::MaybeInt = missing
+    molecule_id::MaybeInt = nothing,
+    chain_id::MaybeInt = nothing,
+    fragment_id::MaybeInt = nothing,
+    nucleotide_id::MaybeInt = nothing,
+    residue_id::MaybeInt = nothing
 ) where T
     push!(sys._atoms, 
         (; atom..., 

--- a/src/core/bond.jl
+++ b/src/core/bond.jl
@@ -97,8 +97,8 @@ end
     $(TYPEDSIGNATURES)
 
 Returns a raw `DataFrame` for all of the given system's bonds associated with at least one atom
-matching the given criteria (value or `missing`). Fields given as `nothing` are ignored. See
-[`_atoms`](@ref).
+matching the given criteria. Fields given as `nothing` are ignored. Use `Some(nothing)` if the field
+should be explicitly checked for a value of `nothing`. See [`_atoms`](@ref).
 """
 function _bonds(sys::System; kwargs...)
     # FIXME this implementation currently ignores bonds with _two_ invalid atom IDs
@@ -121,7 +121,7 @@ Returns a `Vector{Bond{T}}` containing all bonds of the given atom container whe
 associated atom is contained in the same container.
 
 # Supported keyword arguments
- - `frame_id::Union{Nothing, Int} = 1`: \
+ - `frame_id::MaybeInt = 1`: \
 Any value other than `nothing` also limits the result to bonds where at least on atom matches \
 this frame ID.
 """
@@ -142,7 +142,7 @@ Returns a `SubDataFrame` containing all bonds of the given atom container where 
 associated atom is contained in the same container.
 
 # Supported keyword arguments
- - `frame_id::Union{Nothing, Int} = 1`: \
+ - `frame_id::MaybeInt = 1`: \
 Any value other than `nothing` also limits the result to bonds where at least on atom matches \
 this frame ID.
 """
@@ -163,7 +163,7 @@ Returns a `Bond{T}` generator for all bonds of the given atom container where at
 associated atom is contained in the same container.
 
 # Supported keyword arguments
- - `frame_id::Union{Nothing, Int} = 1`: \
+ - `frame_id::MaybeInt = 1`: \
 Any value other than `nothing` also limits the result to bonds where at least on atom matches \
 this frame ID.
 """
@@ -184,7 +184,7 @@ Returns the number of bonds in the given atom container where at least one assoc
 is contained in the same container.
 
 # Supported keyword arguments
- - `frame_id::Union{Nothing, Int} = 1`: \
+ - `frame_id::MaybeInt = 1`: \
 Any value other than `nothing` also limits the result to bonds where at least on atom matches \
 this frame ID.
 """

--- a/src/core/chain.jl
+++ b/src/core/chain.jl
@@ -82,7 +82,7 @@ end
 Returns a raw `DataFrame` for all of the given system's chains matching the given criteria. Fields
 given as `nothing` are ignored. The returned `DataFrame` contains all public and private chain fields.
 """
-function _chains(sys::System; molecule_id::Union{Nothing, Int} = nothing)
+function _chains(sys::System; molecule_id::MaybeInt = nothing)
     isnothing(molecule_id) && return sys._chains
 
     get(

--- a/src/core/fragment.jl
+++ b/src/core/fragment.jl
@@ -87,8 +87,8 @@ Returns a raw `DataFrame` for all of the given system's fragments matching the g
 given as `nothing` are ignored. The returned `DataFrame` contains all public and private fragment fields.
 """
 function _fragments(sys::System{T};
-        molecule_id::Union{Nothing, Int} = nothing,
-        chain_id::Union{Nothing, Int} = nothing
+        molecule_id::MaybeInt = nothing,
+        chain_id::MaybeInt = nothing
 ) where T
     isnothing(molecule_id) && isnothing(chain_id) && return sys._fragments
 

--- a/src/core/nucleotide.jl
+++ b/src/core/nucleotide.jl
@@ -86,8 +86,8 @@ Returns a raw `DataFrame` for all of the given system's nucleotides matching the
 given as `nothing` are ignored. The returned `DataFrame` contains all public and private nucleotide fields.
 """
 function _nucleotides(sys::System{T};
-    molecule_id::Union{Nothing, Int} = nothing,
-    chain_id::Union{Nothing, Int} = nothing
+    molecule_id::MaybeInt = nothing,
+    chain_id::MaybeInt = nothing
 ) where T
     isnothing(molecule_id) && isnothing(chain_id) && return sys._nucleotides
 

--- a/src/core/residue.jl
+++ b/src/core/residue.jl
@@ -85,8 +85,8 @@ Returns a raw `DataFrame` for all of the given system's residues matching the gi
 as `nothing` are ignored. The returned `DataFrame` contains all public and private residue fields.
 """
 function _residues(sys::System{T};
-    molecule_id::Union{Nothing, Int} = nothing,
-    chain_id::Union{Nothing, Int} = nothing
+    molecule_id::MaybeInt = nothing,
+    chain_id::MaybeInt = nothing
 ) where T
     isnothing(molecule_id) && isnothing(chain_id) && return sys._residues
 

--- a/src/core/system.jl
+++ b/src/core/system.jl
@@ -167,7 +167,7 @@ end
 Returns the row number corresponding to the given `idx` in `df`.
 """
 @inline function _row_by_idx(df::DataFrame, idx::Int)
-    DataFramesMeta.@with df findfirst(:idx .== idx)::Union{Nothing, Int}
+    DataFramesMeta.@with df findfirst(:idx .== idx)::MaybeInt
 end
 
 Base.show(io::IO, ::MIME"text/plain", sys::System) = show(io, sys)

--- a/src/core/types.jl
+++ b/src/core/types.jl
@@ -5,6 +5,6 @@ export Vector3, Matrix3, MaybeInt, Properties, Flags
 const Vector3{T} = SVector{3, T}
 const Matrix3{T} = SMatrix{3, 3, T}
 
-const MaybeInt = Union{Missing, Int}
+const MaybeInt = Union{Nothing, Int}
 const Properties = Dict{Symbol, Any}
 const Flags = Set{Symbol}

--- a/test/core/test_atom.jl
+++ b/test/core/test_atom.jl
@@ -69,11 +69,11 @@ using BiochemicalAlgorithms: _SystemAtomTuple, _atoms, _bonds
 
         @test atom._row.frame_id isa Int
         @test atom._row.frame_id == 1
-        @test ismissing(atom._row.molecule_id)
-        @test ismissing(atom._row.chain_id)
-        @test ismissing(atom._row.fragment_id)
-        @test ismissing(atom._row.nucleotide_id)
-        @test ismissing(atom._row.residue_id)
+        @test isnothing(atom._row.molecule_id)
+        @test isnothing(atom._row.chain_id)
+        @test isnothing(atom._row.fragment_id)
+        @test isnothing(atom._row.nucleotide_id)
+        @test isnothing(atom._row.residue_id)
 
         @test atom2._row.frame_id isa Int
         @test atom2._row.frame_id == 10


### PR DESCRIPTION
`missing` and `nothing` behave differently, e.g., when it comes to equality checks via ==. AutoHashEquals v2 adopts standard Julia behavior for types containing missing elements, that is, == returns `missing` rather than a boolean value if at least one member is `missing`:
```
  ==(x, y)

  [...]
  The result is of type Bool, except when one of the operands is missing, in which case missing is returned (three-valued logic (https://en.wikipedia.org/wiki/Three-valued_logic)). For collections, missing is returned if at least one of the operands contains a missing value
  and all non-missing values are equal. Use isequal or === to always get a Bool result.
```

This PR changes the internal representation of atoms to be more in line with the original intention behind `missing` vs. `nothing` while retaining the previous behavior of == for system components.