### PR TITLE
System: support column selection for component tables

### DIFF
--- a/test/core/test_atom.jl
+++ b/test/core/test_atom.jl
@@ -165,12 +165,29 @@
         @test isequal(at2, at)
         @test at2 == at
         @test at2 !== at
+        @test size(at2) == size(at)
+        @test Tables.columnnames(at2) == Tables.columnnames(at)
+        @test Tables.schema(at2) == Tables.schema(at)
+
+        at2 = at[:, [:idx, :flags]]
+        @test at2 isa AtomTable{T}
+        @test size(at2) == (2, 2)
+        @test Tables.columnnames(at2) == [:idx, :flags]
+        @test Tables.schema(at2).names == (:idx, :flags)
+        @test Tables.schema(at2).types == (Vector{Int}, Vector{Flags})
 
         at2 = at[2:-1:1]
         @test at2 isa AtomTable{T}
         @test length(at2) == 2
         @test at2[1] === at[2]
         @test at2[2] === at[1]
+
+        at2 = at[2:-1:1, [:idx, :flags]]
+        @test at2 isa AtomTable{T}
+        @test size(at2) == (2, 2)
+        @test Tables.columnnames(at2) == [:idx, :flags]
+        @test Tables.schema(at2).names == (:idx, :flags)
+        @test Tables.schema(at2).types == (Vector{Int}, Vector{Flags})
 
         at2 = at[at.idx .== -1]
         @test at2 isa AtomTable{T}

--- a/test/core/test_bond.jl
+++ b/test/core/test_bond.jl
@@ -99,12 +99,29 @@
         @test isequal(bt2, bt)
         @test bt2 == bt
         @test bt2 !== bt
+        @test size(bt2) == size(bt)
+        @test Tables.columnnames(bt2) == Tables.columnnames(bt)
+        @test Tables.schema(bt2) == Tables.schema(bt)
+
+        bt2 = bt[:, [:idx, :flags]]
+        @test bt2 isa BondTable{T}
+        @test size(bt2) == (2, 2)
+        @test Tables.columnnames(bt2) == [:idx, :flags]
+        @test Tables.schema(bt2).names == (:idx, :flags)
+        @test Tables.schema(bt2).types == (Vector{Int}, Vector{Flags})
 
         bt2 = bt[2:-1:1]
         @test bt2 isa BondTable{T}
         @test length(bt2) == 2
         @test bt2[1] === bt[2]
         @test bt2[2] === bt[1]
+
+        bt2 = bt[2:-1:1, [:idx, :flags]]
+        @test bt2 isa BondTable{T}
+        @test size(bt2) == (2, 2)
+        @test Tables.columnnames(bt2) == [:idx, :flags]
+        @test Tables.schema(bt2).names == (:idx, :flags)
+        @test Tables.schema(bt2).types == (Vector{Int}, Vector{Flags})
 
         bt2 = bt[bt.idx .== -1]
         @test bt2 isa BondTable{T}

--- a/test/core/test_chain.jl
+++ b/test/core/test_chain.jl
@@ -90,12 +90,29 @@
         @test isequal(ct2, ct)
         @test ct2 == ct
         @test ct2 !== ct
+        @test size(ct2) == size(ct)
+        @test Tables.columnnames(ct2) == Tables.columnnames(ct)
+        @test Tables.schema(ct2) == Tables.schema(ct)
+
+        ct2 = ct[:, [:idx, :flags]]
+        @test ct2 isa ChainTable{T}
+        @test size(ct2) == (2, 2)
+        @test Tables.columnnames(ct2) == [:idx, :flags]
+        @test Tables.schema(ct2).names == (:idx, :flags)
+        @test Tables.schema(ct2).types == (Vector{Int}, Vector{Flags})
 
         ct2 = ct[2:-1:1]
         @test ct2 isa ChainTable{T}
         @test length(ct2) == 2
         @test ct2[1] === ct[2]
         @test ct2[2] === ct[1]
+
+        ct2 = ct[2:-1:1, [:idx, :flags]]
+        @test ct2 isa ChainTable{T}
+        @test size(ct2) == (2, 2)
+        @test Tables.columnnames(ct2) == [:idx, :flags]
+        @test Tables.schema(ct2).names == (:idx, :flags)
+        @test Tables.schema(ct2).types == (Vector{Int}, Vector{Flags})
 
         ct2 = ct[ct.idx .== -1]
         @test ct2 isa ChainTable{T}

--- a/test/core/test_fragment.jl
+++ b/test/core/test_fragment.jl
@@ -182,12 +182,29 @@
         @test isequal(ft2, ft)
         @test ft2 == ft
         @test ft2 !== ft
+        @test size(ft2) == size(ft)
+        @test Tables.columnnames(ft2) == Tables.columnnames(ft)
+        @test Tables.schema(ft2) == Tables.schema(ft)
+
+        ft2 = ft[:, [:idx, :flags]]
+        @test ft2 isa FragmentTable{T}
+        @test size(ft2) == (6, 2)
+        @test Tables.columnnames(ft2) == [:idx, :flags]
+        @test Tables.schema(ft2).names == (:idx, :flags)
+        @test Tables.schema(ft2).types == (Vector{Int}, Vector{Flags})
 
         ft2 = ft[2:-1:1]
         @test ft2 isa FragmentTable{T}
         @test length(ft2) == 2
         @test ft2[1] === ft[2]
         @test ft2[2] === ft[1]
+
+        ft2 = ft[2:-1:1, [:idx, :flags]]
+        @test ft2 isa FragmentTable{T}
+        @test size(ft2) == (2, 2)
+        @test Tables.columnnames(ft2) == [:idx, :flags]
+        @test Tables.schema(ft2).names == (:idx, :flags)
+        @test Tables.schema(ft2).types == (Vector{Int}, Vector{Flags})
 
         ft2 = ft[ft.idx .== -1]
         @test ft2 isa FragmentTable{T}
@@ -335,12 +352,29 @@ end
         @test isequal(ft2, ft)
         @test ft2 == ft
         @test ft2 !== ft
+        @test size(ft2) == size(ft)
+        @test Tables.columnnames(ft2) == Tables.columnnames(ft)
+        @test Tables.schema(ft2) == Tables.schema(ft)
+
+        ft2 = ft[:, [:idx, :flags]]
+        @test ft2 isa FragmentTable{T}
+        @test size(ft2) == (2, 2)
+        @test Tables.columnnames(ft2) == [:idx, :flags]
+        @test Tables.schema(ft2).names == (:idx, :flags)
+        @test Tables.schema(ft2).types == (Vector{Int}, Vector{Flags})
 
         ft2 = ft[2:-1:1]
         @test ft2 isa FragmentTable{T}
         @test length(ft2) == 2
         @test ft2[1] === ft[2]
         @test ft2[2] === ft[1]
+
+        ft2 = ft[2:-1:1, [:idx, :flags]]
+        @test ft2 isa FragmentTable{T}
+        @test size(ft2) == (2, 2)
+        @test Tables.columnnames(ft2) == [:idx, :flags]
+        @test Tables.schema(ft2).names == (:idx, :flags)
+        @test Tables.schema(ft2).types == (Vector{Int}, Vector{Flags})
 
         ft2 = ft[ft.idx .== -1]
         @test ft2 isa FragmentTable{T}
@@ -463,12 +497,29 @@ end
         @test isequal(nt2, nt)
         @test nt2 == nt
         @test nt2 !== nt
+        @test size(nt2) == size(nt)
+        @test Tables.columnnames(nt2) == Tables.columnnames(nt)
+        @test Tables.schema(nt2) == Tables.schema(nt)
+
+        nt2 = nt[:, [:idx, :flags]]
+        @test nt2 isa FragmentTable{T}
+        @test size(nt2) == (2, 2)
+        @test Tables.columnnames(nt2) == [:idx, :flags]
+        @test Tables.schema(nt2).names == (:idx, :flags)
+        @test Tables.schema(nt2).types == (Vector{Int}, Vector{Flags})
 
         nt2 = nt[2:-1:1]
         @test nt2 isa FragmentTable{T}
         @test length(nt2) == 2
         @test nt2[1] === nt[2]
         @test nt2[2] === nt[1]
+
+        nt2 = nt[2:-1:1, [:idx, :flags]]
+        @test nt2 isa FragmentTable{T}
+        @test size(nt2) == (2, 2)
+        @test Tables.columnnames(nt2) == [:idx, :flags]
+        @test Tables.schema(nt2).names == (:idx, :flags)
+        @test Tables.schema(nt2).types == (Vector{Int}, Vector{Flags})
 
         nt2 = nt[nt.idx .== -1]
         @test nt2 isa FragmentTable{T}
@@ -591,12 +642,29 @@ end
         @test isequal(rt2, rt)
         @test rt2 == rt
         @test rt2 !== rt
+        @test size(rt2) == size(rt)
+        @test Tables.columnnames(rt2) == Tables.columnnames(rt)
+        @test Tables.schema(rt2) == Tables.schema(rt)
+
+        rt2 = rt[:, [:idx, :flags]]
+        @test rt2 isa FragmentTable{T}
+        @test size(rt2) == (2, 2)
+        @test Tables.columnnames(rt2) == [:idx, :flags]
+        @test Tables.schema(rt2).names == (:idx, :flags)
+        @test Tables.schema(rt2).types == (Vector{Int}, Vector{Flags})
 
         rt2 = rt[2:-1:1]
         @test rt2 isa FragmentTable{T}
         @test length(rt2) == 2
         @test rt2[1] === rt[2]
         @test rt2[2] === rt[1]
+
+        rt2 = rt[2:-1:1, [:idx, :flags]]
+        @test rt2 isa FragmentTable{T}
+        @test size(rt2) == (2, 2)
+        @test Tables.columnnames(rt2) == [:idx, :flags]
+        @test Tables.schema(rt2).names == (:idx, :flags)
+        @test Tables.schema(rt2).types == (Vector{Int}, Vector{Flags})
 
         rt2 = rt[rt.idx .== -1]
         @test rt2 isa FragmentTable{T}

--- a/test/core/test_molecule.jl
+++ b/test/core/test_molecule.jl
@@ -104,12 +104,29 @@
         @test isequal(mt2, mt)
         @test mt2 == mt
         @test mt2 !== mt
+        @test size(mt2) == size(mt)
+        @test Tables.columnnames(mt2) == Tables.columnnames(mt)
+        @test Tables.schema(mt2) == Tables.schema(mt)
+
+        mt2 = mt[:, [:idx, :flags]]
+        @test mt2 isa MoleculeTable{T}
+        @test size(mt2) == (2, 2)
+        @test Tables.columnnames(mt2) == [:idx, :flags]
+        @test Tables.schema(mt2).names == (:idx, :flags)
+        @test Tables.schema(mt2).types == (Vector{Int}, Vector{Flags})
 
         mt2 = mt[2:-1:1]
         @test mt2 isa MoleculeTable{T}
         @test length(mt2) == 2
         @test mt2[1] === mt[2]
         @test mt2[2] === mt[1]
+
+        mt2 = mt[2:-1:1, [:idx, :flags]]
+        @test mt2 isa MoleculeTable{T}
+        @test size(mt2) == (2, 2)
+        @test Tables.columnnames(mt2) == [:idx, :flags]
+        @test Tables.schema(mt2).names == (:idx, :flags)
+        @test Tables.schema(mt2).types == (Vector{Int}, Vector{Flags})
 
         mt2 = mt[mt.idx .== -1]
         @test mt2 isa MoleculeTable{T}
@@ -266,12 +283,29 @@ end
         @test isequal(mt2, mt)
         @test mt2 == mt
         @test mt2 !== mt
+        @test size(mt2) == size(mt)
+        @test Tables.columnnames(mt2) == Tables.columnnames(mt)
+        @test Tables.schema(mt2) == Tables.schema(mt)
+
+        mt2 = mt[:, [:idx, :flags]]
+        @test mt2 isa MoleculeTable{T}
+        @test size(mt2) == (2, 2)
+        @test Tables.columnnames(mt2) == [:idx, :flags]
+        @test Tables.schema(mt2).names == (:idx, :flags)
+        @test Tables.schema(mt2).types == (Vector{Int}, Vector{Flags})
 
         mt2 = mt[2:-1:1]
         @test mt2 isa MoleculeTable{T}
         @test length(mt2) == 2
         @test mt2[1] === mt[2]
         @test mt2[2] === mt[1]
+
+        mt2 = mt[2:-1:1, [:idx, :flags]]
+        @test mt2 isa MoleculeTable{T}
+        @test size(mt2) == (2, 2)
+        @test Tables.columnnames(mt2) == [:idx, :flags]
+        @test Tables.schema(mt2).names == (:idx, :flags)
+        @test Tables.schema(mt2).types == (Vector{Int}, Vector{Flags})
 
         mt2 = mt[mt.idx .== -1]
         @test mt2 isa MoleculeTable{T}
@@ -375,12 +409,29 @@ end
         @test isequal(pt2, pt)
         @test pt2 == pt
         @test pt2 !== pt
+        @test size(pt2) == size(pt)
+        @test Tables.columnnames(pt2) == Tables.columnnames(pt)
+        @test Tables.schema(pt2) == Tables.schema(pt)
+
+        pt2 = pt[:, [:idx, :flags]]
+        @test pt2 isa MoleculeTable{T}
+        @test size(pt2) == (2, 2)
+        @test Tables.columnnames(pt2) == [:idx, :flags]
+        @test Tables.schema(pt2).names == (:idx, :flags)
+        @test Tables.schema(pt2).types == (Vector{Int}, Vector{Flags})
 
         pt2 = pt[2:-1:1]
         @test pt2 isa MoleculeTable{T}
         @test length(pt2) == 2
         @test pt2[1] === pt[2]
         @test pt2[2] === pt[1]
+
+        pt2 = pt[2:-1:1, [:idx, :flags]]
+        @test pt2 isa MoleculeTable{T}
+        @test size(pt2) == (2, 2)
+        @test Tables.columnnames(pt2) == [:idx, :flags]
+        @test Tables.schema(pt2).names == (:idx, :flags)
+        @test Tables.schema(pt2).types == (Vector{Int}, Vector{Flags})
 
         pt2 = pt[pt.idx .== -1]
         @test pt2 isa MoleculeTable{T}

--- a/test/core/test_secondary_structure.jl
+++ b/test/core/test_secondary_structure.jl
@@ -112,12 +112,29 @@
         @test isequal(st2, st)
         @test st2 == st
         @test st2 !== st
+        @test size(st2) == size(st)
+        @test Tables.columnnames(st2) == Tables.columnnames(st)
+        @test Tables.schema(st2) == Tables.schema(st)
+
+        st2 = st[:, [:idx, :flags]]
+        @test st2 isa SecondaryStructureTable{T}
+        @test size(st2) == (2, 2)
+        @test Tables.columnnames(st2) == [:idx, :flags]
+        @test Tables.schema(st2).names == (:idx, :flags)
+        @test Tables.schema(st2).types == (Vector{Int}, Vector{Flags})
 
         st2 = st[2:-1:1]
         @test st2 isa SecondaryStructureTable{T}
         @test length(st2) == 2
         @test st2[1] === st[2]
         @test st2[2] === st[1]
+
+        st2 = st[2:-1:1, [:idx, :flags]]
+        @test st2 isa SecondaryStructureTable{T}
+        @test size(st2) == (2, 2)
+        @test Tables.columnnames(st2) == [:idx, :flags]
+        @test Tables.schema(st2).names == (:idx, :flags)
+        @test Tables.schema(st2).types == (Vector{Int}, Vector{Flags})
 
         st2 = st[st.idx .== -1]
         @test st2 isa SecondaryStructureTable{T}


### PR DESCRIPTION
Table columns (including hidden columns) can now be selected via `getindex` like

```julia
julia> ft = fragments(sys)
FragmentTable{Float32} with 439 rows:
┌─────┬─────┬────────┬──────┐
│   # │ idx │ number │ name │
├─────┼─────┼────────┼──────┤
│   1 │ 3   │ 16     │ ILE  │
│   2 │ 4   │ 17     │ VAL  │
│   3 │ 5   │ 18     │ GLY  │
│   4 │ 6   │ 19     │ GLY  │
│  ⋮  │  ⋮  │   ⋮    │  ⋮   │
│ 437 │ 440 │ 590    │ HOH  │
│ 438 │ 441 │ 600    │ HOH  │
│ 439 │ 442 │ 610    │ HOH  │
└─────┴─────┴────────┴──────┘
             432 rows omitted

julia> ft[:, [:idx, :name, :variant]]
FragmentTable{Float32} with 439 rows:
┌─────┬─────┬──────┬─────────┐
│   # │ idx │ name │ variant │
├─────┼─────┼──────┼─────────┤
│   1 │ 3   │ ILE  │ Residue │
│   2 │ 4   │ VAL  │ Residue │
│   3 │ 5   │ GLY  │ Residue │
│   4 │ 6   │ GLY  │ Residue │
│  ⋮  │  ⋮  │  ⋮   │    ⋮    │
│ 437 │ 440 │ HOH  │ None    │
│ 438 │ 441 │ HOH  │ None    │
│ 439 │ 442 │ HOH  │ None    │
└─────┴─────┴──────┴─────────┘
              432 rows omitted

julia> ft[1:2, [:idx, :name, :variant]]
FragmentTable{Float32} with 2 rows:
┌───┬─────┬──────┬─────────┐
│ # │ idx │ name │ variant │
├───┼─────┼──────┼─────────┤
│ 1 │ 3   │ ILE  │ Residue │
│ 2 │ 4   │ VAL  │ Residue │
└───┴─────┴──────┴─────────┘
```