### PR TITLE
Backports v0.4

### DIFF
--- a/src/forcefields/common/forcefield.jl
+++ b/src/forcefields/common/forcefield.jl
@@ -47,7 +47,7 @@ end
 
 function _try_assign!(
         templates::Dict{String, AtomTypeTemplate{T}},
-        name::String,
+        name::AbstractString,
         atom::Atom{T};
         assign_typenames::Bool,
         overwrite_typenames::Bool,

--- a/src/substructures/smarts.jl
+++ b/src/substructures/smarts.jl
@@ -3,19 +3,19 @@ export
 
 struct SMARTSQuery
     query::String
-    query_graph::MolecularGraph.SMILESMolGraph
+    query_graph::MolecularGraph.SMARTSMolGraph
 
     function SMARTSQuery(query::String)
-        new(query, smartstomol(query))
+        new(query, MolecularGraph.smartstomol(query))
     end
 end
 
 function _to_substructure(name, mol, m; adjacent_bonds=false)
     matched_atoms = keys(m)
 
-    filter_atoms(
-            :number => n -> n ∈ matched_atoms, mol; 
-            name=name, adjacent_bonds=adjacent_bonds
+    filter_atoms(atom -> atom.number ∈ matched_atoms, mol;
+        name = name,
+        adjacent_bonds = adjacent_bonds
     )
 end
 

--- a/src/substructures/substructure.jl
+++ b/src/substructures/substructure.jl
@@ -27,7 +27,7 @@ end
     atoms::AtomTable{T},
     bonds::BondTable{T},
     properties::Properties = parent.properties
-) where {T, A} = Substructure{Float32, typeof(parent)}(name, parent, atoms, bonds, properties)
+) where {T, A} = Substructure{T, typeof(parent)}(name, parent, atoms, bonds, properties)
 
 function filter_atoms(fn, mol::AbstractAtomContainer{T}; name="", adjacent_bonds=false) where T
     atom_view = filter(fn, atoms(mol))


### PR DESCRIPTION
- [x] [Substructures: fix Substructure ctor for non-Float32 atom containers](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/commit/842941eaa888e816224f6d77bd43617b3f07a904)
- [x] [Substructures: fix SMARTS matching](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/commit/76a9d9d9953b82b5fbb9326ca415d6417f1e4367)
- [x] [FF: fix _try_assign! for abstract-string atom names](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/pull/152/commits/bf7d951d108f2c5326779ac9e2f5583938e0ff2c)