### PR TITLE
FileFormats: allow `IO` as file args (`load_xxx`/`write_xxx`)

### DIFF
--- a/src/fileformats/hinfile.jl
+++ b/src/fileformats/hinfile.jl
@@ -327,14 +327,12 @@ function _handle_hin_line!(parser_state::HINParserState)
 end
 
 """
-    load_hinfile(
-        fname::AbstractString,
-        ::Type{T} = Float32
-    ) -> System{T}
+    load_hinfile(io::IO, ::Type{T} = Float32) -> System{T}
+    load_hinfile(filename::AbstractString, ::Type{T} = Float32) -> System{T}
 
 Read a HyperChem HIN file.
 """
-function load_hinfile(fname::AbstractString, ::Type{T} = Float32) where {T <: Real}
+function load_hinfile(fname_io::Union{AbstractString, IO}, ::Type{T} = Float32) where {T <: Real}
     # we use a very simple state machine for parsing HIN files; legal states are
     #   - :START
     #   - :IN_MOLECULE
@@ -353,7 +351,7 @@ function load_hinfile(fname::AbstractString, ::Type{T} = Float32) where {T <: Re
     parser_state.current_molecule = nothing
     parser_state.current_fragment = nothing
 
-    for (i, line) in enumerate(readlines(fname))
+    for (i, line) in enumerate(readlines(fname_io))
         # ignore comment lines
         if line == "" || first(line) == ';'
             continue
@@ -369,10 +367,8 @@ function load_hinfile(fname::AbstractString, ::Type{T} = Float32) where {T <: Re
 end
 
 """
-    write_hinfile(
-        fname::AbstractString,
-        ac::AtomContainer
-    )
+    write_hinfile(io::IO, ac::AtomContainer)
+    write_hinfile(filename::AbstractString, ac::AtomContainer)
 
 Save an atom container as HyperChem HIN file.
 
@@ -381,105 +377,107 @@ Save an atom container as HyperChem HIN file.
     missing bonds, e.g., after reading a PDB file and not postprocessing it correctly, the HIN file may
     contain a surprisingly large number of molecules.
 """
-function write_hinfile(fname::AbstractString, ac::AbstractAtomContainer)
+function write_hinfile(io::IO, ac::AbstractAtomContainer)
     mg = convert(MolecularGraph.SDFMolGraph, ac)
     hin_molecules = connected_components(mg)
     mgatom2idx = _molgraph_atom_to_idx(mg)
 
-    open(fname, "w") do io
-        write(io, "; HyperChem file created by BiochemicalAlgorithms\n")
-        write(io, ";\n")
-        write(io, "forcefield AMBER\n")
+    write(io, "; HyperChem file created by BiochemicalAlgorithms\n")
+    write(io, ";\n")
+    write(io, "forcefield AMBER\n")
 
-        write(io, "sys $(get_property(ac, :temperature, 0.0))\n")
+    write(io, "sys $(get_property(ac, :temperature, 0.0))\n")
 
-        if has_property(ac, :periodic_box_width) && has_property(ac, :periodic_box_height) && has_property(ac, :periodic_box_depth)
-            write(io, "box $(get_property(ac, :periodic_box_width)) $(get_property(ac, :periodic_box_height)) $(get_property(ac, :periodic_box_depth))\n")
-        end
+    if has_property(ac, :periodic_box_width) && has_property(ac, :periodic_box_height) && has_property(ac, :periodic_box_depth)
+        write(io, "box $(get_property(ac, :periodic_box_width)) $(get_property(ac, :periodic_box_height)) $(get_property(ac, :periodic_box_depth))\n")
+    end
 
-        # now, for each connected component, create a molecule
-        for (mi, m) in enumerate(hin_molecules)
-            # getting the name of the molecule is not entirely simple...
-            # we use the first atom of the connected component to map back to the parent molecule, as many components can arise from the same parent molecule
-            mol_name = parent_molecule(atom_by_idx(ac, mgatom2idx[first(m)])).name
+    # now, for each connected component, create a molecule
+    for (mi, m) in enumerate(hin_molecules)
+        # getting the name of the molecule is not entirely simple...
+        # we use the first atom of the connected component to map back to the parent molecule, as many components can arise from the same parent molecule
+        mol_name = parent_molecule(atom_by_idx(ac, mgatom2idx[first(m)])).name
 
-            # names cannot contain double quotes
-            mol_name = replace(strip(mol_name), "\"" => "")
+        # names cannot contain double quotes
+        mol_name = replace(strip(mol_name), "\"" => "")
 
-            # newer HyperChem releases require molecule names to be enclosed in double quotes
-            write(io, mol_name != "" ? "mol $(mi) \"$(mol_name)\"\n" : "mol $(mi)\n")
+        # newer HyperChem releases require molecule names to be enclosed in double quotes
+        write(io, mol_name != "" ? "mol $(mi) \"$(mol_name)\"\n" : "mol $(mi)\n")
 
-            # we need to re-number the atoms; the input are global numbers, unique over all molecules, while HIN wants atom numbers to be relative to the
-            # current molecule
-            index_map = Dict(a => ai for (ai, a) in enumerate(m))
+        # we need to re-number the atoms; the input are global numbers, unique over all molecules, while HIN wants atom numbers to be relative to the
+        # current molecule
+        index_map = Dict(a => ai for (ai, a) in enumerate(m))
 
-            # now, handle each atom
-            last_fragment = nothing
-            num_fragments = 1
-            for a in m
-                orig_atom = atom_by_idx(ac, mgatom2idx[a])
+        # now, handle each atom
+        last_fragment = nothing
+        num_fragments = 1
+        for a in m
+            orig_atom = atom_by_idx(ac, mgatom2idx[a])
 
-                current_fragment = parent_fragment(orig_atom)
+            current_fragment = parent_fragment(orig_atom)
 
-                if current_fragment != last_fragment
-                    # do we need to close a fragment?
-                    if !isnothing(last_fragment)
-                        write(io, "endres $(num_fragments)\n")
-                        num_fragments += 1
-                    end
-
-                    # do we need to open a new fragment?
-                    if !isnothing(current_fragment)
-                        frag_name = strip(current_fragment.name) != "" ? strip(current_fragment.name) : "-"
-                        chain_name = strip(parent_chain(current_fragment).name) != "" ? strip(parent_chain(current_fragment).name) : "-"
-
-                        het_id = (is_amino_acid(current_fragment) || current_fragment.variant == FragmentVariant.Residue) ? "-" : "h"
-                        write(io, "res $(num_fragments) $(frag_name) $(current_fragment.number) $(het_id) $(chain_name)\n")
-                    end
-
-                    last_fragment = current_fragment
+            if current_fragment != last_fragment
+                # do we need to close a fragment?
+                if !isnothing(last_fragment)
+                    write(io, "endres $(num_fragments)\n")
+                    num_fragments += 1
                 end
 
-                # now, write the atom itself
-                atom_name = strip(orig_atom.name) == "" ? "-" : strip(orig_atom.name)
-                if occursin(" ", atom_name)
-                    @warn "Atom names in HIN files cannot contain spaces!"
+                # do we need to open a new fragment?
+                if !isnothing(current_fragment)
+                    frag_name = strip(current_fragment.name) != "" ? strip(current_fragment.name) : "-"
+                    chain_name = strip(parent_chain(current_fragment).name) != "" ? strip(parent_chain(current_fragment).name) : "-"
 
-                    atom_name = first(split(atom_name))
+                    het_id = (is_amino_acid(current_fragment) || current_fragment.variant == FragmentVariant.Residue) ? "-" : "h"
+                    write(io, "res $(num_fragments) $(frag_name) $(current_fragment.number) $(het_id) $(chain_name)\n")
                 end
 
-                atom_type = strip(orig_atom.atom_type) == "" ? "-" : strip(orig_atom.atom_type)
-
-                atom_string  = "atom $(index_map[a]) $(atom_name) $(orig_atom.element) $(atom_type) - $(orig_atom.charge) $(orig_atom.r[1]) $(orig_atom.r[2]) $(orig_atom.r[3])"
-                atom_string *= " $(nbonds(orig_atom))"
-
-                for b in neighbors(mg, a)
-                    # find the corresponding edge
-                    e = mg.eprops[MolecularGraph.u_edge(mg, a, b)]
-
-                    order =
-                        if e.order == 1
-                            's'
-                        elseif e.order == 2
-                            'd'
-                        elseif e.order == 3
-                            't'
-                        else
-                            '-'
-                        end
-
-                    atom_string *= " $(index_map[b]) $(order)"
-                end
-
-                atom_string *= "\n"
-
-                write(io, atom_string)
-
-                # write the velocities
-                write(io, "vel $(index_map[a]) $(orig_atom.v[1]) $(orig_atom.v[2]) $(orig_atom.v[3])\n")
+                last_fragment = current_fragment
             end
 
-            write(io, "endmol $(mi)\n")
+            # now, write the atom itself
+            atom_name = strip(orig_atom.name) == "" ? "-" : strip(orig_atom.name)
+            if occursin(" ", atom_name)
+                @warn "Atom names in HIN files cannot contain spaces!"
+
+                atom_name = first(split(atom_name))
+            end
+
+            atom_type = strip(orig_atom.atom_type) == "" ? "-" : strip(orig_atom.atom_type)
+
+            atom_string  = "atom $(index_map[a]) $(atom_name) $(orig_atom.element) $(atom_type) - $(orig_atom.charge) $(orig_atom.r[1]) $(orig_atom.r[2]) $(orig_atom.r[3])"
+            atom_string *= " $(nbonds(orig_atom))"
+
+            for b in neighbors(mg, a)
+                # find the corresponding edge
+                e = mg.eprops[MolecularGraph.u_edge(mg, a, b)]
+
+                order =
+                    if e.order == 1
+                        's'
+                    elseif e.order == 2
+                        'd'
+                    elseif e.order == 3
+                        't'
+                    else
+                        '-'
+                    end
+
+                atom_string *= " $(index_map[b]) $(order)"
+            end
+
+            atom_string *= "\n"
+
+            write(io, atom_string)
+
+            # write the velocities
+            write(io, "vel $(index_map[a]) $(orig_atom.v[1]) $(orig_atom.v[2]) $(orig_atom.v[3])\n")
         end
+
+        write(io, "endmol $(mi)\n")
     end
+end
+
+function write_hinfile(fname::AbstractString, ac::AbstractAtomContainer)
+    open(io -> write_hinfile(io, ac), fname, "w")
 end

--- a/src/fileformats/pdb.jl
+++ b/src/fileformats/pdb.jl
@@ -189,7 +189,8 @@ end
 
 
 """
-    load_pdb(fname::AbstractString, ::Type{T} = Float32) -> System{T}
+    load_pdb(io::IO, ::Type{T} = Float32) -> System{T}
+    load_pdb(filename::AbstractString, ::Type{T} = Float32) -> System{T}
 
 Read a PDB file.
 
@@ -197,7 +198,7 @@ Read a PDB file.
     Models are stored as frames, using the model number as `frame_id`.
 """
 function load_pdb(
-        filename::AbstractString,
+        fname_io::Union{AbstractString, IO},
         ::Type{T} = Float32;
         keep_metadata::Bool=true,
         strict_line_checking::Bool=false,
@@ -205,7 +206,7 @@ function load_pdb(
         ignore_xplor_pseudo_atoms::Bool=true,
         create_coils::Bool=true) where {T <: Real}
 
-    pdblines = readlines(filename)
+    pdblines = readlines(fname_io)
 
     sys = System{T}()
     mol = Molecule(sys)
@@ -246,18 +247,19 @@ function load_pdb(
 end
 
 """
-    load_mmcif(fname::AbstractString, ::Type{T} = Float32) -> System{T}
+    load_mmcif(io::IO, ::Type{T} = Float32) -> System{T}
+    load_mmcif(filename::AbstractString, ::Type{T} = Float32) -> System{T}
 
 Read a PDBx/mmCIF file.
 
 !!! note
     Models are stored as frames, using the model number as `frame_id`.
 """
-function load_mmcif(fname::AbstractString, ::Type{T} = Float32) where {T <: Real}
+function load_mmcif(fname_io::Union{AbstractString, IO}, ::Type{T} = Float32) where {T <: Real}
     # TODO: how to handle disordered atoms properly?
 
     # first, read the structure using BioStructures.jl
-    orig_mmcif = read(fname, MMCIFFormat)
+    orig_mmcif = read(fname_io, MMCIFFormat)
     convert(System{T}, orig_mmcif)
 end
 
@@ -342,7 +344,8 @@ function write_pdb(io::IO, ac::AbstractAtomContainer{T}) where T
 end
 
 """
-    write_pdb(fname::AbstractString, ac::AbstractAtomContainer)
+    write_pdb(io::IO, ac::AbstractAtomContainer)
+    write_pdb(filename::AbstractString, ac::AbstractAtomContainer)
 
 Save an atom container as PDB file.
 """
@@ -351,11 +354,12 @@ function write_pdb(fname::AbstractString, ac::AbstractAtomContainer)
 end
 
 """
-    write_mmcif(fname::AbstractString, ac::AbstractAtomContainer)
+    write_mmcif(io::IO, ac::AbstractAtomContainer)
+    write_mmcif(filename::AbstractString, ac::AbstractAtomContainer)
 
 Save an atom container as PDBx/mmCIF file.
 """
-function write_mmcif(fname::AbstractString, ac::AbstractAtomContainer)
+function write_mmcif(fname_io::Union{AbstractString, IO}, ac::AbstractAtomContainer)
     ps = convert(MolecularStructure, ac)
-    writemmcif(fname, ps)
+    writemmcif(fname_io, ps)
 end

--- a/src/fileformats/pubchem_json.jl
+++ b/src/fileformats/pubchem_json.jl
@@ -123,17 +123,18 @@ function _parse_props!(mol::Molecule, compound::JSON.Object)
 end
 
 """
-    load_pubchem_json(fname::AbstractString, ::Type{T} = Float32) -> System{T}
+    load_pubchem_json(io::IO, ::Type{T} = Float32) -> System{T}
+    load_pubchem_json(filename::AbstractString, ::Type{T} = Float32) -> System{T}
 
 Read a PubChem JSON file.
 
 !!! note
     Conformers are stored as frames.
 """
-function load_pubchem_json(fname::AbstractString, ::Type{T} = Float32) where {T <: Real}
+function load_pubchem_json(fname_io::Union{AbstractString, IO}, ::Type{T} = Float32) where {T <: Real}
     # TODO: full conversion, adding all properties
 
-    pb = JSON.parse(read(fname, String))
+    pb = JSON.parse(read(fname_io, String))
     sys = System{T}()
     for compound in pb.PC_Compounds
         # for now, use the file name as the name for the molecule

--- a/src/fileformats/sdfile.jl
+++ b/src/fileformats/sdfile.jl
@@ -3,27 +3,29 @@ export
     write_sdfile
 
 """
-    load_sdfile(fname::AbstractString, ::Type{T} = Float32) -> System{T}
+    load_sdfile(io::IO, ::Type{T} = Float32) -> System{T}
+    load_sdfile(filename::AbstractString, ::Type{T} = Float32) -> System{T}
 
 Read an SDFile.
 """
-function load_sdfile(fname::AbstractString, ::Type{T} = Float32) where {T <: Real}
+function load_sdfile(fname_io::Union{AbstractString, IO}, ::Type{T} = Float32) where {T <: Real}
     sys = System{T}()
-    for mg_mol in MolecularGraph.sdfilereader(fname)
+    for mg_mol in MolecularGraph.sdfilereader(fname_io)
         convert(Molecule{T}, mg_mol; system=sys)
     end
     sys
 end
 
 """
-    write_sdfile(fname::AbstractString, ac::AbstractAtomContainer)
+    write_sdfile(io::IO, ac::AbstractAtomContainer)
+    write_sdfile(filename::AbstractString, ac::AbstractAtomContainer)
 
 Save a 2D projection of an atom container as SDFile.
 """
-@inline function write_sdfile(fname::AbstractString, mol::AbstractAtomContainer)
-    MolecularGraph.sdfilewriter(fname, [convert(MolecularGraph.SDFMolGraph, mol)])
+@inline function write_sdfile(fname_io::Union{AbstractString, IO}, mol::AbstractAtomContainer)
+    MolecularGraph.sdfilewriter(fname_io, [convert(MolecularGraph.SDFMolGraph, mol)])
 end
 
-@inline function write_sdfile(fname::AbstractString, sys::System)
-    MolecularGraph.sdfilewriter(fname, convert.(MolecularGraph.SDFMolGraph, molecules(sys)))
+@inline function write_sdfile(fname_io::Union{AbstractString, IO}, sys::System)
+    MolecularGraph.sdfilewriter(fname_io, convert.(MolecularGraph.SDFMolGraph, molecules(sys)))
 end

--- a/test/fileformats/test_hinfile.jl
+++ b/test/fileformats/test_hinfile.jl
@@ -19,6 +19,9 @@
         @test get_property(sys, :periodic_box_height) ≈ 18.70136
         @test get_property(sys, :periodic_box_depth)  ≈ 18.70136
 
+        sys2 = open(io -> load_hinfile(io, T), ball_data_path("../test/data/hinfile_test.hin"))
+        @test sys == sys2
+
         sys = load_hinfile(ball_data_path("../test/data/AlaGlySer.hin"), T)
 
         @test natoms(sys) == 31
@@ -52,9 +55,11 @@ end
         first(atoms(sys)).name = "TEST NAME"
 
         write_hinfile(outfname, sys)
-
         sys2 = load_hinfile(outfname, T)
+        @test first(atoms(sys2)).name == "TEST"
 
+        open(io -> write_hinfile(io, sys), outfname, "w")
+        sys2 = load_hinfile(outfname, T)
         @test first(atoms(sys2)).name == "TEST"
     end
 end

--- a/test/fileformats/test_pdb.jl
+++ b/test/fileformats/test_pdb.jl
@@ -18,6 +18,9 @@
         @test nnucleotides(sys) == 0
         @test nresidues(sys) == 58
 
+        sys2 = open(io -> load_pdb(io, T), ball_data_path("../test/data/bpti.pdb"))
+        @test sys == sys2
+
         sys = load_pdb(ball_data_path("../test/data/5PTI.pdb"), T)
         @test sys isa System{T}
         @test sys.name == "HYDROLASE INHIBITOR"
@@ -55,6 +58,16 @@ end
         (fname, fh) = mktemp(; cleanup = true)
 
         write_pdb(fname, sys)
+        sys2 = load_pdb(fname, T)
+        @test sys2 isa System{T}
+        @test natoms(sys2) == 2
+        @test atoms(sys2).name == ["C", "O"]
+        @test nfragments(sys2) == 1
+        @test nchains(sys2) == 1
+        @test first(chains(sys2)).name == "A"
+        @test nmolecules(sys2) == 1
+
+        open(io -> write_pdb(io, sys), fname, "w")
         sys2 = load_pdb(fname, T)
         @test sys2 isa System{T}
         @test natoms(sys2) == 2
@@ -176,6 +189,17 @@ end
         @test nfragments(sys) == 123
         @test nnucleotides(sys) == 0
         @test nresidues(sys) == 58
+
+        sys = open(io -> load_mmcif(io, T), ball_data_path("../test/data/5pti.cif"))
+        @test sys isa System{T}
+        @test_broken sys.name == "5pti.cif" # BioStructures does not set a name here...
+        @test natoms(sys) == 1087
+        @test nbonds(sys) == 0
+        @test nmolecules(sys) == 1
+        @test nchains(sys) == 1
+        @test nfragments(sys) == 123
+        @test nnucleotides(sys) == 0
+        @test nresidues(sys) == 58
     end
 end
 
@@ -191,6 +215,16 @@ end
         (fname, fh) = mktemp(; cleanup = true)
 
         write_mmcif(fname, sys)
+        sys2 = load_mmcif(fname, T)
+        @test sys2 isa System{T}
+        @test natoms(sys2) == 2
+        @test atoms(sys2).name == ["C", "O"]
+        @test nfragments(sys2) == 1
+        @test nchains(sys2) == 1
+        @test first(chains(sys2)).name == "A"
+        @test nmolecules(sys2) == 1
+
+        open(io -> write_mmcif(io, sys), fname, "w")
         sys2 = load_mmcif(fname, T)
         @test sys2 isa System{T}
         @test natoms(sys2) == 2

--- a/test/fileformats/test_pubchem_json.jl
+++ b/test/fileformats/test_pubchem_json.jl
@@ -13,6 +13,8 @@
         @test natoms(mol) == 21
         @test nbonds(mol) == 21
 
+        sys2 = open(io -> load_pubchem_json(io, T), ball_data_path("../test/data/aspirin_pug.json"))
+        @test sys == sys2
 
         # used for testing bond orders / file manually manipulated
         sys2 = load_pubchem_json(ball_data_path("../test/data/aspirin_pug_bonds.json"), T)

--- a/test/fileformats/test_sdfile.jl
+++ b/test/fileformats/test_sdfile.jl
@@ -23,6 +23,9 @@
         @test met["a_don"] == "3"
         @test met["logP(o/w)"] == "0.40906"
         @test met["SlogP"] == "1.1878"
+
+        sys2 = open(io -> load_sdfile(io, T), ball_data_path("../test/data/sdfile_test_1.sdf"))
+        @test sys == sys2
     end
 end
 
@@ -47,6 +50,11 @@ end
         (set_name, set_file) = mktemp(; cleanup = true)
 
         write_sdfile(set_name, sys)
+        ms_sd = molecules(load_sdfile(set_name, T))
+
+        @test all([_compare_without_system(ms_sd[i], mols[i]) for i in eachindex(ms_sd)])
+
+        open(io -> write_sdfile(io, sys), set_name, "w")
         ms_sd = molecules(load_sdfile(set_name, T))
 
         @test all([_compare_without_system(ms_sd[i], mols[i]) for i in eachindex(ms_sd)])


### PR DESCRIPTION
In most cases this was already supported by the underlying reader/writer infrastructure and an artificial limitation by our function interface. 