### PR TITLE
PDB: hotfix `load_pdb` for fragments in multiple secondary structures

### DIFF
--- a/src/fileformats/pdb/pdb_general.jl
+++ b/src/fileformats/pdb/pdb_general.jl
@@ -614,6 +614,9 @@ function postprocess_secondary_structures_!(sys, pdb_info, fragment_cache, creat
 
         for f in fragments(parent_chain(initial_res))
             if f.number >= initial_res.number && f.number <= terminal_res.number
+                if !isnothing(f.secondary_structure_idx)
+                    @warn "load_pdb: reassigning secondary structure of fragment $(f.idx): $(new_ss.idx) (was: $(f.secondary_structure_idx))"
+                end
                 f.secondary_structure_idx = new_ss.idx
             end
         end
@@ -647,7 +650,7 @@ function postprocess_secondary_structures_!(sys, pdb_info, fragment_cache, creat
 
     # finally, renumber the elements to be consecutive
     if nsecondary_structures(sys) > 0
-        sort_secondary_structures!(sys, by=se -> (se.chain_idx, minimum(f.number for f in fragments(se))))
+        sort_secondary_structures!(sys, by=se -> (se.chain_idx, minimum(f.number for f in fragments(se); init=0)))
 
         for c in chains(sys)
             secondary_structures(c).number .= collect(1:nsecondary_structures(c))


### PR DESCRIPTION
Fragments can currently only be assigned to at most one secondary structure. This patch replaces the error thrown by `load_pdb` with a warning, so that offending structures can still be loaded.

Fixes: #259