### PR TITLE
FragmentDB: split `label_terminal_fragments!` from `normalize_names!`

### DIFF
--- a/docs/src/public/preprocessing.md
+++ b/docs/src/public/preprocessing.md
@@ -19,6 +19,11 @@ infer_topology!
 normalize_names!
 ```
 
+## Fragment terminal labeling
+```@docs
+label_terminal_fragments!
+```
+
 ## Fragment reconstruction
 ```@docs
 reconstruct_fragments!

--- a/src/preprocessing/build_bonds.jl
+++ b/src/preprocessing/build_bonds.jl
@@ -137,8 +137,12 @@ end
     build_bonds!(::AbstractAtomContainer{T}, ::FragmentDB{T})
 
 Attempts to construct missing bonds in the given container, according to the
-default/given fragment database, and returns the number of built bonds. This
-preprocessor expects fragment and atom names to be normalized.
+default/given fragment database, and returns the number of built bonds.
+
+!!! note
+    This preprocessor expects fragment and atom names to be normalized and
+    fragment terminals to be labeled (cf. [`normalize_names!`](@ref) and
+    [`label_terminal_fragments!`](@ref)).
 """
 function build_bonds!(m::AbstractAtomContainer{T}, fdb::FragmentDB{T}) where T
     # while building up individual fragments, we remember inter-fragment connections

--- a/src/preprocessing/fragmentDB.jl
+++ b/src/preprocessing/fragmentDB.jl
@@ -1,7 +1,8 @@
 export
     FragmentDB,
     default_fragmentdb,
-    infer_topology!
+    infer_topology!,
+    label_terminal_fragments!
 
 @auto_hash_equals struct DBAtom{T <: Real}
     name::String
@@ -156,6 +157,18 @@ end
     end
 end
 
+"""
+    label_terminal_fragments!(::AbstractAtomContainer{Float32})
+    label_terminal_fragments!(::AbstractAtomContainer{T}, ::FragmentDB{T})
+
+Attempt to label terminal fragments, i.e., assign the `N_TERMINAL`/`C_TERMINAL` flag
+to the first/last fragment of all residue chains and the `5_PRIME`/`3_PRIME` flag to
+the first/last fragment of all nucleotide chains, respectively.
+
+!!! note
+    This preprocessor expects fragment and atom names to be normalized (cf.
+    [`normalize_names!`](@ref)).
+"""
 function label_terminal_fragments!(ac::AbstractAtomContainer{T}, fdb::FragmentDB{T}) where T
     # iterate over all chains and label their terminals
     for chain in chains(ac)
@@ -250,10 +263,11 @@ end
 
 Apply standard preprocessing functions to the given atom container, using the default/given
 fragment database. By default, this calls (in order): [`normalize_names!`](@ref),
-[`reconstruct_fragments!`](@ref), and [`build_bonds!`](@ref).
+[`label_terminal_fragments!`](@ref), [`reconstruct_fragments!`](@ref), and [`build_bonds!`](@ref).
 
 # Supported keyword arguments
  - `normalize_names::Bool = true`
+ - `label_terminal_fragments::Bool = true`
  - `reconstruct_fragments::Bool = true`
  - `build_bonds::Bool = true`
 All keyword arguments enable or disable the corresponding preprocessors.
@@ -266,12 +280,14 @@ All keyword arguments enable or disable the corresponding preprocessors.
     ac::AbstractAtomContainer{T},
     fdb::FragmentDB{T};
     normalize_names::Bool = true,
+    label_terminal_fragments::Bool = true,
     reconstruct_fragments::Bool = true,
     build_bonds::Bool = true
 ) where T
-    normalize_names       && normalize_names!(ac, fdb)
-    reconstruct_fragments && reconstruct_fragments!(ac, fdb)
-    build_bonds           && build_bonds!(ac, fdb)
+    normalize_names          && normalize_names!(ac, fdb)
+    label_terminal_fragments && label_terminal_fragments!(ac, fdb)
+    reconstruct_fragments    && reconstruct_fragments!(ac, fdb)
+    build_bonds              && build_bonds!(ac, fdb)
     nothing
 end
 

--- a/src/preprocessing/normalize_names.jl
+++ b/src/preprocessing/normalize_names.jl
@@ -135,10 +135,6 @@ function normalize_names!(
         end
     end
 
-    # label all terminal fragments to speed up terminal lookups later on
-    # TODO this really doesn't belong here...
-    label_terminal_fragments!(m, fdb)
-
     nothing
 end
 

--- a/src/preprocessing/reconstruct_fragments.jl
+++ b/src/preprocessing/reconstruct_fragments.jl
@@ -168,8 +168,12 @@ end
     reconstruct_fragments!(::AbstractAtomContainer{T}, ::FragmentDB{T})
 
 Attempts to reconstruct all fragments in the given container according to the
-default/given fragment database and returns the number of inserted atoms. This
-preprocessor expects fragment and atom names to be normalized.
+default/given fragment database and returns the number of inserted atoms.
+
+!!! note
+    This preprocessor expects fragment and atom names to be normalized and
+    fragment terminals to be labeled (cf. [`normalize_names!`](@ref) and
+    [`label_terminal_fragments!`](@ref)).
 """
 function reconstruct_fragments!(ac::AbstractAtomContainer{T}, fdb::FragmentDB{T}) where T
     num_inserted_atoms = 0

--- a/test/core/test_fragment.jl
+++ b/test/core/test_fragment.jl
@@ -1556,6 +1556,7 @@ end
         fdb = FragmentDB{T}()
         sys = load_hinfile(ball_data_path("../test/data/AlaGlySer.hin"), T)
         normalize_names!(sys, fdb)
+        label_terminal_fragments!(sys, fdb)
 
         frags = collect(fragments(sys))
         @test length(frags) == 3

--- a/test/forcefields/AMBER/test_amberff.jl
+++ b/test/forcefields/AMBER/test_amberff.jl
@@ -4,10 +4,7 @@
     end
 
     let p = load_pdb(ball_data_path("../test/data/AlaAla.pdb"))
-        fdb = FragmentDB()
-        normalize_names!(p, fdb)
-        reconstruct_fragments!(p, fdb)
-        build_bonds!(p, fdb)
+        infer_topology!(p)
 
         a_ff = AmberFF(p)
 
@@ -39,6 +36,7 @@
         # Energy test 1 (single stretch) [AMBER91]
         let sys = load_hinfile(ball_data_path("../test/data/AmberFF_test_1.hin"), T)
             normalize_names!(sys, fdb)
+            label_terminal_fragments!(sys, fdb)
 
             ff = AmberFF(sys, ff_amber91; assign_charges = false, assign_typenames = false)
 
@@ -58,6 +56,7 @@
         # Energy test 2 (Bend) [AMBER91]
         let sys = load_hinfile(ball_data_path("../test/data/AmberFF_test_2.hin"), T)
             normalize_names!(sys, fdb)
+            label_terminal_fragments!(sys, fdb)
 
             ff = AmberFF(sys, ff_amber91; assign_charges = false, assign_typenames = false)
 
@@ -77,6 +76,7 @@
         # Energy test 3 (VdW) [AMBER91]
         let sys = load_hinfile(ball_data_path("../test/data/AmberFF_test_3.hin"), T)
             normalize_names!(sys, fdb)
+            label_terminal_fragments!(sys, fdb)
 
             ff = AmberFF(sys, ff_amber91; assign_charges = false, assign_typenames = false)
 
@@ -96,6 +96,7 @@
         # Energy test 4 (Torsion) [AMBER91]
         let sys = load_hinfile(ball_data_path("../test/data/AmberFF_test_4.hin"), T)
             normalize_names!(sys, fdb)
+            label_terminal_fragments!(sys, fdb)
 
             ff = AmberFF(sys, ff_amber91; assign_charges = false, assign_typenames = false)
 
@@ -115,6 +116,7 @@
         # Energy test 5 (AlaGlySer) [AMBER91]
         let sys = load_hinfile(ball_data_path("../test/data/AlaGlySer.hin"), T)
             normalize_names!(sys, fdb)
+            label_terminal_fragments!(sys, fdb)
 
             ff = AmberFF(sys, ff_amber91; assign_charges = false, assign_typenames = false)
 
@@ -134,6 +136,7 @@
         # Energy test 5 (AlaGlySer) [AMBER96]
         let sys = load_hinfile(ball_data_path("../test/data/AlaGlySer.hin"), T)
             normalize_names!(sys, fdb)
+            label_terminal_fragments!(sys, fdb)
 
             ff = AmberFF(sys, ff_amber96; assign_charges = false, assign_typenames = false)
 
@@ -153,6 +156,7 @@
         # Energy test 6 (AlaGlySer) [AMBER94]
         let sys = load_hinfile(ball_data_path("../test/data/AlaGlySer2.hin"), T)
             normalize_names!(sys, fdb)
+            label_terminal_fragments!(sys, fdb)
 
             ff = AmberFF(sys, ff_amber94; overwrite_typenames = true)
 
@@ -172,6 +176,7 @@
         # Force test 1 (Torsion) [AMBER94]
         let sys = load_hinfile(ball_data_path("../test/data/AMBER_test_1.hin"), T)
             normalize_names!(sys, fdb)
+            label_terminal_fragments!(sys, fdb)
 
             ff = AmberFF(sys, ff_amber94; overwrite_typenames = true)
 
@@ -191,6 +196,7 @@
         # Force test 2 (ES switching) [AMBER91/CDIEL]
         let sys = load_hinfile(ball_data_path("../test/data/AmberFF_test_3.hin"), T)
             normalize_names!(sys, fdb)
+            label_terminal_fragments!(sys, fdb)
 
             ff = AmberFF(sys, ff_amber91;
                 assign_charges = false,
@@ -224,6 +230,7 @@
         # Force test 3 (ES switching) [AMBER91/RDIEL]
         let sys = load_hinfile(ball_data_path("../test/data/AmberFF_test_3.hin"), T)
             normalize_names!(sys, fdb)
+            label_terminal_fragments!(sys, fdb)
 
             ff = AmberFF(sys, ff_amber91;
                 assign_charges = false,
@@ -245,7 +252,7 @@
                 update!(ff)
                 compute_forces!(ff)
 
-                force = a2.F[1] 
+                force = a2.F[1]
                 dE = compute_energy!(ff)
                 a2.r = Vector3{T}(d - 0.0001, 0, 0)
                 update!(ff)
@@ -257,6 +264,7 @@
         # Force test 4 (VdW switching) [AMBER91]
         let sys = load_hinfile(ball_data_path("../test/data/AmberFF_test_3.hin"), T)
             normalize_names!(sys, fdb)
+            label_terminal_fragments!(sys, fdb)
 
             ff = AmberFF(sys, ff_amber91;
                 assign_charges = false,

--- a/test/preprocessing/test_fragmentdb.jl
+++ b/test/preprocessing/test_fragmentdb.jl
@@ -55,3 +55,35 @@
         @test contains(repr(fdb), "33 fragments")
     end
 end
+
+@testitem "label_terminal_fragments!" begin
+    for T in [Float32, Float64]
+        fdb = FragmentDB{T}()
+
+        # basic terminal labeling on AlaGlySer tripeptide
+        let sys = load_hinfile(ball_data_path("../test/data/AlaGlySer.hin"), T)
+            normalize_names!(sys, fdb)
+            label_terminal_fragments!(sys, fdb)
+
+            # terminal fragments should be flagged
+            frags = collect(fragments(sys))
+            @test :N_TERMINAL in frags[1].flags
+            @test :C_TERMINAL in frags[end].flags
+
+            # middle fragment should have neither terminal flag
+            @test :N_TERMINAL ∉ frags[2].flags
+            @test :C_TERMINAL ∉ frags[2].flags
+        end
+
+        # BPTI: verify terminal labeling on a real protein
+        let sys = load_pdb(ball_data_path("../test/data/bpti.pdb"), T)
+            normalize_names!(sys, fdb)
+            label_terminal_fragments!(sys, fdb)
+
+            n_terms = filter(f -> :N_TERMINAL in f.flags, fragments(sys))
+            c_terms = filter(f -> :C_TERMINAL in f.flags, fragments(sys))
+            @test length(n_terms) == 1
+            @test length(c_terms) == 1
+        end
+    end
+end

--- a/test/preprocessing/test_normalize_names.jl
+++ b/test/preprocessing/test_normalize_names.jl
@@ -2,30 +2,6 @@
     for T in [Float32, Float64]
         fdb = FragmentDB{T}()
 
-        # basic normalization on AlaGlySer tripeptide
-        let sys = load_hinfile(ball_data_path("../test/data/AlaGlySer.hin"), T)
-            normalize_names!(sys, fdb)
-
-            # terminal fragments should be flagged
-            frags = collect(fragments(sys))
-            @test :N_TERMINAL in frags[1].flags
-            @test :C_TERMINAL in frags[end].flags
-
-            # middle fragment should have neither terminal flag
-            @test :N_TERMINAL ∉ frags[2].flags
-            @test :C_TERMINAL ∉ frags[2].flags
-        end
-
-        # BPTI: verify terminal labeling on a real protein
-        let sys = load_pdb(ball_data_path("../test/data/bpti.pdb"), T)
-            normalize_names!(sys, fdb)
-
-            n_terms = filter(f -> :N_TERMINAL in f.flags, fragments(sys))
-            c_terms = filter(f -> :C_TERMINAL in f.flags, fragments(sys))
-            @test length(n_terms) == 1
-            @test length(c_terms) == 1
-        end
-
         # system with no fragments: no crash
         let sys = System{T}()
             Molecule(sys)

--- a/test/preprocessing/test_reconstruct_fragments.jl
+++ b/test/preprocessing/test_reconstruct_fragments.jl
@@ -16,6 +16,7 @@
 
         let sys = load_hinfile(ball_data_path("../test/data/ReconstructFragmentProcessor_test1.hin"), T)
             normalize_names!(sys, fdb)
+            label_terminal_fragments!(sys, fdb)
 
             @test reconstruct_fragments!(sys, fdb) == 4
             @test natoms(sys) == 31
@@ -41,6 +42,7 @@
         # multi-fragment system: already complete → 0 reconstructed
         let sys = load_pdb(ball_data_path("../test/data/AlaAla.pdb"), T)
             normalize_names!(sys, fdb)
+            label_terminal_fragments!(sys, fdb)
             before = natoms(sys)
             @test reconstruct_fragments!(sys, fdb) == 0
             @test natoms(sys) == before


### PR DESCRIPTION
`normalize_names!` no longer implicitly assigns fragment terminal flags such as `N_TERMINAL`, `C_TERMINAL`, `5_PRIME`, and `3_PRIME`. Instead, this is now factored out into a separate function `label_terminal_fragments!`.

Users of `infer_topology!` (the preferred way of using the fragment database as of v0.7) should see no change as `label_terminal_fragments!` is now called after `normalize_names!`. However, if `normalize_names!` was used explicitly, chances are that `label_terminal_fragments!` might now need to be called as well.