### PR TITLE
Backports v0.4.8

### DIFF
--- a/src/forcefields/AMBER/amberff.jl
+++ b/src/forcefields/AMBER/amberff.jl
@@ -5,7 +5,7 @@ get_amber_default_options(T=Float32) = Dict{Symbol, Any}(
     :nonbonded_cutoff               => T(20.0),
     :vdw_cutoff                     => T(15.0),
     :vdw_cuton                      => T(13.0),
-	:electrostatic_cutoff           => T(15.0),
+    :electrostatic_cutoff           => T(15.0),
     :electrostatic_cuton            => T(13.0),
     :scaling_vdw_1_4                => T(2.0),
     :scaling_electrostatic_1_4      => T(1.2),
@@ -28,11 +28,21 @@ function AmberFF(
         constrained_atoms=Vector{Int}()) where {T<:Real}
 
     amber_params = AmberFFParameters(filename, T)
+    options = get_amber_default_options(T)
+
+    # read :scaling_electrostatic_1_4 from parameter file (if present)
+    if haskey(amber_params.sections, "Options")
+        props = extract_section(amber_params, "Options").properties
+        if haskey(props, "SCEE")
+            options[:scaling_electrostatic_1_4] = parse(T, props["SCEE"])
+        end
+    end
+
     amber_ff = ForceField{T}(
         "AmberFF",
         ac,
         amber_params,
-        get_amber_default_options(T),
+        options,
         init_atom_types(amber_params, T),
         Vector{AbstractForceFieldComponent{T}}(),
         Dict{String, T}(),

--- a/src/forcefields/AMBER/amberff.jl
+++ b/src/forcefields/AMBER/amberff.jl
@@ -27,7 +27,7 @@ function AmberFF(
         filename=ball_data_path("forcefields/AMBER/amber96.ini");
         constrained_atoms=Vector{Int}()) where {T<:Real}
 
-    amber_params = AmberFFParameters(filename)
+    amber_params = AmberFFParameters(filename, T)
     amber_ff = ForceField{T}(
         "AmberFF",
         ac,


### PR DESCRIPTION
 - [x] [FF: use the ForceField float type for parameter file reading](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/pull/165/commits/18edfe7bab3dbe5f172ed49ebae1dea480c4d938)
 - [x] [FF: read 1-4 ES scaling factor from parameter file](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/commit/6f109dd0b6ec85bd77c762f77dc455e4b4abbb35)