### PR TITLE
Backports v0.5.2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
         version:
           - 'lts'
           - '1.11'
-          - '1.12-nightly'
+          - 'pre'
           - 'nightly'
         os:
           - ubuntu-latest
@@ -40,7 +40,7 @@ jobs:
           # Broken by dependency, cf. https://github.com/BioJulia/IndexableBitVectors.jl/issues/9
           # - x86
         include:
-          - version: '1.12-nightly'
+          - version: 'pre'
             experimental: true
           - version: 'nightly'
             experimental: true

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -21,14 +21,14 @@ jobs:
         version:
           - 'lts'
           - '1.11'
-          - '1.12-nightly'
+          - 'pre'
           - 'nightly'
         os:
           - ubuntu-latest
         arch:
           - x64
         include:
-          - version: '1.12-nightly'
+          - version: 'pre'
             experimental: true
           - version: 'nightly'
             experimental: true

--- a/src/core/types.jl
+++ b/src/core/types.jl
@@ -14,5 +14,5 @@ const MaybeInt = Union{Nothing, Int}
 const Properties = Dict{Symbol, Any}
 const Flags = Set{Symbol}
 
-@inline squared_norm(v::Vector3{T}) where T = dot(v, v)
-@inline distance(v::Vector3{T}, w::Vector3{T}) where T = norm(v - w)
+@inline squared_norm(v::AbstractVector) = dot(v, v)
+@inline distance(v::AbstractVector{T}, w::AbstractVector{T}) where T = norm(v - w)


### PR DESCRIPTION
 - [x] [CI: use Julia pre instead of 1.12-nightly](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/commit/c7011f8a3438d4238e21c877d300bacef4442db0)
 - [x] [Core: relax type restrictions on `squared_norm` and `distance`](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/commit/8fe9d6e899f1dbdea005f719ec46da0f4119ba63)