### PR TITLE
System: fix inconsistent return values w/ table generators

### DIFF
--- a/src/core/chain.jl
+++ b/src/core/chain.jl
@@ -112,7 +112,7 @@ Any value other than `nothing` limits the result to chains belonging to the mole
     sys::System{T} = default_system();
     molecule_idx::MaybeInt = nothing
 ) where T
-    isnothing(molecule_idx) && return ChainTable{T}(sys, sys._chains.idx)
+    isnothing(molecule_idx) && return ChainTable{T}(sys, copy(sys._chains.idx))
     _filter_chains(chain -> chain.molecule_idx == molecule_idx, sys)
 end
 

--- a/src/core/fragment.jl
+++ b/src/core/fragment.jl
@@ -150,7 +150,7 @@ function fragments(sys::System{T} = default_system();
     isnothing(variant) &&
         isnothing(molecule_idx) &&
         isnothing(chain_idx) &&
-        return FragmentTable{T}(sys, sys._fragments.idx)
+        return FragmentTable{T}(sys, copy(sys._fragments.idx))
     _filter_fragments(frag ->
         (isnothing(variant)      || frag.variant      == something(variant)) &&
         (isnothing(molecule_idx) || frag.molecule_idx == something(molecule_idx)) &&

--- a/src/core/molecule.jl
+++ b/src/core/molecule.jl
@@ -147,7 +147,7 @@ Keyword arguments set to `nothing` are ignored.
 @inline function molecules(sys::System{T} = default_system();
     variant::Union{Nothing, MoleculeVariantType} = nothing
 ) where T
-    isnothing(variant) && return MoleculeTable{T}(sys, sys._molecules.idx)
+    isnothing(variant) && return MoleculeTable{T}(sys, copy(sys._molecules.idx))
     _filter_molecules(mol -> mol.variant == something(variant), sys)
 end
 

--- a/test/core/test_atom.jl
+++ b/test/core/test_atom.jl
@@ -20,6 +20,13 @@
 
         at = atoms(sys)
 
+        # AutoHashEquals and identity
+        at2 = atoms(sys)
+        @test at == at2
+        @test isequal(at, at2)
+        @test hash(at) == hash(at2)
+        @test at !== at2
+
         # Tables.jl interface
         @test Tables.istable(typeof(at))
         @test Tables.columnaccess(typeof(at))

--- a/test/core/test_bond.jl
+++ b/test/core/test_bond.jl
@@ -16,6 +16,13 @@
 
         bt = bonds(sys)
 
+        # AutoHashEquals and identity
+        bt2 = bonds(sys)
+        @test bt == bt2
+        @test isequal(bt, bt2)
+        @test hash(bt) == hash(bt2)
+        @test bt !== bt2
+
         # Tables.jl interface
         @test Tables.istable(typeof(bt))
         @test Tables.columnaccess(typeof(bt))

--- a/test/core/test_chain.jl
+++ b/test/core/test_chain.jl
@@ -14,6 +14,13 @@
 
         ct = chains(sys)
 
+        # AutoHashEquals and identity
+        ct2 = chains(sys)
+        @test ct == ct2
+        @test isequal(ct, ct2)
+        @test hash(ct) == hash(ct2)
+        @test ct !== ct2
+
         # Tables.jl interface
         @test Tables.istable(typeof(ct))
         @test Tables.columnaccess(typeof(ct))

--- a/test/core/test_fragment.jl
+++ b/test/core/test_fragment.jl
@@ -20,6 +20,27 @@
 
         ft = fragments(sys)
 
+        # AutoHashEquals and identity
+        ft2 = fragments(sys)
+        @test ft == ft2
+        @test isequal(ft, ft2)
+        @test hash(ft) == hash(ft2)
+        @test ft !== ft2
+
+        nt = nucleotides(sys)
+        nt2 = nucleotides(sys)
+        @test nt == nt2
+        @test isequal(nt, nt2)
+        @test hash(nt) == hash(nt2)
+        @test nt !== nt2
+
+        rt = residues(sys)
+        rt2 = residues(sys)
+        @test rt == rt2
+        @test isequal(rt, rt2)
+        @test hash(rt) == hash(rt2)
+        @test rt !== rt2
+
         # Tables.jl interface
         @test Tables.istable(typeof(ft))
         @test Tables.columnaccess(typeof(ft))

--- a/test/core/test_molecule.jl
+++ b/test/core/test_molecule.jl
@@ -15,6 +15,20 @@
 
         mt = molecules(sys)
 
+        # AutoHashEquals and identity
+        mt2 = molecules(sys)
+        @test mt == mt2
+        @test isequal(mt, mt2)
+        @test hash(mt) == hash(mt2)
+        @test mt !== mt2
+
+        pt = proteins(sys)
+        pt2 = proteins(sys)
+        @test pt == pt2
+        @test isequal(pt, pt2)
+        @test hash(pt) == hash(pt2)
+        @test pt !== pt2
+
         # Tables.jl interface
         @test Tables.istable(typeof(mt))
         @test Tables.columnaccess(typeof(mt))


### PR DESCRIPTION
In some cases, `molecules()`, `chains()`, and `fragments()` returned indistinguishable table objects.

Fixes: #114