### PR TITLE
System: introduce `ColumnTableRow` type

### DIFF
--- a/src/core/atom.jl
+++ b/src/core/atom.jl
@@ -70,7 +70,7 @@ Atom(
 ```
 Creates a new `Atom{Float32}` in the default system. Supports the same keyword arguments as above.
 """
-const Atom{T} = SystemComponent{T, _AtomTableRow{T}}
+const Atom{T} = SystemComponent{T, _AtomTable{T}}
 
 @inline function Atom(
     sys::System{T},

--- a/src/core/bond.jl
+++ b/src/core/bond.jl
@@ -51,7 +51,7 @@ Bond(
 ```
 Creates a new `Bond{Float32}` in the default system.
 """
-const Bond{T} = AtomContainer{T, _BondTableRow}
+const Bond{T} = AtomContainer{T, _BondTable}
 
 @inline function Bond(
     sys::System{T}, 

--- a/src/core/chain.jl
+++ b/src/core/chain.jl
@@ -32,7 +32,7 @@ Chain(
 ```
 Creates a new `Chain{T}` in the given molecule.
 """
-const Chain{T} = AtomContainer{T, _ChainTableRow}
+const Chain{T} = AtomContainer{T, _ChainTable}
 
 @inline function Chain(
     mol::Molecule;

--- a/src/core/fragment.jl
+++ b/src/core/fragment.jl
@@ -58,7 +58,7 @@ Fragment(
 ```
 Creates a new `Fragment{T}` in the given chain.
 """
-const Fragment{T} = AtomContainer{T, _FragmentTableRow}
+const Fragment{T} = AtomContainer{T, _FragmentTable}
 
 @inline function Fragment(
     chain::Chain{T},

--- a/src/core/molecule.jl
+++ b/src/core/molecule.jl
@@ -50,7 +50,7 @@ Molecule(;
 ```
 Creates a new `Molecule{Float32}` in the default system.
 """
-const Molecule{T} = AtomContainer{T, _MoleculeTableRow}
+const Molecule{T} = AtomContainer{T, _MoleculeTable}
 
 @inline function Molecule(
     sys::System{T};

--- a/src/core/system.jl
+++ b/src/core/system.jl
@@ -191,9 +191,9 @@ Returns the `System{T}` containing the given object. Alias for
 """ parent_system
 parent_system(s::System) = s
 
-@auto_hash_equals struct SystemComponent{T, R <: _AbstractColumnTableRow} <: AbstractSystemComponent{T}
+@auto_hash_equals struct SystemComponent{T, C <: AbstractColumnTable} <: AbstractSystemComponent{T}
     _sys::System{T}
-    _row::R
+    _row::ColumnTableRow{C}
 end
 
 @inline function Base.getproperty(sc::SystemComponent, name::Symbol)
@@ -215,13 +215,13 @@ end
 @inline Base.parent(sc::SystemComponent) = sc._sys
 @inline parent_system(sc::SystemComponent) = parent(sc)
 
-@auto_hash_equals struct AtomContainer{T, R <: _AbstractColumnTableRow} <: AbstractAtomContainer{T}
-    _comp::SystemComponent{T, R}
+@auto_hash_equals struct AtomContainer{T, C <: AbstractColumnTable} <: AbstractAtomContainer{T}
+    _comp::SystemComponent{T, C}
 
-    function AtomContainer{T, R}(
+    function AtomContainer{T, C}(
         sys::System{T},
-        row::R
-    ) where {T, R <: _AbstractColumnTableRow}
+        row::ColumnTableRow{C}
+    ) where {T, C <: AbstractColumnTable}
         new(SystemComponent(sys, row))
     end
 end

--- a/src/core/system_component_table.jl
+++ b/src/core/system_component_table.jl
@@ -64,3 +64,5 @@ end
 @inline function Base.getindex(ct::SystemComponentTable{T, C}, I::AbstractArray) where {T, C}
     SystemComponentTable{T, C}(ct._sys, collect(Int, map(i -> ct._idx[i], I)))
 end
+
+@inline _row_by_idx(ct::SystemComponentTable, idx::Int) = _row_by_idx(_table(ct), idx)

--- a/src/core/system_internals/_atom_table.jl
+++ b/src/core/system_internals/_atom_table.jl
@@ -132,24 +132,4 @@ function _atom_table(::Type{T}, itr) where T
 end
 @inline Tables.materializer(::Type{_AtomTable{T}}) where T = itr -> _atom_table(T, itr)
 
-@auto_hash_equals struct _AtomTableRow{T} <: _AbstractColumnTableRow
-    _row::Int
-    _tab::_AtomTable{T}
-end
-
-@inline Tables.getcolumn(atr::_AtomTableRow, nm::Symbol) = Tables.getcolumn(getfield(atr, :_tab), nm)[getfield(atr, :_row)]
-@inline Tables.getcolumn(atr::_AtomTableRow, i::Int) = getfield(atr, Tables.columnnames(atr)[i])
-@inline Tables.columnnames(::_AtomTableRow) = _atom_table_cols
-
-@inline _row_by_idx(at::_AtomTable{T}, idx::Int) where T = _AtomTableRow{T}(getfield(at, :_idx_map)[idx], at)
-
-@inline function Base.getproperty(atr::_AtomTableRow, nm::Symbol)
-    getindex(getfield(getfield(atr, :_tab), nm), getfield(atr, :_row))
-end
-
-@inline function Base.setproperty!(atr::_AtomTableRow, nm::Symbol, val)
-    setindex!(getproperty(getfield(atr, :_tab), nm), val, getfield(atr, :_row))
-end
-
-@inline Base.eltype(::_AtomTable{T}) where T = _AtomTableRow{T}
-@inline Base.iterate(at::_AtomTable, st=1) = st > length(at) ? nothing : (_AtomTableRow(st, at), st + 1)
+@inline _row_by_idx(at::_AtomTable, idx::Int) = ColumnTableRow(getfield(at, :_idx_map)[idx], at)

--- a/src/core/system_internals/_bond_table.jl
+++ b/src/core/system_internals/_bond_table.jl
@@ -73,24 +73,4 @@ function _bond_table(itr)
 end
 Tables.materializer(::Type{_BondTable}) = _bond_table
 
-@auto_hash_equals struct _BondTableRow <: _AbstractColumnTableRow
-    _row::Int
-    _tab::_BondTable
-end
-
-@inline Tables.getcolumn(btr::_BondTableRow, nm::Symbol) = Tables.getcolumn(getfield(btr, :_tab), nm)[getfield(btr, :_row)]
-@inline Tables.getcolumn(btr::_BondTableRow, i::Int) = getfield(btr, Tables.columnnames(btr)[i])
-@inline Tables.columnnames(::_BondTableRow) = _bond_table_cols
-
-@inline _row_by_idx(bt::_BondTable, idx::Int) = _BondTableRow(getfield(bt, :_idx_map)[idx], bt)
-
-@inline function Base.getproperty(btr::_BondTableRow, nm::Symbol)
-    getindex(getfield(getfield(btr, :_tab), nm), getfield(btr, :_row))
-end
-
-@inline function Base.setproperty!(btr::_BondTableRow, nm::Symbol, val)
-    setindex!(getproperty(getfield(btr, :_tab), nm), val, getfield(btr, :_row))
-end
-
-@inline Base.eltype(::_BondTable) = _BondTableRow
-@inline Base.iterate(bt::_BondTable, st=1) = st > length(bt) ? nothing : (_BondTableRow(st, bt), st + 1)
+@inline _row_by_idx(bt::_BondTable, idx::Int) = ColumnTableRow(getfield(bt, :_idx_map)[idx], bt)

--- a/src/core/system_internals/_chain_table.jl
+++ b/src/core/system_internals/_chain_table.jl
@@ -71,24 +71,4 @@ function _chain_table(itr)
 end
 @inline Tables.materializer(::Type{_ChainTable}) = itr -> _chain_table(itr)
 
-@auto_hash_equals struct _ChainTableRow <: _AbstractColumnTableRow
-    _row::Int
-    _tab::_ChainTable
-end
-
-@inline Tables.getcolumn(ctr::_ChainTableRow, nm::Symbol) = Tables.getcolumn(getfield(ctr, :_tab), nm)[getfield(ctr, :_row)]
-@inline Tables.getcolumn(ctr::_ChainTableRow, i::Int) = getfield(ctr, Tables.columnnames(ctr)[i])
-@inline Tables.columnnames(::_ChainTableRow) = _chain_table_cols
-
-@inline _row_by_idx(ct::_ChainTable, idx::Int) = _ChainTableRow(getfield(ct, :_idx_map)[idx], ct)
-
-@inline function Base.getproperty(ctr::_ChainTableRow, nm::Symbol)
-    getindex(getfield(getfield(ctr, :_tab), nm), getfield(ctr, :_row))
-end
-
-@inline function Base.setproperty!(ctr::_ChainTableRow, nm::Symbol, val)
-    setindex!(getproperty(getfield(ctr, :_tab), nm), val, getfield(ctr, :_row))
-end
-
-@inline Base.eltype(::_ChainTable) = _ChainTableRow
-@inline Base.iterate(ct::_ChainTable, st=1) = st > length(ct) ? nothing : (_ChainTableRow(st, ct), st + 1)
+@inline _row_by_idx(ct::_ChainTable, idx::Int) = ColumnTableRow(getfield(ct, :_idx_map)[idx], ct)

--- a/src/core/system_internals/_fragment_table.jl
+++ b/src/core/system_internals/_fragment_table.jl
@@ -84,24 +84,4 @@ function _fragment_table(itr)
 end
 @inline Tables.materializer(::Type{_FragmentTable}) = itr -> _fragment_table(itr)
 
-@auto_hash_equals struct _FragmentTableRow <: _AbstractColumnTableRow
-    _row::Int
-    _tab::_FragmentTable
-end
-
-@inline Tables.getcolumn(ftr::_FragmentTableRow, nm::Symbol) = Tables.getcolumn(getfield(ftr, :_tab), nm)[getfield(ftr, :_row)]
-@inline Tables.getcolumn(ftr::_FragmentTableRow, i::Int) = getfield(ftr, Tables.columnnames(ftr)[i])
-@inline Tables.columnnames(::_FragmentTableRow) = _fragment_table_cols
-
-@inline _row_by_idx(ft::_FragmentTable, idx::Int) = _FragmentTableRow(getfield(ft, :_idx_map)[idx], ft)
-
-@inline function Base.getproperty(ftr::_FragmentTableRow, nm::Symbol)
-    getindex(getfield(getfield(ftr, :_tab), nm), getfield(ftr, :_row))
-end
-
-@inline function Base.setproperty!(ftr::_FragmentTableRow, nm::Symbol, val)
-    setindex!(getproperty(getfield(ftr, :_tab), nm), val, getfield(ftr, :_row))
-end
-
-@inline Base.eltype(::_FragmentTable) = _FragmentTableRow
-@inline Base.iterate(ft::_FragmentTable, st=1) = st > length(ft) ? nothing : (_FragmentTableRow(st, ft), st + 1)
+@inline _row_by_idx(ft::_FragmentTable, idx::Int) = ColumnTableRow(getfield(ft, :_idx_map)[idx], ft)

--- a/src/core/system_internals/_molecule_table.jl
+++ b/src/core/system_internals/_molecule_table.jl
@@ -72,24 +72,4 @@ function _molecule_table(itr)
 end
 Tables.materializer(::Type{_MoleculeTable}) = _molecule_table
 
-@auto_hash_equals struct _MoleculeTableRow <: _AbstractColumnTableRow
-    _row::Int
-    _tab::_MoleculeTable
-end
-
-@inline Tables.getcolumn(mtr::_MoleculeTableRow, nm::Symbol) = Tables.getcolumn(getfield(mtr, :_tab), nm)[getfield(mtr, :_row)]
-@inline Tables.getcolumn(mtr::_MoleculeTableRow, i::Int) = getfield(mtr, Tables.columnnames(mtr)[i])
-@inline Tables.columnnames(::_MoleculeTableRow) = _molecule_table_cols
-
-@inline _row_by_idx(mt::_MoleculeTable, idx::Int) = _MoleculeTableRow(getfield(mt, :_idx_map)[idx], mt)
-
-@inline function Base.getproperty(mtr::_MoleculeTableRow, nm::Symbol)
-    getindex(getfield(getfield(mtr, :_tab), nm), getfield(mtr, :_row))
-end
-
-@inline function Base.setproperty!(mtr::_MoleculeTableRow, nm::Symbol, val) 
-    setindex!(getproperty(getfield(mtr, :_tab), nm), val, getfield(mtr, :_row))
-end
-
-@inline Base.eltype(::_MoleculeTable) = _MoleculeTableRow
-@inline Base.iterate(mt::_MoleculeTable, st=1) = st > length(mt) ? nothing : (_MoleculeTableRow(st, mt), st + 1)
+@inline _row_by_idx(mt::_MoleculeTable, idx::Int) = ColumnTableRow(getfield(mt, :_idx_map)[idx], mt)

--- a/test/core/test_atom.jl
+++ b/test/core/test_atom.jl
@@ -253,7 +253,7 @@ end
         @test isnothing(atom.fragment_idx)
 
         @test atom._sys isa System{T}
-        @test atom._row isa BiochemicalAlgorithms._AtomTableRow{T}
+        @test atom._row isa ColumnTableRow{BiochemicalAlgorithms._AtomTable{T}}
 
         @test atom2.frame_id isa Int
         @test atom2.frame_id == 10

--- a/test/core/test_bond.jl
+++ b/test/core/test_bond.jl
@@ -148,7 +148,7 @@ end
         @test bond.flags == Flags()
 
         @test bond._sys isa System{T}
-        @test bond._row isa BiochemicalAlgorithms._BondTableRow
+        @test bond._row isa ColumnTableRow{BiochemicalAlgorithms._BondTable}
 
         @test bond2.idx isa Int
         @test bond2.a1 isa Int

--- a/test/core/test_chain.jl
+++ b/test/core/test_chain.jl
@@ -126,7 +126,7 @@ end
         @test chain.molecule_idx == mol.idx
 
         @test chain._sys isa System{T}
-        @test chain._row isa BiochemicalAlgorithms._ChainTableRow
+        @test chain._row isa ColumnTableRow{BiochemicalAlgorithms._ChainTable}
 
         @test chain2.name == "something"
         @test chain2.properties == Properties(:a => 1)

--- a/test/core/test_fragment.jl
+++ b/test/core/test_fragment.jl
@@ -519,7 +519,7 @@ end
         @test frag.chain_idx == chain.idx
 
         @test frag._sys isa System{T}
-        @test frag._row isa BiochemicalAlgorithms._FragmentTableRow
+        @test frag._row isa ColumnTableRow{BiochemicalAlgorithms._FragmentTable}
         
         @test frag2.number == 1
         @test frag2.name == "something"
@@ -739,7 +739,7 @@ end
         @test nuc.chain_idx == chain.idx
 
         @test nuc._sys isa System{T}
-        @test nuc._row isa BiochemicalAlgorithms._FragmentTableRow
+        @test nuc._row isa ColumnTableRow{BiochemicalAlgorithms._FragmentTable}
         
         @test nuc2.number == 1
         @test nuc2.name == "something"
@@ -959,7 +959,7 @@ end
         @test res.chain_idx == chain.idx
 
         @test res._sys isa System{T}
-        @test res._row isa BiochemicalAlgorithms._FragmentTableRow
+        @test res._row isa ColumnTableRow{BiochemicalAlgorithms._FragmentTable}
         
         @test res2.number == 1
         @test res2.name == "something"

--- a/test/core/test_molecule.jl
+++ b/test/core/test_molecule.jl
@@ -325,7 +325,7 @@ end
         @test mol.variant == MoleculeVariant.None
 
         @test mol._sys isa System{T}
-        @test mol._row isa BiochemicalAlgorithms._MoleculeTableRow
+        @test mol._row isa ColumnTableRow{BiochemicalAlgorithms._MoleculeTable}
 
         @test mol2.name == "something"
         @test mol2.properties == Properties(:a => 1)
@@ -442,7 +442,7 @@ end
         @test prot.variant === MoleculeVariant.Protein
 
         @test prot._sys isa System{T}
-        @test prot._row isa BiochemicalAlgorithms._MoleculeTableRow
+        @test prot._row isa ColumnTableRow{BiochemicalAlgorithms._MoleculeTable}
 
         @test prot2.name == "something"
         @test prot2.properties == Properties(:a => 1)


### PR DESCRIPTION
This PR simplifies our previous table row handling and removes a lot of redundant code.