### PR TITLE
System: simplify `SystemComponent`

### DIFF
--- a/src/core/atom.jl
+++ b/src/core/atom.jl
@@ -253,8 +253,9 @@ end
 Returns a `BondTable{T}` containing all bonds of the given atom.
 """
 @inline function bonds(atom::Atom)
+    aidx = atom.idx
     _filter_bonds(
-        bond -> bond.a1 == atom.idx || bond.a2 == atom.idx,
+        bond -> bond.a1 == aidx || bond.a2 == aidx,
         parent(atom)
     )
 end

--- a/src/core/bond.jl
+++ b/src/core/bond.jl
@@ -28,9 +28,9 @@ Mutable representation of an individual bond in a system.
 # Constructors
 ```julia
 Bond(
-    sys::System{T}, 
-    a1::Int, 
-    a2::Int, 
+    sys::System{T},
+    a1::Int,
+    a2::Int,
     order::BondOrderType;
     # keyword arguments
     properties::Properties = Properties(),
@@ -51,12 +51,12 @@ Bond(
 ```
 Creates a new `Bond{Float32}` in the default system.
 """
-const Bond{T} = AtomContainer{T, _BondTable}
+const Bond{T} = AtomContainer{T, :Bond}
 
 @inline function Bond(
-    sys::System{T}, 
-    a1::Int, 
-    a2::Int, 
+    sys::System{T},
+    a1::Int,
+    a2::Int,
     order::BondOrderType;
     kwargs...
 ) where T
@@ -122,7 +122,8 @@ Returns the `Bond{T}` associated with the given `idx` in `sys`. Throws a `KeyErr
 bond exists.
 """
 @inline function bond_by_idx(sys::System{T}, idx::Int) where T
-    Bond{T}(sys, _row_by_idx(sys._bonds, idx))
+    _rowno_by_idx(_table(sys, Bond{T}), idx) # check idx
+    Bond{T}(sys, idx)
 end
 
 @inline function bond_by_idx(idx::Int)

--- a/src/core/chain.jl
+++ b/src/core/chain.jl
@@ -32,7 +32,7 @@ Chain(
 ```
 Creates a new `Chain{T}` in the given molecule.
 """
-const Chain{T} = AtomContainer{T, _ChainTable}
+const Chain{T} = AtomContainer{T, :Chain}
 
 @inline function Chain(
     mol::Molecule;
@@ -90,7 +90,8 @@ Returns the `Chain{T}` associated with the given `idx` in `sys`. Throws a `KeyEr
 chain exists.
 """
 @inline function chain_by_idx(sys::System{T}, idx::Int) where T
-    Chain{T}(sys, _row_by_idx(sys._chains, idx))
+    _rowno_by_idx(_table(sys, Chain{T}), idx) # check idx
+    Chain{T}(sys, idx)
 end
 
 @inline function chain_by_idx(idx::Int)

--- a/src/core/fragment.jl
+++ b/src/core/fragment.jl
@@ -58,7 +58,7 @@ Fragment(
 ```
 Creates a new `Fragment{T}` in the given chain.
 """
-const Fragment{T} = AtomContainer{T, _FragmentTable}
+const Fragment{T} = AtomContainer{T, :Fragment}
 
 @inline function Fragment(
     chain::Chain{T},
@@ -120,7 +120,8 @@ Returns the `Fragment{T}` associated with the given `idx` in `sys`. Throws a `Ke
 fragment exists.
 """
 @inline function fragment_by_idx(sys::System{T}, idx::Int) where T
-    Fragment{T}(sys, _row_by_idx(sys._fragments, idx))
+    _rowno_by_idx(_table(sys, Fragment{T}), idx) # check idx
+    Fragment{T}(sys, idx)
 end
 
 @inline function fragment_by_idx(idx::Int)
@@ -541,7 +542,7 @@ function get_full_name(
     full_name = strip(f.name)
 
     # if the variant extension should be added, do so
-    if (   type == FullNameType.ADD_VARIANT_EXTENSIONS 
+    if (   type == FullNameType.ADD_VARIANT_EXTENSIONS
         || type == FullNameType.ADD_VARIANT_EXTENSIONS_AND_ID)
         suffix = "-"
 
@@ -553,7 +554,7 @@ function get_full_name(
             suffix = "-C"
         end
 
-        if (is_c_terminal(f) && is_n_terminal(f)) 
+        if (is_c_terminal(f) && is_n_terminal(f))
             suffix = "-M"
         end
 
@@ -566,9 +567,9 @@ function get_full_name(
         end
     end
 
-    if (   type == FullNameType.ADD_RESIDUE_ID 
+    if (   type == FullNameType.ADD_RESIDUE_ID
         || type == FullNameType.ADD_VARIANT_EXTENSIONS_AND_ID)
-  
+
         full_name *= string(f.number);
     end
 

--- a/src/core/molecule.jl
+++ b/src/core/molecule.jl
@@ -50,7 +50,7 @@ Molecule(;
 ```
 Creates a new `Molecule{Float32}` in the default system.
 """
-const Molecule{T} = AtomContainer{T, _MoleculeTable}
+const Molecule{T} = AtomContainer{T, :Molecule}
 
 @inline function Molecule(
     sys::System{T};
@@ -126,7 +126,8 @@ Returns the `Molecule{T}` associated with the given `idx` in `sys`. Throws a `Ke
 molecule exists.
 """
 @inline function molecule_by_idx(sys::System{T}, idx::Int) where T
-    Molecule{T}(sys, _row_by_idx(sys._molecules, idx))
+    _rowno_by_idx(_table(sys, Molecule{T}), idx) # check idx
+    Molecule{T}(sys, idx)
 end
 
 @inline function molecule_by_idx(idx::Int)

--- a/src/core/system_component_table.jl
+++ b/src/core/system_component_table.jl
@@ -32,7 +32,7 @@ end
 @inline _hascolumn(::SystemComponentTable{T, C}, nm::Symbol) where {T, C} = _hascolumn(C, nm)
 
 @inline function _element_by_idx(ct::SystemComponentTable{T, C}, idx::Int) where {T, C}
-    C(ct._sys, _row_by_idx(_table(ct), idx))
+    C(ct._sys, idx)
 end
 
 @inline function Tables.getcolumn(ct::SystemComponentTable, nm::Symbol)

--- a/src/core/system_internals/_atom_table.jl
+++ b/src/core/system_internals/_atom_table.jl
@@ -132,4 +132,5 @@ function _atom_table(::Type{T}, itr) where T
 end
 @inline Tables.materializer(::Type{_AtomTable{T}}) where T = itr -> _atom_table(T, itr)
 
-@inline _row_by_idx(at::_AtomTable, idx::Int) = ColumnTableRow(getfield(at, :_idx_map)[idx], at)
+@inline _rowno_by_idx(at::_AtomTable, idx::Int) = getindex(getfield(at, :_idx_map), idx)
+@inline _row_by_idx(at::_AtomTable, idx::Int) = ColumnTableRow(_rowno_by_idx(at, idx), at)

--- a/src/core/system_internals/_bond_table.jl
+++ b/src/core/system_internals/_bond_table.jl
@@ -73,4 +73,5 @@ function _bond_table(itr)
 end
 Tables.materializer(::Type{_BondTable}) = _bond_table
 
-@inline _row_by_idx(bt::_BondTable, idx::Int) = ColumnTableRow(getfield(bt, :_idx_map)[idx], bt)
+@inline _rowno_by_idx(bt::_BondTable, idx::Int) = getindex(getfield(bt, :_idx_map), idx)
+@inline _row_by_idx(bt::_BondTable, idx::Int) = ColumnTableRow(_rowno_by_idx(bt, idx), bt)

--- a/src/core/system_internals/_chain_table.jl
+++ b/src/core/system_internals/_chain_table.jl
@@ -71,4 +71,5 @@ function _chain_table(itr)
 end
 @inline Tables.materializer(::Type{_ChainTable}) = itr -> _chain_table(itr)
 
-@inline _row_by_idx(ct::_ChainTable, idx::Int) = ColumnTableRow(getfield(ct, :_idx_map)[idx], ct)
+@inline _rowno_by_idx(ct::_ChainTable, idx::Int) = getindex(getfield(ct, :_idx_map), idx)
+@inline _row_by_idx(ct::_ChainTable, idx::Int) = ColumnTableRow(_rowno_by_idx(ct, idx), ct)

--- a/src/core/system_internals/_fragment_table.jl
+++ b/src/core/system_internals/_fragment_table.jl
@@ -84,4 +84,5 @@ function _fragment_table(itr)
 end
 @inline Tables.materializer(::Type{_FragmentTable}) = itr -> _fragment_table(itr)
 
-@inline _row_by_idx(ft::_FragmentTable, idx::Int) = ColumnTableRow(getfield(ft, :_idx_map)[idx], ft)
+@inline _rowno_by_idx(ft::_FragmentTable, idx::Int) = getindex(getfield(ft, :_idx_map), idx)
+@inline _row_by_idx(ft::_FragmentTable, idx::Int) = ColumnTableRow(_rowno_by_idx(ft, idx), ft)

--- a/src/core/system_internals/_molecule_table.jl
+++ b/src/core/system_internals/_molecule_table.jl
@@ -72,4 +72,5 @@ function _molecule_table(itr)
 end
 Tables.materializer(::Type{_MoleculeTable}) = _molecule_table
 
-@inline _row_by_idx(mt::_MoleculeTable, idx::Int) = ColumnTableRow(getfield(mt, :_idx_map)[idx], mt)
+@inline _rowno_by_idx(mt::_MoleculeTable, idx::Int) = getindex(getfield(mt, :_idx_map), idx)
+@inline _row_by_idx(mt::_MoleculeTable, idx::Int) = ColumnTableRow(_rowno_by_idx(mt, idx), mt)

--- a/src/core/tables.jl
+++ b/src/core/tables.jl
@@ -20,7 +20,7 @@ abstract type AbstractColumnTable <: Tables.AbstractColumns end
 @inline Base.length(at::AbstractColumnTable) = size(at, 1)
 @inline Base.keys(at::AbstractColumnTable) = LinearIndices((length(at),))
 
-@inline function Base.show(io::IO, at::AbstractColumnTable) 
+@inline function Base.show(io::IO, at::AbstractColumnTable)
     print(io, "$(typeof(at)) with $(length(at)) rows")
 end
 
@@ -58,7 +58,7 @@ struct ColumnTableRow{CT <: AbstractColumnTable} <: Tables.AbstractRow
 end
 
 @inline Tables.getcolumn(ctr::ColumnTableRow, nm::Symbol) = Tables.getcolumn(getfield(ctr, :_tab), nm)[getfield(ctr, :_row)]
-@inline Tables.getcolumn(ctr::ColumnTableRow, i::Int) = getfield(ctr, Tables.columnnames(ctr)[i])
+@inline Tables.getcolumn(ctr::ColumnTableRow, i::Int) = getproperty(ctr, Tables.columnnames(ctr)[i])
 
 @inline Tables.columnnames(ctr::ColumnTableRow) = Tables.columnnames(getfield(ctr, :_tab))
 

--- a/test/core/test_atom.jl
+++ b/test/core/test_atom.jl
@@ -19,7 +19,7 @@
         a2 = Atom(sys, 2, Elements.C)
 
         at = atoms(sys)
-        
+
         # Tables.jl interface
         @test Tables.istable(typeof(at))
         @test Tables.columnaccess(typeof(at))
@@ -213,12 +213,6 @@ end
             fragment_idx = 13
         )
 
-        #=
-            Make sure we test for the correct number of fields.
-            Add missing tests if the following test fails!
-        =#
-        @test length(atom._row) == 11
-
         # getproperty
         @test atom.idx isa Int
         @test atom.number isa Int
@@ -253,7 +247,7 @@ end
         @test isnothing(atom.fragment_idx)
 
         @test atom._sys isa System{T}
-        @test atom._row isa ColumnTableRow{BiochemicalAlgorithms._AtomTable{T}}
+        @test atom._idx isa Int
 
         @test atom2.frame_id isa Int
         @test atom2.frame_id == 10
@@ -376,7 +370,7 @@ end
 
         Bond(sys, a.idx, b.idx, BondOrder.Single)
         Bond(sys, b.idx, c.idx, BondOrder.Single)
-        
+
         @test !is_geminal(a, b)
         @test is_geminal(a, c)
         @test is_geminal(c, a)

--- a/test/core/test_bond.jl
+++ b/test/core/test_bond.jl
@@ -123,15 +123,9 @@ end
         Bond(
             sys,
             Atom(sys, 1, Elements.H; frame_id = 2).idx,
-            Atom(sys, 2, Elements.C; frame_id = 2).idx, 
+            Atom(sys, 2, Elements.C; frame_id = 2).idx,
             BondOrder.Single
         )
-
-        #=
-            Make sure we test for the correct number of fields.
-            Add missing tests if the following test fails!
-        =#
-        @test length(bond._row) == 4
 
         # getproperty
         @test bond.idx isa Int
@@ -148,7 +142,7 @@ end
         @test bond.flags == Flags()
 
         @test bond._sys isa System{T}
-        @test bond._row isa ColumnTableRow{BiochemicalAlgorithms._BondTable}
+        @test bond._idx isa Int
 
         @test bond2.idx isa Int
         @test bond2.a1 isa Int

--- a/test/core/test_chain.jl
+++ b/test/core/test_chain.jl
@@ -107,12 +107,6 @@ end
 
         chain2 = Chain(mol2; name = "something", properties = Properties(:a => 1), flags = Flags([:A, :B]))
 
-        #=
-            Make sure we test for the correct number of fields.
-            Add missing tests if the following test fails!
-        =#
-        @test length(chain._row) == 2
-
         # getproperty
         @test chain.idx isa Int
         @test chain.name isa String
@@ -126,7 +120,7 @@ end
         @test chain.molecule_idx == mol.idx
 
         @test chain._sys isa System{T}
-        @test chain._row isa ColumnTableRow{BiochemicalAlgorithms._ChainTable}
+        @test chain._idx isa Int
 
         @test chain2.name == "something"
         @test chain2.properties == Properties(:a => 1)
@@ -153,7 +147,7 @@ end
         @test_throws KeyError chain_by_idx(sys, -1)
         @test chain_by_idx(sys, chain.idx) isa Chain{T}
         @test chain_by_idx(sys, chain.idx) == chain
-        
+
         # chains
         cv = chains(sys)
         @test cv isa ChainTable{T}

--- a/test/core/test_fragment.jl
+++ b/test/core/test_fragment.jl
@@ -494,12 +494,6 @@ end
             flags = Flags([:A, :B])
         )
 
-        #=
-            Make sure we test for the correct number of fields.
-            Add missing tests if the following test fails!
-        =#
-        @test length(frag._row) == 3
-
         # getproperty
         @test frag.idx isa Int
         @test frag.number isa Int
@@ -519,8 +513,8 @@ end
         @test frag.chain_idx == chain.idx
 
         @test frag._sys isa System{T}
-        @test frag._row isa ColumnTableRow{BiochemicalAlgorithms._FragmentTable}
-        
+        @test frag._idx isa Int
+
         @test frag2.number == 1
         @test frag2.name == "something"
         @test frag2.properties == Properties(:a => 1)
@@ -714,12 +708,6 @@ end
             flags = Flags([:A, :B])
         )
 
-        #=
-            Make sure we test for the correct number of fields.
-            Add missing tests if the following test fails!
-        =#
-        @test length(nuc._row) == 3
-
         # getproperty
         @test nuc.idx isa Int
         @test nuc.number isa Int
@@ -739,8 +727,8 @@ end
         @test nuc.chain_idx == chain.idx
 
         @test nuc._sys isa System{T}
-        @test nuc._row isa ColumnTableRow{BiochemicalAlgorithms._FragmentTable}
-        
+        @test nuc._idx isa Int
+
         @test nuc2.number == 1
         @test nuc2.name == "something"
         @test nuc2.properties == Properties(:a => 1)
@@ -934,12 +922,6 @@ end
             flags = Flags([:A, :B])
         )
 
-        #=
-            Make sure we test for the correct number of fields.
-            Add missing tests if the following test fails!
-        =#
-        @test length(res._row) == 3
-
         # getproperty
         @test res.idx isa Int
         @test res.number isa Int
@@ -959,8 +941,8 @@ end
         @test res.chain_idx == chain.idx
 
         @test res._sys isa System{T}
-        @test res._row isa ColumnTableRow{BiochemicalAlgorithms._FragmentTable}
-        
+        @test res._idx isa Int
+
         @test res2.number == 1
         @test res2.name == "something"
         @test res2.properties == Properties(:a => 1)

--- a/test/core/test_molecule.jl
+++ b/test/core/test_molecule.jl
@@ -306,12 +306,6 @@ end
 
         mol2 = Molecule(sys; name = "something", properties = Properties(:a => 1), flags = Flags([:A, :B]))
 
-        #=
-            Make sure we test for the correct number of fields.
-            Add missing tests if the following test fails!
-        =#
-        @test length(mol._row) == 2
-
         # getproperty
         @test mol.idx isa Int
         @test mol.name isa String
@@ -325,7 +319,7 @@ end
         @test mol.variant == MoleculeVariant.None
 
         @test mol._sys isa System{T}
-        @test mol._row isa ColumnTableRow{BiochemicalAlgorithms._MoleculeTable}
+        @test mol._idx isa Int
 
         @test mol2.name == "something"
         @test mol2.properties == Properties(:a => 1)
@@ -423,12 +417,6 @@ end
 
         prot2 = Protein(sys; name = "something", properties = Properties(:a => 1), flags = Flags([:A, :B]))
 
-        #=
-            Make sure we test for the correct number of fields.
-            Add missing tests if the following test fails!
-        =#
-        @test length(prot._row) == 2
-
         # getproperty
         @test prot.idx isa Int
         @test prot.name isa String
@@ -442,7 +430,7 @@ end
         @test prot.variant === MoleculeVariant.Protein
 
         @test prot._sys isa System{T}
-        @test prot._row isa ColumnTableRow{BiochemicalAlgorithms._MoleculeTable}
+        @test prot._idx isa Int
 
         @test prot2.name == "something"
         @test prot2.properties == Properties(:a => 1)


### PR DESCRIPTION
# Benchmark Report

## Job Properties
* Time of benchmarks:
    - Target: 13 Aug 2024 - 15:40
    - Baseline: 13 Aug 2024 - 15:41
* Package commits:
    - Target: 3d9600
    - Baseline: ed0b52
* Julia commits:
    - Target: 48d4fd
    - Baseline: 48d4fd
* Julia command flags:
    - Target: None
    - Baseline: None
* Environment variables:
    - Target: None
    - Baseline: None

## Results
A ratio greater than `1.0` denotes a possible regression (marked with :x:), while a ratio less
than `1.0` denotes a possible improvement (marked with :white_check_mark:). Only significant results - results
that indicate possible regressions or improvements - are shown below (thus, an empty table means that all
benchmark results remained invariant between builds).

| ID                                              | time ratio                   | memory ratio                 |
|-------------------------------------------------|------------------------------|------------------------------|
| `["ForceFields", "AmberFF", "Creation"]`        | 0.77 (5%) :white_check_mark: | 0.37 (1%) :white_check_mark: |
| `["ForceFields", "AmberFF", "compute_energy!"]` | 0.17 (5%) :white_check_mark: |                   1.00 (1%)  |
| `["ForceFields", "AmberFF", "compute_forces!"]` | 0.66 (5%) :white_check_mark: |                   1.00 (1%)  |
| `["ForceFields", "AmberFF", "setup"]`           | 0.90 (5%) :white_check_mark: | 0.72 (1%) :white_check_mark: |
| `["ForceFields", "AmberFF", "update!"]`         | 0.71 (5%) :white_check_mark: | 0.32 (1%) :white_check_mark: |

## Benchmark Group List
Here's a list of all the benchmark groups executed by this job:

- `["ForceFields", "AmberFF"]`

## Julia versioninfo

### Target
```
Julia Version 1.10.4
Commit 48d4fd48430 (2024-06-04 10:41 UTC)
Build Info:
  Official https://julialang.org/ release
Platform Info:
  OS: macOS (arm64-apple-darwin22.4.0)
  uname: Darwin 23.5.0 Darwin Kernel Version 23.5.0: Wed May  1 20:13:18 PDT 2024; root:xnu-10063.121.3~5/RELEASE_ARM64_T6030 arm64 arm
  CPU: Apple M3 Pro: 
                 speed         user         nice          sys         idle          irq
       #1-11  2400 MHz    1378688 s          0 s     875602 s   20377734 s          0 s
  Memory: 18.0 GB (52.75 MB free)
  Uptime: 1.220945e6 sec
  Load Avg:  1.552734375  1.642578125  1.7099609375
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-15.0.7 (ORCJIT, apple-m1)
Threads: 1 default, 0 interactive, 1 GC (on 5 virtual cores)
```

### Baseline
```
Julia Version 1.10.4
Commit 48d4fd48430 (2024-06-04 10:41 UTC)
Build Info:
  Official https://julialang.org/ release
Platform Info:
  OS: macOS (arm64-apple-darwin22.4.0)
  uname: Darwin 23.5.0 Darwin Kernel Version 23.5.0: Wed May  1 20:13:18 PDT 2024; root:xnu-10063.121.3~5/RELEASE_ARM64_T6030 arm64 arm
  CPU: Apple M3 Pro: 
                 speed         user         nice          sys         idle          irq
       #1-11  2400 MHz    1379342 s          0 s     875761 s   20382628 s          0 s
  Memory: 18.0 GB (113.28125 MB free)
  Uptime: 1.220997e6 sec
  Load Avg:  1.7900390625  1.6982421875  1.72607421875
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-15.0.7 (ORCJIT, apple-m1)
Threads: 1 default, 0 interactive, 1 GC (on 5 virtual cores)
```