### PR TITLE
PDB: hotfix alternate location-related `load_pdb` errors

### DIFF
--- a/src/fileformats/pdb.jl
+++ b/src/fileformats/pdb.jl
@@ -197,11 +197,11 @@ Read a PDB file.
     Models are stored as frames, using the model number as `frame_id`.
 """
 function load_pdb(
-        filename::AbstractString, 
+        filename::AbstractString,
         ::Type{T} = Float32;
         keep_metadata::Bool=true,
         strict_line_checking::Bool=false,
-        selected_model::Int=-1, 
+        selected_model::Int=-1,
         ignore_xplor_pseudo_atoms::Bool=true,
         create_coils::Bool=true) where {T <: Real}
 
@@ -213,7 +213,7 @@ function load_pdb(
     pdb_info = PDBDetails.PDBInfo{T}(selected_model)
 
     for pl in pdblines
-        PDBDetails.handle_record(pl, sys, pdb_info; 
+        PDBDetails.handle_record(pl, sys, pdb_info;
             strict_line_checking=strict_line_checking,
             ignore_xplor_pseudo_atoms=ignore_xplor_pseudo_atoms)
     end
@@ -236,6 +236,10 @@ function load_pdb(
         pdb_info.current_residue = nothing
 
         set_property!(sys, :PDBInfo, pdb_info)
+    end
+
+    if pdb_info.alternate_location_warning
+        @warn "load_pdb: alternate locations other than A are currently not supported. Affected records have been ignored!"
     end
 
     sys

--- a/src/fileformats/pdb/pdb_defs.jl
+++ b/src/fileformats/pdb/pdb_defs.jl
@@ -1,7 +1,7 @@
 using AutoHashEquals
 using DataStructures
 
-using BiochemicalAlgorithms: 
+using BiochemicalAlgorithms:
     Molecule,
     Chain,
     Fragment
@@ -68,7 +68,7 @@ export PDBInfo
     RECORD_TYPE__TITLE,
     RECORD_TYPE__TURN,
     RECORD_TYPE__TVECT,
-        
+
     NUMBER_OF_REGISTERED_RECORD_TYPES,
 
     ALL_RECORD_TYPES
@@ -164,13 +164,14 @@ end
     current_residue::Union{Fragment{T}, Nothing}
 
     alternate_location_identifier::String
+    alternate_location_warning::Bool
 
     writer_stats::PDBWriterStats
 
     function PDBInfo{T}(selected_model=-1) where {T}
-        new("", "", "", "", Deque{PDBRecord}(), Deque{SSBondRecord}(), 
-            Deque{Union{HelixRecord, SheetRecord, TurnRecord}}(), selected_model, 
-            1, nothing, nothing, "A", PDBWriterStats())
+        new("", "", "", "", Deque{PDBRecord}(), Deque{SSBondRecord}(),
+            Deque{Union{HelixRecord, SheetRecord, TurnRecord}}(), selected_model,
+            1, nothing, nothing, "A", false, PDBWriterStats())
     end
 end
 

--- a/src/fileformats/pdb/pdb_general.jl
+++ b/src/fileformats/pdb/pdb_general.jl
@@ -170,6 +170,17 @@ function interpret_record(
         return
     end
 
+    residue_name = strip(residue_name)
+
+    # right now, we only read the first alternate location indicator
+    if (strip(alternate_location_identifier) != ""
+        &&
+        (alternate_location_identifier != pdb_info.alternate_location_identifier))
+        @debug "load_pdb: ignoring ATOM $residue_name:$(strip(atom_name)) at alternate location $alternate_location_identifier"
+        pdb_info.alternate_location_warning = true
+        return
+    end
+
     # is this a new chain?
     if (isnothing(pdb_info.current_chain)
         ||
@@ -178,15 +189,7 @@ function interpret_record(
         pdb_info.current_residue = nothing
     end
 
-    # right now, we only read the first alternate location indicator
-    if (strip(alternate_location_identifier) != ""
-        &&
-        (alternate_location_identifier != pdb_info.alternate_location_identifier))
-        return
-    end
-
     # is this a new residue?
-    residue_name = strip(residue_name)
     if (isnothing(pdb_info.current_residue)
         || residue_sequence_number != pdb_info.current_residue.number
         || residue_name != pdb_info.current_residue.name
@@ -254,6 +257,15 @@ function interpret_record(
 
     # should we skip this model?
     if ((pdb_info.selected_model != -1) && (pdb_info.selected_model != pdb_info.current_model))
+        return
+    end
+
+    # right now, we only read the first alternate location indicator
+    if (strip(alternate_location_identifier) != ""
+        &&
+        (alternate_location_identifier != pdb_info.alternate_location_identifier))
+        @debug "load_pdb: ignoring HETATM $residue_name:$(strip(atom_name)) at alternate location $alternate_location_identifier"
+        pdb_info.alternate_location_warning = true
         return
     end
 
@@ -487,6 +499,10 @@ function interpret_record(
 
 
     a = _atom_by_number(sys, serial_number)
+    if isnothing(a)
+        return
+    end
+
     bond_atoms = [bond_atom1, bond_atom2, bond_atom3]
     hbond_atoms = [hbond_atom1, hbond_atom2, hbond_atom3, hbond_atom4]
     salt_bridge_atoms = [salt_bridge_atom1, salt_bridge_atom2]
@@ -657,4 +673,3 @@ function postprocess_secondary_structures_!(sys, pdb_info, fragment_cache, creat
         end
     end
 end
-


### PR DESCRIPTION
Alternate location IDs other than A are currently not supported and previously lead to errors. This patch hotfixes these errors and issues a warning when such alternate location IDs are encountered.

Issue: #265
Fixes: #266
Fixes: #267