### PR TITLE
System: add `full_table` for component tables (incl. hidden columns)

### DIFF
--- a/docs/src/public/system.md
+++ b/docs/src/public/system.md
@@ -24,6 +24,7 @@ AbstractSystemComponent
 AbstractSystemComponentTable
 SystemComponentTable
 SystemComponentTableCol
+full_table
 get_property
 has_flag
 has_property

--- a/src/core/system_component_table.jl
+++ b/src/core/system_component_table.jl
@@ -2,6 +2,7 @@ export
     AbstractSystemComponentTable,
     SystemComponentTable,
     SystemComponentTableCol,
+    full_table,
     revalidate_indices!
 
 """
@@ -142,6 +143,15 @@ In-place variant of [`sort`](@ref Base.sort(::SystemComponentTable)).
 @inline function Base.sort!(ct::SystemComponentTable; kwargs...)
     ct._idx .= getproperty.(sort(collect(ct); by=e -> e.idx, kwargs...), :idx)
     ct
+end
+
+"""
+    full_table(::SystemComponentTable)
+
+Returns an extended copy of the given table, with all columns being visible.
+"""
+@inline function full_table(ct::SystemComponentTable)
+    ct[:, collect(Symbol, propertynames(ct))]
 end
 
 @inline _row_by_idx(ct::SystemComponentTable, idx::Int) = _row_by_idx(_table(ct), idx)


### PR DESCRIPTION
This function is primarily intended to facilitate conversion to DataFrames as hidden columns would be ignored on direct conversion.

```julia
julia> chains(sys)
ChainTable{Float32} with 3 rows:
┌───┬─────┬──────┐
│ # │ idx │ name │
├───┼─────┼──────┤
│ 1 │ 2   │ A    │
│ 2 │ 195 │ B    │
│ 3 │ 213 │ C    │
└───┴─────┴──────┘

julia> DataFrame(chains(sys))
3×2 DataFrame
 Row │ idx    name   
     │ Int64  String 
─────┼───────────────
   1 │     2  A
   2 │   195  B
   3 │   213  C
```

```julia
julia> full_table(chains(sys))
ChainTable{Float32} with 3 rows:
┌───┬─────┬──────┬─────────────────────┬───────────────┬──────────────┐
│ # │ idx │ name │ properties          │ flags         │ molecule_idx │
├───┼─────┼──────┼─────────────────────┼───────────────┼──────────────┤
│ 1 │ 2   │ A    │ Dict{Symbol, Any}() │ Set{Symbol}() │ 1            │
│ 2 │ 195 │ B    │ Dict{Symbol, Any}() │ Set{Symbol}() │ 1            │
│ 3 │ 213 │ C    │ Dict{Symbol, Any}() │ Set{Symbol}() │ 1            │
└───┴─────┴──────┴─────────────────────┴───────────────┴──────────────┘

julia> DataFrame(full_table(chains(sys)))
3×5 DataFrame
 Row │ idx    name    properties           flags          molecule_idx 
     │ Int64  String  Dict…                Set…           Int64        
─────┼─────────────────────────────────────────────────────────────────
   1 │     2  A       Dict{Symbol, Any}()  Set{Symbol}()             1
   2 │   195  B       Dict{Symbol, Any}()  Set{Symbol}()             1
   3 │   213  C       Dict{Symbol, Any}()  Set{Symbol}()             1
```