### PR TITLE
FragmentDB: unexport `get_reference_fragment`

### DIFF
--- a/src/preprocessing/fragmentDB.jl
+++ b/src/preprocessing/fragmentDB.jl
@@ -1,6 +1,5 @@
 export
-    FragmentDB,
-    get_reference_fragment
+    FragmentDB
 
 @auto_hash_equals struct DBAtom{T <: Real}
     name::String

--- a/test/preprocessing/test_fragmentdb.jl
+++ b/test/preprocessing/test_fragmentdb.jl
@@ -1,4 +1,6 @@
 @testitem "FragmentDB" begin
+    using BiochemicalAlgorithms: get_reference_fragment
+
     for fdb in (FragmentDB(), FragmentDB{Float32}(), FragmentDB{Float64}())
         @test length(fdb.fragments) == 33
         @test length(fdb.name_mappings) == 6


### PR DESCRIPTION
This function returns objects of unexported data types, which are not meant to be used in the public interface.