### PR TITLE
Fix `write_pdb(_, ::Chain)` and `write_pdb(_, ::Fragment)`

### DIFF
--- a/docs/src/tutorials/handle_molecules.md
+++ b/docs/src/tutorials/handle_molecules.md
@@ -175,7 +175,7 @@ all_chains = chains(sys)
 This snippet will create separate PDB files for the two chains of the system:
 
 ``` julia
-#type
+write_pdb("2ptc_chainE.pdb", all_chains[1])
 write_pdb("2ptc_chainI.pdb", all_chains[2])
 ```
 

--- a/docs/src/tutorials/handle_molecules.md
+++ b/docs/src/tutorials/handle_molecules.md
@@ -173,11 +173,10 @@ all_chains = chains(sys)
 |      4 | 2615    | I        |
 
 This snippet will create separate PDB files for the two chains of the system:
-Note: Currently fails see [issue 209](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/issues/209)
 
 ``` julia
-#write_pdb("2ptc_chainE.pdb", all_chains[1])
-#write_pdb("2ptc_chainI.pdb", all_chains[2])
+#type
+write_pdb("2ptc_chainI.pdb", all_chains[2])
 ```
 
 ## How can I map two configurations of the same protein onto each other?

--- a/src/fileformats/pdb.jl
+++ b/src/fileformats/pdb.jl
@@ -323,7 +323,7 @@ function write_pdb(io::IO, ac::AbstractAtomContainer{T}) where T
     pdb_info = get_property(ac, :PDBInfo, PDBDetails.PDBInfo{T}())
 
     pdb_info.writer_stats = PDBDetails.PDBWriterStats()
-    
+
     PDBDetails.write_title_section(io, pdb_info)
     PDBDetails.write_primary_structure_section(io, pdb_info, ac)
     PDBDetails.write_heterogen_section(io, pdb_info)

--- a/src/fileformats/pdb.jl
+++ b/src/fileformats/pdb.jl
@@ -307,14 +307,14 @@ function Base.convert(::Type{MolecularStructure}, ac::AbstractAtomContainer{T}) 
     fixlists!(struc)
     struc
 end
-function write_pdb(io::IO, ac::Fragment{T}) where T
+
+function write_pdb(io::IO, ac::Union{Chain{T}, Fragment{T}}) where T
         # get the PDBInfo object
     pdb_info = get_property(ac, :PDBInfo, PDBDetails.PDBInfo{T}())
-
     pdb_info.writer_stats = PDBDetails.PDBWriterStats()
 
-        PDBDetails.write_coordinate_section(io, pdb_info, ac, true)
-        PDBDetails.write_record(io, pdb_info, PDBDetails.RECORD_TAG_END)
+    PDBDetails.write_coordinate_section(io, pdb_info, ac; coordinate_only=true)
+    PDBDetails.write_record(io, pdb_info, PDBDetails.RECORD_TAG_END)
 end
 
 function write_pdb(io::IO, ac::AbstractAtomContainer{T}) where T
@@ -331,7 +331,7 @@ function write_pdb(io::IO, ac::AbstractAtomContainer{T}) where T
     PDBDetails.write_connectivity_annotation_section(io, pdb_info, ac)
     PDBDetails.write_miscellaneous_features_section(io, pdb_info)
     PDBDetails.write_crystallographic_section(io, pdb_info)
-    PDBDetails.write_coordinate_section(io, pdb_info, ac, false)
+    PDBDetails.write_coordinate_section(io, pdb_info, ac)
     PDBDetails.write_connectivity_section(io, pdb_info, ac)
     PDBDetails.write_bookkeeping_section(io, pdb_info, ac)
     PDBDetails.write_record(io, pdb_info, PDBDetails.RECORD_TAG_END)

--- a/src/fileformats/pdb.jl
+++ b/src/fileformats/pdb.jl
@@ -307,14 +307,23 @@ function Base.convert(::Type{MolecularStructure}, ac::AbstractAtomContainer{T}) 
     fixlists!(struc)
     struc
 end
-
-
-function write_pdb(io::IO, ac::AbstractAtomContainer{T}) where T
-    # get the PDBInfo object
+function write_pdb(io::IO, ac::Fragment{T}) where T
+        # get the PDBInfo object
     pdb_info = get_property(ac, :PDBInfo, PDBDetails.PDBInfo{T}())
 
     pdb_info.writer_stats = PDBDetails.PDBWriterStats()
 
+        PDBDetails.write_coordinate_section(io, pdb_info, ac, true)
+        PDBDetails.write_record(io, pdb_info, PDBDetails.RECORD_TAG_END)
+end
+
+function write_pdb(io::IO, ac::AbstractAtomContainer{T}) where T
+
+    # get the PDBInfo object
+    pdb_info = get_property(ac, :PDBInfo, PDBDetails.PDBInfo{T}())
+
+    pdb_info.writer_stats = PDBDetails.PDBWriterStats()
+    
     PDBDetails.write_title_section(io, pdb_info)
     PDBDetails.write_primary_structure_section(io, pdb_info, ac)
     PDBDetails.write_heterogen_section(io, pdb_info)
@@ -322,7 +331,7 @@ function write_pdb(io::IO, ac::AbstractAtomContainer{T}) where T
     PDBDetails.write_connectivity_annotation_section(io, pdb_info, ac)
     PDBDetails.write_miscellaneous_features_section(io, pdb_info)
     PDBDetails.write_crystallographic_section(io, pdb_info)
-    PDBDetails.write_coordinate_section(io, pdb_info, ac)
+    PDBDetails.write_coordinate_section(io, pdb_info, ac, false)
     PDBDetails.write_connectivity_section(io, pdb_info, ac)
     PDBDetails.write_bookkeeping_section(io, pdb_info, ac)
     PDBDetails.write_record(io, pdb_info, PDBDetails.RECORD_TAG_END)

--- a/src/fileformats/pdb/pdb_writer.jl
+++ b/src/fileformats/pdb/pdb_writer.jl
@@ -143,18 +143,6 @@ function write_records(io::IO, pdb_info::PDBInfo, record_type)
     end
 end
 
-
-function write_seqres(io::IO, pdb_info::PDBInfo, chain::Chain{T}) where {T <:Real}
-    res = fragments(chain)
-    nres = length(res)
-    # each chain is stored in groups of 13 residues
-    for (i, rs) in enumerate(Iterators.partition(res, 13))
-        rs = vcat(map(r -> fix_nucleotide_name(r.name), rs), repeat([""], 13 - length(rs)))
-        write_record(io, pdb_info, RECORD_TAG_SEQRES, i, chain.name, nres, rs...)
-    end
-end 
-
-
 function write_seqres(io::IO, pdb_info::PDBInfo, ac::AbstractAtomContainer{T}) where {T <:Real}
 
     # iterate over all chains
@@ -429,10 +417,10 @@ function write_atom_section(io::IO, pdb_info::PDBInfo, ac::AbstractAtomContainer
         end
 end
 
-function write_coordinate_section(io::IO, pdb_info::PDBInfo, ac::AbstractAtomContainer{T}, coordinate_only::Bool) where {T <:Real}
+function write_coordinate_section(io::IO, pdb_info::PDBInfo, ac::AbstractAtomContainer{T}; coordinate_only::Bool=false) where {T <:Real}
 
     if coordinate_only
-        # if we only want to write the coordinates, we can skip all the bookkeeping and just write the ATOM/HETATM records
+        # if the  ac::Chain or ac::Fragment, we skip all other sections and write plain atom records
         write_atom_section(io, pdb_info, ac)
         return
     end

--- a/src/fileformats/pdb/pdb_writer.jl
+++ b/src/fileformats/pdb/pdb_writer.jl
@@ -384,23 +384,8 @@ function write_crystallographic_section(io::IO, pdb_info::PDBInfo)
     write_records(io, pdb_info, Val(RECORD_TYPE__TVECT))
 end
 
-function write_coordinate_section(io::IO, pdb_info::PDBInfo, ac::AbstractAtomContainer{T}) where {T <:Real}
-    # first, figure out if we have to write multiple models...
-    models = frame_ids(ac)
-    
-    if pdb_info.selected_model != -1
-        models = collect(Iterators.filter(m -> m == pdb_info.selected_model, models))
-    end
-
-    multiple_models = length(models) > 1
-
-    for model in models
-        if multiple_models
-            # write a models record
-            write_record(io, pdb_info, RECORD_TAG_MODEL, pdb_info.selected_model)
-        end
-
-        # we iterate over all atoms and decide if we have to write an ATOM, HETATM, or TER record
+function write_atom_section(io::IO, pdb_info::PDBInfo, ac::AbstractAtomContainer{T}) where {T <:Real}
+ # we iterate over all atoms and decide if we have to write an ATOM, HETATM, or TER record
 
         last_atom = nothing
         atom_number = 1
@@ -442,6 +427,32 @@ function write_coordinate_section(io::IO, pdb_info::PDBInfo, ac::AbstractAtomCon
         if natoms(ac) > 0
             write_record(io, pdb_info, RECORD_TAG_TER, atom_number, atom_details(atoms(ac)[end])...)
         end
+end
+
+function write_coordinate_section(io::IO, pdb_info::PDBInfo, ac::AbstractAtomContainer{T}, coordinate_only::Bool) where {T <:Real}
+
+    if coordinate_only
+        # if we only want to write the coordinates, we can skip all the bookkeeping and just write the ATOM/HETATM records
+        write_atom_section(io, pdb_info, ac)
+        return
+    end
+
+    # first, figure out if we have to write multiple models...
+    models = frame_ids(ac)
+    
+    if pdb_info.selected_model != -1
+        models = collect(Iterators.filter(m -> m == pdb_info.selected_model, models))
+    end
+
+    multiple_models = length(models) > 1
+
+    for model in models
+        if multiple_models
+            # write a models record
+            write_record(io, pdb_info, RECORD_TAG_MODEL, pdb_info.selected_model)
+        end
+
+        write_atom_section(io, pdb_info, ac)
 
         if multiple_models
             # write a model record

--- a/src/fileformats/pdb/pdb_writer.jl
+++ b/src/fileformats/pdb/pdb_writer.jl
@@ -143,7 +143,20 @@ function write_records(io::IO, pdb_info::PDBInfo, record_type)
     end
 end
 
+
+function write_seqres(io::IO, pdb_info::PDBInfo, chain::Chain{T}) where {T <:Real}
+    res = fragments(chain)
+    nres = length(res)
+    # each chain is stored in groups of 13 residues
+    for (i, rs) in enumerate(Iterators.partition(res, 13))
+        rs = vcat(map(r -> fix_nucleotide_name(r.name), rs), repeat([""], 13 - length(rs)))
+        write_record(io, pdb_info, RECORD_TAG_SEQRES, i, chain.name, nres, rs...)
+    end
+end 
+
+
 function write_seqres(io::IO, pdb_info::PDBInfo, ac::AbstractAtomContainer{T}) where {T <:Real}
+
     # iterate over all chains
     for chain in chains(ac)
         res = fragments(chain)

--- a/test/fileformats/test_pdb.jl
+++ b/test/fileformats/test_pdb.jl
@@ -64,6 +64,34 @@ end
         @test first(chains(sys2)).name == "A"
         @test nmolecules(sys2) == 1
     end
+
+
+    # test for single chain
+    for T in [Float32, Float64]
+        sys = System{T}()
+        mol = Molecule(sys)
+        chain = Chain(mol; name = "A")
+        chain2 = Chain(mol; name = "B")
+        frag = Fragment(chain, 1)
+        frag2 = Fragment(chain2, 2)
+        Atom(frag, 1, Elements.C; name = "C")
+        Atom(frag, 2, Elements.O; name = "O", r = ones(Vector3{T}))
+
+        Atom(frag2, 1, Elements.C; name = "C")
+        Atom(frag2, 2, Elements.O; name = "H", r = ones(Vector3{T}))
+        Atom(frag2, 3, Elements.O; name = "H", r = ones(Vector3{T}))
+        (fname, fh) = mktemp(; cleanup = true)
+
+        write_pdb(fname, chain2)
+        sys2 = load_pdb(fname, T)
+        @test sys2 isa System{T}
+        @test natoms(sys2) == 3
+        @test atoms(sys2).name == ["C", "H", "H"]
+        @test nfragments(sys2) == 1
+        @test nchains(sys2) == 1
+        @test first(chains(sys2)).name == "B"
+        @test nmolecules(sys2) == 1
+    end
 end
 
 @testitem "Read PDBx/mmCIF" begin

--- a/test/fileformats/test_pdb.jl
+++ b/test/fileformats/test_pdb.jl
@@ -92,6 +92,33 @@ end
         @test first(chains(sys2)).name == "B"
         @test nmolecules(sys2) == 1
     end
+
+    # test for single fragment (only coordinates)
+    for T in [Float32, Float64]
+        sys = System{T}()
+        mol = Molecule(sys)
+        chain = Chain(mol; name = "A")
+        chain2 = Chain(mol; name = "B")
+        frag = Fragment(chain, 1)
+        frag2 = Fragment(chain2, 2)
+        Atom(frag, 1, Elements.C; name = "C")
+        Atom(frag, 2, Elements.O; name = "O", r = ones(Vector3{T}))
+
+        Atom(frag2, 1, Elements.C; name = "C")
+        Atom(frag2, 2, Elements.O; name = "H", r = ones(Vector3{T}))
+        Atom(frag2, 3, Elements.O; name = "H", r = ones(Vector3{T}))
+        (fname, fh) = mktemp(; cleanup = true)
+
+        write_pdb(fname, chain2)
+        sys2 = load_pdb(fname, T)
+        @test sys2 isa System{T}
+        @test natoms(sys2) == 3
+        @test atoms(sys2).name == ["C", "H", "H"]
+        @test nfragments(sys2) == 1
+        @test nchains(sys2) == 1
+        @test first(chains(sys2)).name == "B"
+        @test nmolecules(sys2) == 1
+    end
 end
 
 @testitem "Read PDBx/mmCIF" begin

--- a/tutorials/handle_molecules.qmd
+++ b/tutorials/handle_molecules.qmd
@@ -91,10 +91,10 @@ all_chains = chains(sys)
 ```
 
 This snippet will create separate PDB files for the two chains of the system:
-Note: Currently fails see [issue 209](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/issues/209)
+
 ```{julia}
-#write_pdb("2ptc_chainE.pdb", all_chains[1])
-#write_pdb("2ptc_chainI.pdb", all_chains[2])
+#type
+write_pdb("2ptc_chainI.pdb", all_chains[2])
 ```
 
 

--- a/tutorials/handle_molecules.qmd
+++ b/tutorials/handle_molecules.qmd
@@ -93,7 +93,7 @@ all_chains = chains(sys)
 This snippet will create separate PDB files for the two chains of the system:
 
 ```{julia}
-#type
+write_pdb("2ptc_chainE.pdb", all_chains[1])
 write_pdb("2ptc_chainI.pdb", all_chains[2])
 ```
 


### PR DESCRIPTION
- `write_seqres` for chains has been added (required) for writing a valid PDB file
- writing of single fragments is possible now (only ATOM entries)

Chains will only be written out as valid PDB and not as "ATOM only"