### PR TITLE
FileFormats: fix missing bond orders read from HIN files

### DIFF
--- a/src/fileformats/hinfile.jl
+++ b/src/fileformats/hinfile.jl
@@ -101,13 +101,13 @@ function _handle_hin_atom!(parser_state::HINParserState{T}) where T
 
             partner_type_field = strip(String(fields[11 + 2*current_bond]))
             partner_type =
-                if partner_type_field == 's'
+                if partner_type_field == "s"
                     BondOrder.Single
-                elseif partner_type_field == 'd'
+                elseif partner_type_field == "d"
                     BondOrder.Double
-                elseif partner_type_field == 't'
+                elseif partner_type_field == "t"
                     BondOrder.Triple
-                elseif partner_type_field == 'a'
+                elseif partner_type_field == "a"
                     BondOrder.Aromatic
                 else
                     BondOrder.Unknown

--- a/test/fileformats/test_hinfile.jl
+++ b/test/fileformats/test_hinfile.jl
@@ -27,6 +27,10 @@
         @test nresidues(sys) == 3
         @test nchains(sys) == 1
         @test nbonds(sys) == 30
+        @test only(bonds(atom_by_name(sys, "OXT"))).order == BondOrder.Aromatic
+        @test count(b -> b.order == BondOrder.Single, bonds(sys)) == 26
+        @test count(b -> b.order == BondOrder.Double, bonds(sys)) == 2
+        @test count(b -> b.order == BondOrder.Aromatic, bonds(sys)) == 2
 
         @test_throws SystemError load_hinfile(ball_data_path("../test/data/ASDFASDFASEFADSFASDFAEW.hin"), T)
         @test_throws MethodError load_hinfile(ball_data_path("../test/data/hinfile_test_invalid.hin"), T)


### PR DESCRIPTION
Fixes: #154