### PR TITLE
System: support multiple secondary structures per fragment

### DIFF
--- a/docs/src/public/system.md
+++ b/docs/src/public/system.md
@@ -114,10 +114,8 @@ SecondaryStructureTable
 secondary_structure_by_idx
 secondary_structures
 nsecondary_structures
-parent_secondary_structure
 sort_secondary_structures!
 Base.delete!(::SecondaryStructure)
-Base.push!(::Chain{T}, ::SecondaryStructure{T}) where T
 ```
 
 ## Fragments
@@ -145,7 +143,6 @@ nfragments
 parent_fragment
 sort_fragments!
 Base.delete!(::Fragment)
-Base.push!(::SecondaryStructure{T}, ::Fragment{T}) where T
 Base.push!(::Chain{T}, ::Fragment{T}) where T
 ```
 

--- a/docs/src/tutorials/core_components.md
+++ b/docs/src/tutorials/core_components.md
@@ -532,45 +532,47 @@ Now, that we learned about chains, we can take a look at the secondary structure
 s = System()
 chain = Chain(Molecule(s))
 ss1 = SecondaryStructure(
-    chain,
+    Residue(chain, 1),
+    Residue(chain, 2),
     1,
     SecondaryStructureElement.Helix;
     name="H1"
 )
 
 ss2 = SecondaryStructure(
-    chain,
+    Residue(chain, 3),
+    Residue(chain, 4),
     2,
     SecondaryStructureElement.Coil;
     name="C1"
 )
 
 ss3 = SecondaryStructure(
-    chain,
+    Residue(chain, 5),
+    Residue(chain, 6),
     3,
     SecondaryStructureElement.Strand;
     name="S1"
 )
 ss4 = SecondaryStructure(
-    chain,
+    Residue(chain, 7),
+    Residue(chain, 8),
     4,
     SecondaryStructureElement.Turn;
     name="T1"
 )
 
-ss3.type = SecondaryStructureElement.Helix
 println("Number of secondary structures: ", nsecondary_structures(s))
 
 # get all helices of the chain
-helices = (filter(sst -> sst.type == ss1.type, secondary_structures(chain)))
+filter(sst -> sst.type == SecondaryStructureElement.Helix, secondary_structures(chain))
 ```
 
     Number of secondary structures: 4
 
 | **\#** | **idx** | **number** | **type** | **name** |
 |-------:|:--------|:-----------|:---------|:---------|
-|      1 | 3       | 1          | Helix    | H1       |
-|      2 | 5       | 3          | Helix    | S1       |
+|      1 | 5       | 1          | Helix    | H1       |
 
 In addition, we can compute the secondary structures for an input file:
 

--- a/src/BiochemicalAlgorithms.jl
+++ b/src/BiochemicalAlgorithms.jl
@@ -53,8 +53,8 @@ include("core/system_internals/_atom_table.jl")
 include("core/system_internals/_bond_table.jl")
 include("core/system_internals/_molecule_table.jl")
 include("core/system_internals/_chain_table.jl")
-include("core/system_internals/_secondary_structure_table.jl")
 include("core/system_internals/_fragment_table.jl")
+include("core/system_internals/_secondary_structure_table.jl")
 include("core/system.jl")
 
 # system components
@@ -63,8 +63,8 @@ include("core/atom.jl")
 include("core/bond.jl")
 include("core/molecule.jl")
 include("core/chain.jl")
-include("core/secondary_structure.jl")
 include("core/fragment.jl")
+include("core/secondary_structure.jl")
 
 # molgraph
 include("core/moleculargraph_wrapper.jl")

--- a/src/core/atom.jl
+++ b/src/core/atom.jl
@@ -156,14 +156,6 @@ end
         chain_by_idx(atom._sys, atom.chain_idx)
 end
 
-@inline function parent_secondary_structure(atom::Atom)
-    pf = parent_fragment(atom)
-
-    isnothing(pf) || isnothing(pf.secondary_structure_idx) ?
-        nothing :
-        secondary_structure_by_idx(parent(atom), pf.secondary_structure_idx)
-end
-
 @inline function parent_fragment(atom::Atom)
     isnothing(atom.fragment_idx) ?
         nothing :

--- a/src/core/fragment.jl
+++ b/src/core/fragment.jl
@@ -53,7 +53,6 @@ Mutable representation of an individual fragment in a system.
  - `flags::Flags`
  - `molecule_idx::Int`
  - `chain_idx::Int`
- - `secondary_structure_idx::Int`
 
 # Constructors
 ```julia
@@ -96,14 +95,6 @@ const Fragment{T} = AtomContainer{T, :Fragment}
     fragment_by_idx(sys, idx)
 end
 
-@inline function Fragment(
-    ss::SecondaryStructure{T},
-    number::Int;
-    kwargs...
-) where T
-    Fragment(parent_chain(ss), number; secondary_structure_idx = ss.idx, kwargs...)
-end
-
 """
     FragmentTable{T} <: AbstractSystemComponentTable{T}
 
@@ -140,7 +131,6 @@ end
 
 @inline parent_molecule(frag::Fragment) = molecule_by_idx(parent(frag), frag.molecule_idx)
 @inline parent_chain(frag::Fragment) = chain_by_idx(parent(frag), frag.chain_idx)
-@inline parent_secondary_structure(frag::Fragment) = secondary_structure_by_idx(parent(frag), frag.secondary_structure_idx)
 
 @doc raw"""
     parent_fragment(::Atom)
@@ -178,26 +168,22 @@ Returns a `FragmentTable{T}` containing all fragments of the given atom containe
  - `variant::Union{Nothing, FragmentVariantType} = nothing`
  - `molecule_idx::MaybeInt = nothing`
  - `chain_idx::MaybeInt = nothing`
- - `secondary_structure_idx::MaybeInt = nothing`
 All keyword arguments limit the results to fragments matching the given IDs or variant type.
 Keyword arguments set to `nothing` are ignored.
 """
 function fragments(sys::System{T} = default_system();
     variant::Union{Nothing, FragmentVariantType} = nothing,
     molecule_idx::MaybeInt = nothing,
-    chain_idx::MaybeInt = nothing,
-    secondary_structure_idx::MaybeInt = nothing
+    chain_idx::MaybeInt = nothing
 ) where T
     isnothing(variant) &&
         isnothing(molecule_idx) &&
         isnothing(chain_idx) &&
-        isnothing(secondary_structure_idx) &&
         return FragmentTable{T}(sys, copy(sys._fragments.idx))
     _filter_fragments(frag ->
         (isnothing(variant)                 || frag.variant      == something(variant)) &&
         (isnothing(molecule_idx)            || frag.molecule_idx == something(molecule_idx)) &&
-        (isnothing(chain_idx)               || frag.chain_idx    == something(chain_idx)) &&
-        (isnothing(secondary_structure_idx) || frag.secondary_structure_idx == something(secondary_structure_idx)),
+        (isnothing(chain_idx)               || frag.chain_idx    == something(chain_idx)),
         sys
     )
 end
@@ -283,23 +269,6 @@ end
 
 @inline nfragments(ct::ChainTable; kwargs...) = length(fragments(ct; kwargs...))
 
-#=
-    SecondaryStructure fragments
-=#
-@inline fragments(ss::SecondaryStructure; kwargs...) = fragments(parent(ss); secondary_structure_idx = ss.idx, kwargs...)
-@inline nfragments(ss::SecondaryStructure; kwargs...) = nfragments(parent(ss); secondary_structure_idx = ss.idx, kwargs...)
-
-@inline function fragments(st::SecondaryStructureTable;
-        variant::Union{Nothing, FragmentVariantType} = nothing
-)
-    idx = Set(st.idx)
-    isnothing(variant) ?
-        _filter_fragments(frag -> frag.secondary_structure_idx in idx, st._sys) :
-        _filter_fragments(frag -> frag.secondary_structure_idx in idx && frag.variant == something(variant), st._sys)
-end
-
-@inline nfragments(st::SecondaryStructureTable; kwargs...) = length(fragments(st; kwargs...))
-
 """
     delete!(::Fragment)
     delete!(::FragmentTable)
@@ -346,23 +315,6 @@ new `idx`.
     )
     chain
 end
-
-"""
-    push!(::SecondaryStructure{T}, ::Fragment{T})
-
-Creates a copy of the given fragment in the given SecondaryStructure. The new fragment is automatically assigned a
-new `idx`.
-"""
-@inline function Base.push!(ss::SecondaryStructure{T}, frag::Fragment{T}) where T
-    Fragment(ss, frag.number;
-        name = frag.name,
-        variant = frag.variant,
-        properties = frag.properties,
-        flags = frag.flags
-    )
-    ss
-end
-
 
 #=
     Fragment atoms
@@ -420,19 +372,6 @@ See [`Fragment`](@ref)
     Fragment(chain, number; variant = FragmentVariant.Nucleotide, kwargs...)
 end
 
-
-"""
-    Nucleotide(ss::SecondaryStructure, number::Int)
-
-`Fragment` constructor defaulting to the [`FragmentVariant.Nucleotide`](@ref FragmentVariant) variant.
-
-# Supported keyword arguments
-See [`Fragment`](@ref)
-"""
-@inline function Nucleotide(ss::SecondaryStructure, number::Int; kwargs...)
-    Fragment(ss, number; variant = FragmentVariant.Nucleotide, kwargs...)
-end
-
 """
     $(TYPEDSIGNATURES)
 
@@ -478,7 +417,7 @@ fragments of the given atom container or table.
 See [`fragments`](@ref)
 """
 @inline function nucleotides(
-    ac::Union{Chain, ChainTable, SecondaryStructure, SecondaryStructureTable, Molecule, MoleculeTable, System} = default_system();
+    ac::Union{Chain, ChainTable, Molecule, MoleculeTable, System} = default_system();
     kwargs...
 )
     fragments(ac; variant = FragmentVariant.Nucleotide, kwargs...)
@@ -497,7 +436,7 @@ atom container.
 See [`fragments`](@ref)
 """
 @inline function nnucleotides(
-    ac::Union{Chain, ChainTable, SecondaryStructure, SecondaryStructureTable, Molecule, MoleculeTable, System} = default_system();
+    ac::Union{Chain, ChainTable, Molecule, MoleculeTable, System} = default_system();
     kwargs...
 )
     nfragments(ac; variant = FragmentVariant.Nucleotide, kwargs...)
@@ -516,7 +455,7 @@ table.
     length(filter(isnucleotide, ft))
 end
 
-@inline function nnucleotides(ct::Union{ChainTable, SecondaryStructureTable, MoleculeTable})
+@inline function nnucleotides(ct::Union{ChainTable, MoleculeTable})
     nfragments(ct; variant = FragmentVariant.Nucleotide)
 end
 
@@ -544,18 +483,6 @@ See [`Fragment`](@ref)
 """
 @inline function Residue(chain::Chain, number::Int; kwargs...)
     Fragment(chain, number; variant = FragmentVariant.Residue, kwargs...)
-end
-
-"""
-    Residue(ss::SecondaryStructure, number::Int)
-
-`Fragment` constructor defaulting to the [`FragmentVariant.Residue`](@ref FragmentVariant) variant.
-
-# Supported keyword arguments
-See [`Fragment`](@ref)
-"""
-@inline function Residue(ss::SecondaryStructure, number::Int; kwargs...)
-    Fragment(ss, number; variant = FragmentVariant.Residue, kwargs...)
 end
 
 """
@@ -603,7 +530,7 @@ fragments of the given atom container or table.
 See [`fragments`](@ref)
 """
 @inline function residues(
-    ac::Union{Chain, ChainTable, SecondaryStructure, SecondaryStructureTable, Molecule, MoleculeTable, System} = default_system();
+    ac::Union{Chain, ChainTable, Molecule, MoleculeTable, System} = default_system();
     kwargs...
 )
     fragments(ac; variant = FragmentVariant.Residue, kwargs...)
@@ -622,7 +549,7 @@ atom container.
 See [`fragments`](@ref)
 """
 @inline function nresidues(
-    ac::Union{Chain, ChainTable, SecondaryStructure, SecondaryStructureTable, Molecule, MoleculeTable, System} = default_system();
+    ac::Union{Chain, ChainTable, Molecule, MoleculeTable, System} = default_system();
     kwargs...
 )
     nfragments(ac; variant = FragmentVariant.Residue, kwargs...)
@@ -641,7 +568,7 @@ table.
     length(filter(isresidue, ft))
 end
 
-@inline function nresidues(ct::Union{ChainTable, SecondaryStructureTable, MoleculeTable})
+@inline function nresidues(ct::Union{ChainTable, MoleculeTable})
     nfragments(ct; variant = FragmentVariant.Residue)
 end
 

--- a/src/core/secondary_structure.jl
+++ b/src/core/secondary_structure.jl
@@ -3,8 +3,7 @@ export
     SecondaryStructureTable,
     secondary_structure_by_idx,
     secondary_structures,
-    nsecondary_structures,
-    parent_secondary_structure
+    nsecondary_structures
 
 """
     SecondaryStructure{T} <: AbstractAtomContainer{T}
@@ -22,11 +21,14 @@ Mutable representation of an individual secondary structure element in a Chain.
  - `flags::Flags`
  - `molecule_idx::Int`
  - `chain_idx::Int`
+ - `first_fragment_idx::Int`
+ - `last_fragment_idx::Int`
 
 # Constructors
 ```julia
 SecondaryStructure(
-    chain::Chain{T};
+    first_fragment::Fragment{T},
+    last_fragment::Fragment{T};
     number::Int,
     type::SecondaryStructureType;
     # keyword arguments
@@ -40,15 +42,18 @@ Creates a new `SecondaryStructure{T}` in the given chain.
 const SecondaryStructure{T} = AtomContainer{T, :SecondaryStructure}
 
 @inline function SecondaryStructure(
-    chain::Chain,
+    first_fragment::Fragment{T},
+    last_fragment::Fragment{T},
     number::Int,
     type::SecondaryStructureType;
     name::AbstractString="",
     kwargs...
-)
-    sys = parent(chain)
+) where T
+    @assert first_fragment.chain_idx == last_fragment.chain_idx "Invalid secondary structure: fragments on different chains!"
+    sys = parent(first_fragment)
+    chain = parent_chain(first_fragment)
     idx = _next_idx!(sys)
-    push!(sys._secondary_structures, idx, number, type, chain.molecule_idx, chain.idx; name=name, kwargs...)
+    push!(sys._secondary_structures, idx, number, type, chain.molecule_idx, chain.idx, first_fragment.idx, last_fragment.idx; name=name, kwargs...)
     secondary_structure_by_idx(sys, idx)
 end
 
@@ -69,6 +74,8 @@ generated using [`secondary_structures`](@ref) or filtered from other secondary 
  - `flags::AbstractVector{Flags}`
  - `molecule_idx::AbstractVector{Int}`
  - `chain_idx::AbstractVector{Int}`
+ - `first_fragment_idx::AbstractVector{Int}`
+ - `last_fragment_idx::AbstractVector{Int}`
 """
 const SecondaryStructureTable{T} = SystemComponentTable{T, SecondaryStructure{T}}
 
@@ -89,15 +96,6 @@ end
 @inline parent_molecule(secondary_structure::SecondaryStructure) = molecule_by_idx(parent(secondary_structure), secondary_structure.molecule_idx)
 @inline parent_chain(secondary_structure::SecondaryStructure) = chain_by_idx(parent(secondary_structure), secondary_structure.chain_idx)
 
-@doc raw"""
-    parent_secondary_structure(::Atom)
-    parent_secondary_structure(::Fragment)
-    parent_secondary_structure(::Nucleotide)
-    parent_secondary_structure(::Residue)
-
-Returns the `SecondaryStructure{T}` containing the given object. Returns `nothing` if no such secondary structure exists.
-""" parent_secondary_structure
-
 """
     $(TYPEDSIGNATURES)
 
@@ -115,6 +113,7 @@ end
 
 
 """
+    secondary_structures(::Fragment)
     secondary_structures(::Molecule)
     secondary_structures(::Chain)
     secondary_structures(::System; kwargs...)
@@ -139,6 +138,7 @@ All keyword arguments limit the results to secondary structures matching the giv
 end
 
 """
+    nsecondary_structures(::Fragment)
     nsecondary_structures(::Chain)
     nsecondary_structures(::Molecule)
     nsecondary_structures(::System; kwargs...)
@@ -159,6 +159,7 @@ end
 @inline nsecondary_structures(mol::Molecule; kwargs...) = nsecondary_structures(parent(mol); molecule_idx = mol.idx, kwargs...)
 
 """
+    secondary_structures(::FragmentTable)
     secondary_structures(::ChainTable)
     secondary_structures(::MoleculeTable)
 
@@ -174,6 +175,7 @@ See [`secondary_structures`](@ref secondary_structures)
 end
 
 """
+    nsecondary_structures(::FragmentTable)
     nsecondary_structures(::ChainTable)
     nsecondary_structures(::SecondaryStructureTable)
     nsecondary_structures(::MoleculeTable)
@@ -204,6 +206,22 @@ end
 
 @inline nsecondary_structures(ct::ChainTable; kwargs...) = length(secondary_structures(ct; kwargs...))
 
+#=
+    Fragment secondary structures
+=#
+@inline function secondary_structures(frag::Fragment; kwargs...)
+    filter(ss -> frag.idx in fragments(ss).idx, secondary_structures(parent(frag); kwargs...))
+end
+
+@inline function secondary_structures(ft::FragmentTable; kwargs...)
+    idx = Set(ft.idx)
+    filter(ss -> !isempty(idx ∩ fragments(ss).idx), secondary_structures(ft._sys; kwargs...))
+end
+
+@inline function nsecondary_structures(frag::Union{Fragment, FragmentTable}; kwargs...)
+    length(secondary_structures(frag; kwargs...))
+end
+
 """
     delete!(::SecondaryStructure; keep_fragments::Bool = false)
     delete!(::SecondaryStructureTable; keep_fragments::Bool = false)
@@ -217,9 +235,7 @@ Removes the given secondary_structure(s) from the associated system.
    fragments are deleted as well.
 """
 function Base.delete!(ss::SecondaryStructure; keep_fragments::Bool = false)
-    if keep_fragments
-        fragments(ss).secondary_structure_idx .= Ref(nothing)
-    else
+    if !keep_fragments
         delete!(fragments(ss); keep_atoms = false)
     end
 
@@ -228,9 +244,7 @@ function Base.delete!(ss::SecondaryStructure; keep_fragments::Bool = false)
 end
 
 function Base.delete!(st::SecondaryStructureTable; keep_fragments::Bool = false)
-    if keep_fragments
-        fragments(st).secondary_structure_idx .= Ref(nothing)
-    else
+    if !keep_fragments
         delete!(fragments(st); keep_atoms = false)
     end
 
@@ -244,21 +258,6 @@ function Base.delete!(st::SecondaryStructureTable, idx::Int; kwargs...)
     delete!(secondary_structure_by_idx(st._sys, idx); kwargs...)
     deleteat!(st._idx, findall(i -> i == idx, st._idx))
     st
-end
-
-"""
-    push!(::Chain{T}, ::SecondaryStructure{T})
-
-Creates a copy of the given secondary structure in the given chain. The new secondary structure is automatically assigned a
-new `idx`.
-"""
-@inline function Base.push!(chain::Chain{T}, ss::SecondaryStructure{T}) where T
-    SecondaryStructure(chain, ss.number, ss.type;
-        name = ss.name,
-        properties = ss.properties,
-        flags = ss.flags
-    )
-    chain
 end
 
 #=
@@ -278,3 +277,44 @@ end
 
 @inline bonds(st::SecondaryStructureTable; kwargs...) = bonds(fragments(st); kwargs...)
 @inline nbonds(st::SecondaryStructureTable; kwargs...) = nbonds(fragments(st); kwargs...)
+
+#=
+    SecondaryStructure fragments
+=#
+
+@inline function fragments(ss::SecondaryStructure; kwargs...)
+    sys = parent(ss)
+    first_frag = fragment_by_idx(sys, ss.first_fragment_idx)
+    last_frag = fragment_by_idx(sys, ss.last_fragment_idx)
+    number_range = first_frag.number:last_frag.number
+    filter(frag -> frag.number in number_range, fragments(parent_chain(ss); kwargs...))
+end
+
+@inline function nfragments(ss::SecondaryStructure; kwargs...)
+    length(fragments(ss; kwargs...))
+end
+
+@inline function fragments(st::SecondaryStructureTable; kwargs...)
+    idx = Set(Iterators.flatten(getproperty.(fragments.(secondary_structures(st._sys); kwargs...), :idx)))
+    _filter_fragments(frag -> frag.idx in idx, st._sys)
+end
+
+@inline function nfragments(st::SecondaryStructureTable; kwargs...)
+    length(fragments(st; kwargs...))
+end
+
+@inline function nucleotides(ac::Union{SecondaryStructure, SecondaryStructureTable}; kwargs...)
+    fragments(ac; variant = FragmentVariant.Nucleotide, kwargs...)
+end
+
+@inline function nnucleotides(ac::Union{SecondaryStructure, SecondaryStructureTable}; kwargs...)
+    nfragments(ac; variant = FragmentVariant.Nucleotide, kwargs...)
+end
+
+@inline function residues(ac::Union{SecondaryStructure, SecondaryStructureTable}; kwargs...)
+    fragments(ac; variant = FragmentVariant.Residue, kwargs...)
+end
+
+@inline function nresidues(ac::Union{SecondaryStructure, SecondaryStructureTable}; kwargs...)
+    nfragments(ac; variant = FragmentVariant.Residue, kwargs...)
+end

--- a/src/core/system.jl
+++ b/src/core/system.jl
@@ -201,13 +201,14 @@ end
 
 @inline function _offset_secondary_structure_indices!(sys::System, by::Int)
     _offset_indices!(sys._secondary_structures, by)
-    _offset_indices!(sys._fragments, :secondary_structure_idx, by)
     sys
 end
 
 @inline function _offset_fragment_indices!(sys::System, by::Int)
     _offset_indices!(sys._fragments, by)
     _offset_indices!(sys._atoms, :fragment_idx, by)
+    _offset_indices!(sys._secondary_structures, :first_fragment_idx, by)
+    _offset_indices!(sys._secondary_structures, :last_fragment_idx, by)
     sys
 end
 

--- a/src/core/system_internals/_fragment_table.jl
+++ b/src/core/system_internals/_fragment_table.jl
@@ -1,5 +1,5 @@
 const _fragment_table_cols_main = (:idx, :number, :name)
-const _fragment_table_cols_extra = (:variant, :properties, :flags, :molecule_idx, :chain_idx, :secondary_structure_idx)
+const _fragment_table_cols_extra = (:variant, :properties, :flags, :molecule_idx, :chain_idx)
 const _fragment_table_cols = (_fragment_table_cols_main..., _fragment_table_cols_extra...)
 const _fragment_table_cols_set = Set(_fragment_table_cols)
 const _fragment_table_schema = Tables.Schema(
@@ -19,7 +19,6 @@ const _fragment_table_schema = Tables.Schema(
     flags::Vector{Flags}
     molecule_idx::Vector{Int}
     chain_idx::Vector{Int}
-    secondary_structure_idx::Vector{MaybeInt}
 
     # internals
     _idx_map::_IdxMap
@@ -34,7 +33,6 @@ const _fragment_table_schema = Tables.Schema(
             Flags[],
             Int[],
             Int[],
-            MaybeInt[],
             _IdxMap()
         )
     end
@@ -62,7 +60,6 @@ function Base.push!(
     number::Int,
     molecule_idx::Int,
     chain_idx::Int;
-    secondary_structure_idx::MaybeInt = nothing,
     name::AbstractString = "",
     variant::FragmentVariantType = FragmentVariant.None,
     properties::Properties = Properties(),
@@ -77,7 +74,6 @@ function Base.push!(
     push!(ft.flags, flags)
     push!(ft.molecule_idx, molecule_idx)
     push!(ft.chain_idx, chain_idx)
-    push!(ft.secondary_structure_idx, secondary_structure_idx)
     ft
 end
 
@@ -85,7 +81,6 @@ function _fragment_table(itr)
     ft = _FragmentTable()
     for f in itr
         push!(ft, f.idx, f.number, f.molecule_idx, f.chain_idx;
-            secondary_structure_idx = f.secondary_structure_idx,
             name = f.name,
             variant = f.variant,
             properties = f.properties,

--- a/src/core/system_internals/_secondary_structure_table.jl
+++ b/src/core/system_internals/_secondary_structure_table.jl
@@ -1,5 +1,5 @@
 const _secondary_structure_table_cols_main = (:idx, :number, :type, :name)
-const _secondary_structure_table_cols_extra = (:properties, :flags, :molecule_idx, :chain_idx)
+const _secondary_structure_table_cols_extra = (:properties, :flags, :molecule_idx, :chain_idx, :first_fragment_idx, :last_fragment_idx)
 const _secondary_structure_table_cols = (_secondary_structure_table_cols_main..., _secondary_structure_table_cols_extra...)
 const _secondary_structure_table_cols_set = Set(_secondary_structure_table_cols)
 const _secondary_structure_table_schema = Tables.Schema(
@@ -19,6 +19,8 @@ const _secondary_structure_table_schema = Tables.Schema(
     flags::Vector{Flags}
     molecule_idx::Vector{Int}
     chain_idx::Vector{Int}
+    first_fragment_idx::Vector{Int}
+    last_fragment_idx::Vector{Int}
 
     # internals
     _idx_map::_IdxMap
@@ -31,6 +33,8 @@ const _secondary_structure_table_schema = Tables.Schema(
             String[],
             Properties[],
             Flags[],
+            Int[],
+            Int[],
             Int[],
             Int[],
             _IdxMap()
@@ -60,7 +64,9 @@ function Base.push!(
     number::Int,
     type::SecondaryStructureType,
     molecule_idx::Int,
-    chain_idx::Int;
+    chain_idx::Int,
+    first_fragment_idx::Int,
+    last_fragment_idx::Int;
     name::AbstractString = "",
     properties::Properties = Properties(),
     flags::Flags = Flags()
@@ -74,16 +80,18 @@ function Base.push!(
     push!(st.flags, flags)
     push!(st.molecule_idx, molecule_idx)
     push!(st.chain_idx, chain_idx)
+    push!(st.first_fragment_idx, first_fragment_idx)
+    push!(st.last_fragment_idx, last_fragment_idx)
     st
 end
 
 function _secondary_structure_table(itr)
     st = _SecondaryStructureTable()
-    for c in itr
-        push!(st, c.idx, c.number, c.type, c.molecule_idx, c.chain_idx;
-            name = c.name,
-            properties = c.properties,
-            flags = c.flags
+    for s in itr
+        push!(st, s.idx, s.number, s.type, s.molecule_idx, s.chain_idx, s.first_fragment_idx, s.last_fragment_idx;
+            name = s.name,
+            properties = s.properties,
+            flags = s.flags
        )
     end
     st

--- a/src/fileformats/pdb/pdb_general.jl
+++ b/src/fileformats/pdb/pdb_general.jl
@@ -595,7 +595,8 @@ function postprocess_secondary_structures_!(sys, pdb_info, fragment_cache, creat
 
         new_ss = if typeof(ss) == HelixRecord
             new_ss = SecondaryStructure(
-                parent_chain(initial_res),
+                initial_res,
+                terminal_res,
                 ss.number,
                 SecondaryStructureElement.Helix;
                 name=strip(ss.name))
@@ -605,7 +606,8 @@ function postprocess_secondary_structures_!(sys, pdb_info, fragment_cache, creat
             new_ss
         elseif typeof(ss) == SheetRecord
             new_ss = SecondaryStructure(
-                parent_chain(initial_res),
+                initial_res,
+                terminal_res,
                 ss.number,
                 SecondaryStructureElement.Strand;
                 name=strip("$(ss.name):$(ss.number)"))
@@ -614,7 +616,8 @@ function postprocess_secondary_structures_!(sys, pdb_info, fragment_cache, creat
             new_ss
         else
             new_ss = SecondaryStructure(
-                parent_chain(initial_res),
+                initial_res,
+                terminal_res,
                 ss.number,
                 SecondaryStructureElement.Turn;
                 name=strip(ss.name))
@@ -622,39 +625,44 @@ function postprocess_secondary_structures_!(sys, pdb_info, fragment_cache, creat
 
             new_ss
         end
-
-        for f in fragments(parent_chain(initial_res))
-            if f.number >= initial_res.number && f.number <= terminal_res.number
-                if !isnothing(f.secondary_structure_idx)
-                    @warn "load_pdb: reassigning secondary structure of fragment $(f.idx): $(new_ss.idx) (was: $(f.secondary_structure_idx))"
-                end
-                f.secondary_structure_idx = new_ss.idx
-            end
-        end
     end
 
     # do we need to put every amino acid residue into a secondary structure?
     if create_coils
+        fragments_in_ss = Set(fragments(secondary_structures(sys)).idx)
         for c in chains(sys)
-            fs = residues(c, variant=FragmentVariant.Residue)
+            rt = residues(c)
 
-            if isempty(fs[fs.secondary_structure_idx .== nothing])
+            if isempty(setdiff(Set(rt.idx), fragments_in_ss))
                 continue
             end
 
-            last_fragment = nothing
+            first_frag = nothing
+            last_frag = nothing
+            for res in rt
+                if res.idx ∉ fragments_in_ss && isnothing(first_frag)
+                    first_frag = res
 
-            current_ss = nothing
-            for f in fs
-                if isnothing(f.secondary_structure_idx)
-                    if isnothing(last_fragment) || isnothing(current_ss) || parent_secondary_structure(last_fragment).idx != current_ss.idx
-                        current_ss = SecondaryStructure(c,
+                elseif res.idx ∈ fragments_in_ss && !isnothing(first_frag) && !isnothing(last_frag)
+                    SecondaryStructure(
+                        first_frag,
+                        last_frag,
                         maximum(secondary_structures(c).number, init=0) + 1,
-                        SecondaryStructureElement.Coil)
-                    end
-                    f.secondary_structure_idx = current_ss.idx
+                        SecondaryStructureElement.Coil
+                    )
+                    first_frag = nothing
+                    last_frag = nothing
+                    continue
                 end
-                last_fragment = f
+                last_frag = res
+            end
+            if !isnothing(first_frag) && !isnothing(last_frag)
+                SecondaryStructure(
+                    first_frag,
+                    last_frag,
+                    maximum(secondary_structures(c).number, init=0) + 1,
+                    SecondaryStructureElement.Coil
+                )
             end
         end
     end

--- a/src/preprocessing/predict_secondary_structure.jl
+++ b/src/preprocessing/predict_secondary_structure.jl
@@ -752,6 +752,8 @@ function _postprocess_dssp!(ac::AbstractAtomContainer, summary::Vector{Char})
     delete!(secondary_structures(ac); keep_fragments=true)
 
     all_fragments = fragments(ac)
+    first_frag = nothing
+    last_frag = nothing
 
     for i in range(1, length(summary))
         current_type = get_dssp_type_(summary[i])
@@ -759,38 +761,46 @@ function _postprocess_dssp!(ac::AbstractAtomContainer, summary::Vector{Char})
         current_chain = parent_chain(current_frag)
 
         if current_type != last_ss_type || last_chain_idx != current_chain.idx
-            # create a new secondary structure type
-            last_ss_type, last_ss = _create_new_ss(current_chain, ss_number, current_type)
+            if !isnothing(first_frag) && !isnothing(last_frag)
+                _create_new_ss(first_frag, last_frag, ss_number, current_type)
+                ss_number += 1
+            end
 
+            # start new segment
+            first_frag = current_frag
+            last_frag = current_frag
+            last_ss_type = current_type
             last_chain_idx = current_chain.idx
-
-            ss_number += 1
+        else
+            last_frag = current_frag
         end
-
-        current_frag.secondary_structure_idx = last_ss.idx
     end
+    if !isnothing(first_frag) && !isnothing(last_frag)
+        _create_new_ss(first_frag, last_frag, ss_number, get_dssp_type_(last(summary)))
+    end
+    nothing
 end
 
 function get_dssp_type_(type::Char)
     type ∉ ['H', 'G', 'I', 'E'] ? 'L' : type
 end
 
-function _create_new_ss(chain::Chain, number::Int, type::Char)
+function _create_new_ss(first_frag::Fragment, last_frag::Fragment, number::Int, type::Char)
     ss = nothing
 
     if     type == 'H'
-        ss = SecondaryStructure(chain, number, SecondaryStructureElement.Helix)
+        ss = SecondaryStructure(first_frag, last_frag, number, SecondaryStructureElement.Helix)
         set_property!(ss, :HELIX_TYPE, :ALPHA)
     elseif type == 'G'
-        ss = SecondaryStructure(chain, number, SecondaryStructureElement.Helix)
+        ss = SecondaryStructure(first_frag, last_frag, number, SecondaryStructureElement.Helix)
         set_property!(ss, :HELIX_TYPE, :THREE_TEN)
     elseif type == 'I'
-        ss = SecondaryStructure(chain, number, SecondaryStructureElement.Helix)
+        ss = SecondaryStructure(first_frag, last_frag, number, SecondaryStructureElement.Helix)
         set_property!(ss, :HELIX_TYPE, :PI)
     elseif type == 'E'
-        ss = SecondaryStructure(chain, number, SecondaryStructureElement.Strand)
+        ss = SecondaryStructure(first_frag, last_frag, number, SecondaryStructureElement.Strand)
     else
-        ss = SecondaryStructure(chain, number, SecondaryStructureElement.Coil)
+        ss = SecondaryStructure(first_frag, last_frag, number, SecondaryStructureElement.Coil)
     end
 
     type, ss

--- a/src/substructures/substructure.jl
+++ b/src/substructures/substructure.jl
@@ -71,13 +71,11 @@ private atom fields.
     frame_id::MaybeInt = 1,
     molecule_idx::Union{MaybeInt, Some{Nothing}} = nothing,
     chain_idx::Union{MaybeInt, Some{Nothing}} = nothing,
-    secondary_structure_idx::Union{MaybeInt, Some{Nothing}} = nothing,
     fragment_idx::Union{MaybeInt, Some{Nothing}} = nothing
 ) where T
     filter(row ->
         (isnothing(frame_id)                || row.frame_id == frame_id) &&
         (isnothing(molecule_idx)            || row.molecule_idx == something(molecule_idx)) &&
-        (isnothing(secondary_structure_idx) || row.secondary_structure_idx == something(secondary_structure_idx)) &&
         (isnothing(chain_idx)               || row.chain_idx == something(chain_idx)) &&
         (isnothing(fragment_idx)            || row.fragment_idx == something(fragment_idx)),
         substruct._atoms

--- a/test/core/test_fragment.jl
+++ b/test/core/test_fragment.jl
@@ -5,7 +5,6 @@
         sys = System{T}()
         mol = Molecule(sys)
         chain = Chain(mol)
-        ss = SecondaryStructure(chain, 1, SecondaryStructureElement.Helix; name="H1")
 
         f1 = Fragment(chain, 1;
             name = "my fragment",
@@ -19,18 +18,7 @@
             name = "my residue"
         )
 
-        f2 = Fragment(ss, 4;
-        name = "my fragment",
-        properties = Properties(:first => 'a', :second => "b"),
-            flags = Flags([:third])
-        )
-        n2 = Nucleotide(ss, 5;
-            name = "my nucleotide"
-        )
-        r2 = Residue(ss, 6;
-            name = "my residue"
-        )
-
+        ss = SecondaryStructure(f1, r1, 1, SecondaryStructureElement.Helix; name="H1")
         ft = fragments(sys)
 
         # AutoHashEquals, copy, and identity
@@ -80,80 +68,54 @@
         @test !isnothing(Tables.rows(ft))
 
         # AbstractArray interface
-        @test size(ft) == (6, 3)
-        @test length(ft) == 6
+        @test size(ft) == (3, 3)
+        @test length(ft) == 3
         @test eltype(ft) == Fragment{T}
-        @test keys(ft) == [1, 2, 3, 4, 5, 6]
+        @test keys(ft) == [1, 2, 3]
 
         # getproperty
         @test ft._sys === sys
-        @test ft._idx == [f1.idx, n1.idx, r1.idx,
-                          f2.idx, n2.idx, r2.idx]
+        @test ft._idx == [f1.idx, n1.idx, r1.idx]
 
         @test ft.idx isa AbstractVector{Int}
-        @test ft.idx == [f1.idx, n1.idx, r1.idx,
-                         f2.idx, n2.idx, r2.idx]
+        @test ft.idx == [f1.idx, n1.idx, r1.idx]
         @test ft.number isa AbstractVector{Int}
-        @test ft.number == [f1.number, n1.number, r1.number,
-                            f2.number, n2.number, r2.number]
+        @test ft.number == [f1.number, n1.number, r1.number]
         @test ft.name isa AbstractVector{String}
-        @test ft.name == [f1.name, n1.name, r1.name,
-                          f2.name, n2.name, r2.name]
+        @test ft.name == [f1.name, n1.name, r1.name]
 
         @test ft.properties isa AbstractVector{Properties}
-        @test ft.properties == [f1.properties, n1.properties, r1.properties,
-                                f2.properties, n2.properties, r2.properties]
+        @test ft.properties == [f1.properties, n1.properties, r1.properties]
         @test ft.flags isa AbstractVector{Flags}
-        @test ft.flags == [f1.flags, n1.flags, r1.flags,
-                           f2.flags, n2.flags, r2.flags]
+        @test ft.flags == [f1.flags, n1.flags, r1.flags]
         @test ft.variant isa AbstractVector{FragmentVariantType}
-        @test ft.variant == [f1.variant, n1.variant, r1.variant,
-                             f2.variant, n2.variant, r2.variant]
+        @test ft.variant == [f1.variant, n1.variant, r1.variant]
         @test ft.molecule_idx isa AbstractVector{Int}
-        @test ft.molecule_idx == [f1.molecule_idx, n1.molecule_idx, r1.molecule_idx,
-                                  f2.molecule_idx, n2.molecule_idx, r2.molecule_idx]
+        @test ft.molecule_idx == [f1.molecule_idx, n1.molecule_idx, r1.molecule_idx]
         @test ft.chain_idx isa AbstractVector{Int}
-        @test ft.chain_idx == [f1.chain_idx, n1.chain_idx, r1.chain_idx,
-                               f2.chain_idx, n2.chain_idx, r2.chain_idx]
-        @test ft.secondary_structure_idx isa AbstractVector{MaybeInt}
-        @test ft.secondary_structure_idx ==
-            [f1.secondary_structure_idx, n1.secondary_structure_idx, r1.secondary_structure_idx,
-             f2.secondary_structure_idx, n2.secondary_structure_idx, r2.secondary_structure_idx]
-
+        @test ft.chain_idx == [f1.chain_idx, n1.chain_idx, r1.chain_idx]
 
         # Tables.getcolumn
         @test Tables.getcolumn(ft, :idx) isa AbstractVector{Int}
         @test Tables.getcolumn(ft, 1) isa AbstractVector{Int}
-        @test Tables.getcolumn(ft, :idx) == Tables.getcolumn(ft, 1) == [f1.idx, n1.idx, r1.idx,
-                                                                        f2.idx, n2.idx, r2.idx]
+        @test Tables.getcolumn(ft, :idx) == Tables.getcolumn(ft, 1) == [f1.idx, n1.idx, r1.idx]
         @test Tables.getcolumn(ft, :number) isa AbstractVector{Int}
         @test Tables.getcolumn(ft, 2) isa AbstractVector{Int}
-        @test Tables.getcolumn(ft, :number) == Tables.getcolumn(ft, 2) == [f1.number, n1.number, r1.number,
-                                                                           f2.number, n2.number, r2.number]
+        @test Tables.getcolumn(ft, :number) == Tables.getcolumn(ft, 2) == [f1.number, n1.number, r1.number]
         @test Tables.getcolumn(ft, :name) isa AbstractVector{String}
         @test Tables.getcolumn(ft, 3) isa AbstractVector{String}
-        @test Tables.getcolumn(ft, :name) == Tables.getcolumn(ft, 3) == [f1.name, n1.name, r1.name,
-                                                                         f2.name, n2.name, r2.name]
+        @test Tables.getcolumn(ft, :name) == Tables.getcolumn(ft, 3) == [f1.name, n1.name, r1.name]
 
         @test Tables.getcolumn(ft, :properties) isa AbstractVector{Properties}
-        @test Tables.getcolumn(ft, :properties) == [f1.properties, n1.properties, r1.properties,
-                                                    f2.properties, n2.properties, r2.properties]
+        @test Tables.getcolumn(ft, :properties) == [f1.properties, n1.properties, r1.properties]
         @test Tables.getcolumn(ft, :flags) isa AbstractVector{Flags}
-        @test Tables.getcolumn(ft, :flags) == [f1.flags, n1.flags, r1.flags,
-                                               f2.flags, n2.flags, r2.flags]
+        @test Tables.getcolumn(ft, :flags) == [f1.flags, n1.flags, r1.flags]
         @test Tables.getcolumn(ft, :variant) isa AbstractVector{FragmentVariantType}
-        @test Tables.getcolumn(ft, :variant) == [f1.variant, n1.variant, r1.variant,
-                                                 f2.variant, n2.variant, r2.variant]
+        @test Tables.getcolumn(ft, :variant) == [f1.variant, n1.variant, r1.variant]
         @test Tables.getcolumn(ft, :molecule_idx) isa AbstractVector{Int}
-        @test Tables.getcolumn(ft, :molecule_idx) == [f1.molecule_idx, n1.molecule_idx, r1.molecule_idx,
-                                                      f2.molecule_idx, n2.molecule_idx, r2.molecule_idx]
+        @test Tables.getcolumn(ft, :molecule_idx) == [f1.molecule_idx, n1.molecule_idx, r1.molecule_idx]
         @test Tables.getcolumn(ft, :chain_idx) isa AbstractVector{Int}
-        @test Tables.getcolumn(ft, :chain_idx) == [f1.chain_idx, n1.chain_idx, r1.chain_idx,
-                                                   f2.chain_idx, n2.chain_idx, r2.chain_idx]
-        @test Tables.getcolumn(ft, :secondary_structure_idx) isa AbstractVector{MaybeInt}
-        @test Tables.getcolumn(ft, :secondary_structure_idx) ==
-            [f1.secondary_structure_idx, n1.secondary_structure_idx, r1.secondary_structure_idx,
-             f2.secondary_structure_idx, n2.secondary_structure_idx, r2.secondary_structure_idx]
+        @test Tables.getcolumn(ft, :chain_idx) == [f1.chain_idx, n1.chain_idx, r1.chain_idx]
 
         # setproperty!
         @test_throws ErrorException ft.idx = [999, 998, 997]
@@ -165,17 +127,13 @@
         @test_throws ErrorException ft.variant = [FragmentVariant.Residue, FragmentVariant.Residue, FragmentVariant.Residue]
         @test_throws ErrorException ft.molecule_idx = [993, 992, 991]
         @test_throws ErrorException ft.chain_idx = [990, 989, 988]
-        @test_throws ErrorException ft.secondary_structure_idx = [987, 986, 985]
 
         # getindex
         @test ft[1] === f1
         @test ft[2] === n1
         @test ft[3] === r1
-        @test ft[4] === f2
-        @test ft[5] === n2
-        @test ft[6] === r2
         @test_throws BoundsError ft[0]
-        @test_throws BoundsError ft[7]
+        @test_throws BoundsError ft[4]
 
         ft2 = ft[:]
         @test ft2 isa FragmentTable{T}
@@ -188,7 +146,7 @@
 
         ft2 = ft[:, [:idx, :flags]]
         @test ft2 isa FragmentTable{T}
-        @test size(ft2) == (6, 2)
+        @test size(ft2) == (3, 2)
         @test Tables.columnnames(ft2) == [:idx, :flags]
         @test Tables.schema(ft2).names == (:idx, :flags)
         @test Tables.schema(ft2).types == (Vector{Int}, Vector{Flags})
@@ -210,10 +168,10 @@
         @test ft2 isa FragmentTable{T}
         @test length(ft2) == 0
 
-        ft2 = ft[ft.idx .== f2.idx]
+        ft2 = ft[ft.idx .== f1.idx]
         @test ft2 isa FragmentTable{T}
         @test length(ft2) == 1
-        @test only(ft2) === f2
+        @test only(ft2) === f1
 
         # filter
         @test filter(_ -> true, ft) == ft
@@ -222,7 +180,7 @@
         # collect
         fv = collect(ft)
         @test fv isa Vector{Fragment{T}}
-        @test length(fv) == 6
+        @test length(fv) == 3
 
         # atoms
         @test length(atoms(ft)) == 0
@@ -244,10 +202,14 @@
         @test nbonds(ft) == 2
 
         # fragments
-        @test nfragments(ft) == 6
-        @test nfragments(ft; variant = FragmentVariant.None) == 2
-        @test nnucleotides(ft) == 2
-        @test nresidues(ft) == 2
+        @test nfragments(ft) == 3
+        @test nfragments(ft; variant = FragmentVariant.None) == 1
+        @test nnucleotides(ft) == 1
+        @test nresidues(ft) == 1
+
+        # secondary structures
+        @test length(secondary_structures(ft)) == 1
+        @test nsecondary_structures(ft) == 1
     end
 end
 
@@ -690,16 +652,13 @@ end
     for T in [Float32, Float64]
         sys = System{T}()
         chain = Chain(Molecule(sys))
-        ss = SecondaryStructure(chain, 1, SecondaryStructureElement.Helix; name="H1")
 
         # constructors + parent
         frag = Fragment(chain, 1)
         nuc = Nucleotide(chain, 2)
         res = Residue(chain, 3)
 
-        frag2 = Fragment(ss, 4)
-        nuc2 = Nucleotide(ss, 5)
-        res2 = Residue(ss, 6)
+        ss = SecondaryStructure(frag, res, 1, SecondaryStructureElement.Helix; name="H1")
 
         # fragment_by_idx
         @test_throws KeyError fragment_by_idx(sys, -1)
@@ -709,22 +668,16 @@ end
         @test fragment_by_idx(sys, nuc.idx) == nuc
         @test fragment_by_idx(sys, res.idx) isa Fragment{T}
         @test fragment_by_idx(sys, res.idx) == res
-        @test fragment_by_idx(sys, frag2.idx) isa Fragment{T}
-        @test fragment_by_idx(sys, frag2.idx) == frag2
-        @test fragment_by_idx(sys, nuc2.idx) isa Fragment{T}
-        @test fragment_by_idx(sys, nuc2.idx) == nuc2
-        @test fragment_by_idx(sys, res2.idx) isa Fragment{T}
-        @test fragment_by_idx(sys, res2.idx) == res2
 
         # fragments
         ft = fragments(sys)
         @test ft isa FragmentTable{T}
-        @test length(ft) == 6
-        @test length(fragments(sys)) == 6
+        @test length(ft) == 3
+        @test length(fragments(sys)) == 3
 
         # nfragments
         @test nfragments(sys) isa Int
-        @test nfragments(sys) == 6
+        @test nfragments(sys) == 3
 
         # delete!
         Bond(Atom(frag, 1, Elements.H), Atom(frag, 2, Elements.C), BondOrder.Single)
@@ -733,10 +686,10 @@ end
         @test nmolecules(sys) == 1
         @test nchains(sys) == 1
         @test nsecondary_structures(sys) == 1
-        @test nfragments(sys) == 6
-        @test nfragments(sys; variant = FragmentVariant.None) == 2
-        @test nnucleotides(sys) == 2
-        @test nresidues(sys) == 2
+        @test nfragments(sys) == 3
+        @test nfragments(sys; variant = FragmentVariant.None) == 1
+        @test nnucleotides(sys) == 1
+        @test nresidues(sys) == 1
 
         @test delete!(frag; keep_atoms = true) === nothing
         @test natoms(sys) == 2
@@ -744,10 +697,10 @@ end
         @test nmolecules(sys) == 1
         @test nchains(sys) == 1
         @test nsecondary_structures(sys) == 1
-        @test nfragments(sys) == 5
-        @test nfragments(sys; variant = FragmentVariant.None) == 1
-        @test nnucleotides(sys) == 2
-        @test nresidues(sys) == 2
+        @test nfragments(sys) == 2
+        @test nfragments(sys; variant = FragmentVariant.None) == 0
+        @test nnucleotides(sys) == 1
+        @test nresidues(sys) == 1
         @test_throws KeyError frag.idx
         @test all(isnothing, atoms(sys).fragment_idx)
 
@@ -757,10 +710,10 @@ end
         @test nmolecules(sys) == 1
         @test nchains(sys) == 1
         @test nsecondary_structures(sys) == 1
-        @test nfragments(sys) == 5
-        @test nfragments(sys; variant = FragmentVariant.None) == 1
-        @test nnucleotides(sys) == 2
-        @test nresidues(sys) == 2
+        @test nfragments(sys) == 2
+        @test nfragments(sys; variant = FragmentVariant.None) == 0
+        @test nnucleotides(sys) == 1
+        @test nresidues(sys) == 1
 
         @test delete!(nuc; keep_atoms = false) === nothing
         @test natoms(sys) == 3
@@ -768,10 +721,10 @@ end
         @test nmolecules(sys) == 1
         @test nchains(sys) == 1
         @test nsecondary_structures(sys) == 1
-        @test nfragments(sys) == 4
-        @test nfragments(sys; variant = FragmentVariant.None) == 1
-        @test nnucleotides(sys) == 1
-        @test nresidues(sys) == 2
+        @test nfragments(sys) == 1
+        @test nfragments(sys; variant = FragmentVariant.None) == 0
+        @test nnucleotides(sys) == 0
+        @test nresidues(sys) == 1
         @test_throws KeyError nuc.idx
     end
 end

--- a/test/core/test_secondary_structure.jl
+++ b/test/core/test_secondary_structure.jl
@@ -6,16 +6,21 @@
         mol = Molecule(sys)
 
         c = Chain(mol)
+        f1 = Fragment(c, 1)
+        f2 = Fragment(c, 2)
+        f3 = Fragment(c, 3)
+        f4 = Fragment(c, 4)
 
         ss1 = SecondaryStructure(
-            c,
+            f1,
+            f2,
             1,
             SecondaryStructureElement.Helix;
             name = "H1",
             properties = Properties(:first => 'a', :second => "b"),
             flags = Flags([:third])
         )
-        ss2 = SecondaryStructure(c, 2, SecondaryStructureElement.Coil; name="C1")
+        ss2 = SecondaryStructure(f3, f4, 2, SecondaryStructureElement.Coil; name="C1")
 
         st = secondary_structures(sys)
 
@@ -66,6 +71,10 @@
         @test st.molecule_idx == [ss1.molecule_idx, ss2.molecule_idx]
         @test st.chain_idx isa AbstractVector{Int}
         @test st.chain_idx == [ss1.chain_idx, ss2.chain_idx]
+        @test st.first_fragment_idx isa AbstractVector{Int}
+        @test st.first_fragment_idx == [f1.idx, f3.idx]
+        @test st.last_fragment_idx isa AbstractVector{Int}
+        @test st.last_fragment_idx == [f2.idx, f4.idx]
 
         # Tables.getcolumn
         @test Tables.getcolumn(st, :idx) isa AbstractVector{Int}
@@ -89,6 +98,10 @@
         @test Tables.getcolumn(st, :molecule_idx) == [ss1.molecule_idx, ss2.molecule_idx]
         @test Tables.getcolumn(st, :chain_idx) isa AbstractVector{Int}
         @test Tables.getcolumn(st, :chain_idx) == [ss1.chain_idx, ss2.chain_idx]
+        @test Tables.getcolumn(st, :first_fragment_idx) isa AbstractVector{Int}
+        @test Tables.getcolumn(st, :first_fragment_idx) == [f1.idx, f3.idx]
+        @test Tables.getcolumn(st, :last_fragment_idx) isa AbstractVector{Int}
+        @test Tables.getcolumn(st, :last_fragment_idx) == [f2.idx, f4.idx]
 
         # setproperty!
         @test_throws ErrorException st.idx = [999, 998]
@@ -100,6 +113,8 @@
         @test_throws ErrorException st.flags = [Flags(), Flags([:fifth])]
         @test_throws ErrorException st.molecule_idx = [996, 995]
         @test_throws ErrorException st.chain_idx = [996, 995]
+        @test_throws ErrorException st.first_fragment_idx = [996, 995]
+        @test_throws ErrorException st.last_fragment_idx = [996, 995]
 
         # getindex
         @test st[1] === ss1
@@ -158,33 +173,21 @@
         @test nsecondary_structures(st) == 2
 
         # fragments
-        @test length(fragments(st)) == 0
-        @test nfragments(st) == 0
-        @test length(fragments(st; variant = FragmentVariant.None)) == 0
-        @test nfragments(st; variant = FragmentVariant.None) == 0
+        @test length(fragments(st)) == 4
+        @test nfragments(st) == 4
+        @test length(fragments(st; variant = FragmentVariant.None)) == 4
+        @test nfragments(st; variant = FragmentVariant.None) == 4
         @test length(nucleotides(st)) == 0
         @test nnucleotides(st) == 0
         @test length(residues(st)) == 0
         @test nresidues(st) == 0
 
-        Fragment(ss1, 1)
-        Nucleotide(ss1, 1)
-        r = Residue(ss2, 1)
-        @test length(fragments(st)) == 3
-        @test nfragments(st) == 3
-        @test length(fragments(st; variant = FragmentVariant.None)) == 1
-        @test nfragments(st; variant = FragmentVariant.None) == 1
-        @test length(nucleotides(st)) == 1
-        @test nnucleotides(st) == 1
-        @test length(residues(st)) == 1
-        @test nresidues(st) == 1
-
         # atoms
         @test length(atoms(st)) == 0
         @test natoms(st) == 0
 
-        a1 = Atom(r, 1, Elements.H)
-        a2 = Atom(r, 1, Elements.C)
+        a1 = Atom(f1, 1, Elements.H)
+        a2 = Atom(f2, 1, Elements.C)
         @test length(atoms(st)) == 2
         @test natoms(st) == 2
 
@@ -204,10 +207,15 @@ end
         mol = Molecule(sys)
         mol2 = Molecule(sys)
         chain = Chain(mol)
+        frag11 = Fragment(chain, 1)
+        frag12 = Fragment(chain, 2)
         chain2 = Chain(mol2)
+        frag21 = Fragment(chain2, 1)
+        frag22 = Fragment(chain2, 2)
 
         # constructors + parent
-        ss = SecondaryStructure(chain, 1, SecondaryStructureElement.Coil; name="C1")
+        ss = SecondaryStructure(frag11, frag12, 1, SecondaryStructureElement.Coil; name="C1")
+        @test only(secondary_structures(frag11)) === ss
 
         @test ss isa SecondaryStructure{T}
         @test parent(ss) === sys
@@ -218,14 +226,18 @@ end
         if T == Float32
             mol_ds = Molecule()
             chain_ds = Chain(mol_ds)
-            ss_ds = SecondaryStructure(chain_ds, 1, SecondaryStructureElement.Coil; name="C1")
+            frag1_ds = Fragment(chain_ds, 1)
+            frag2_ds = Fragment(chain_ds, 2)
+            frag3_ds = Fragment(chain_ds, 3)
+            frag4_ds = Fragment(chain_ds, 4)
+            ss_ds = SecondaryStructure(frag1_ds, frag2_ds, 1, SecondaryStructureElement.Coil; name="C1")
             parent(ss_ds) === default_system()
             parent_system(ss_ds) === default_system()
 
-            SecondaryStructure(chain_ds, 2, SecondaryStructureElement.Helix; name="H1", properties = Properties(:a => "b"), flags = Flags([:A]))
+            SecondaryStructure(frag3_ds, frag4_ds, 2, SecondaryStructureElement.Helix; name="H1", properties = Properties(:a => "b"), flags = Flags([:A]))
         end
 
-        ss2 = SecondaryStructure(chain2, 1, SecondaryStructureElement.Turn; name="T1", properties = Properties(:a => 1), flags = Flags([:A, :B]))
+        ss2 = SecondaryStructure(frag21, frag22, 1, SecondaryStructureElement.Turn; name="T1", properties = Properties(:a => 1), flags = Flags([:A, :B]))
 
         # getproperty
         @test ss.idx isa Int
@@ -268,7 +280,8 @@ end
         @test length(ss.flags) == 1
         @test :C in ss.flags
 
-        ss3 = SecondaryStructure(Chain(Molecule(System{T}())), 1, SecondaryStructureElement.Unknown; name="U1")
+        c3 = Chain(Molecule(System{T}()))
+        ss3 = SecondaryStructure(Fragment(c3, 1), Fragment(c3, 2), 1, SecondaryStructureElement.Unknown; name="U1")
         ss3.molecule_idx = 999
         @test ss3.molecule_idx == 999
 
@@ -293,7 +306,7 @@ end
         @test length(secondary_structures(sys, chain_idx = nothing)) == 2
 
 
-        # nsecondary_structures + push!
+        # nsecondary_structures
         @test nsecondary_structures(sys) isa Int
         @test nsecondary_structures(sys) == 2
         @test nsecondary_structures(sys, molecule_idx = -1) == 0
@@ -306,23 +319,6 @@ end
         @test nsecondary_structures(sys, chain_idx = chain2.idx) == 1
         @test nsecondary_structures(sys, chain_idx = nothing) == 2
 
-        @test push!(chain, ss) === chain
-        @test nsecondary_structures(sys) == 3
-        @test nsecondary_structures(sys, chain_idx = -1) == 0
-        @test nsecondary_structures(sys, chain_idx = chain.idx) == 2
-        @test nsecondary_structures(sys, chain_idx = chain2.idx) == 1
-        @test nsecondary_structures(sys, chain_idx = nothing) == 3
-
-        lss = last(secondary_structures(mol))
-        @test lss.idx != ss.idx
-        @test lss.number == ss.number
-        @test lss.type == ss.type
-        @test lss.name == ss.name
-        @test lss.properties == ss.properties
-        @test lss.flags == ss.flags
-        @test lss.molecule_idx == mol.idx
-        @test lss.chain_idx == chain.idx
-
         # molecule secondary structures
         mol3 = Molecule(sys)
         @test length(secondary_structures(mol3)) == 0
@@ -330,7 +326,8 @@ end
         @test nsecondary_structures(mol3) == 0
         @test nsecondary_structures(mol3) == nsecondary_structures(sys, molecule_idx = mol3.idx)
 
-        @test SecondaryStructure(Chain(mol3), 1, SecondaryStructureElement.Unknown; name="U1").molecule_idx == mol3.idx
+        chain3 = Chain(mol3)
+        @test SecondaryStructure(Fragment(chain3, 1), Fragment(chain3, 2), 1, SecondaryStructureElement.Unknown; name="U1").molecule_idx == mol3.idx
         @test length(secondary_structures(mol3)) == 1
         @test secondary_structures(mol3) == secondary_structures(sys, molecule_idx = mol3.idx)
         @test nsecondary_structures(mol3) == 1
@@ -340,82 +337,42 @@ end
         @test length(atoms(ss)) == 0
         @test natoms(ss) == 0
 
-        frag = Fragment(ss, 1)
-        Atom(frag, 1, Elements.H)
-        @test length(atoms(ss)) == 1
-        @test natoms(ss) == 1
+        # secondary structure atoms
+        chain4 = Chain(mol3)
+        a1 = Atom(Residue(chain4, 1), 1, Elements.O)
+        a2 = Atom(Residue(chain4, 2), 2, Elements.H)
+        a3 = Atom(Residue(chain4, 3), 3, Elements.C)
 
-        nuc = Nucleotide(ss, 1)
-        Atom(nuc, 2, Elements.C)
-        @test length(atoms(ss)) == 2
-        @test natoms(ss) == 2
-
-        res = Residue(ss, 1)
-        Atom(res, 3, Elements.O)
-        @test length(atoms(ss)) == 3
-        @test natoms(chain) == 3
-
-        for atom in atoms(ss)
-            @test parent_secondary_structure(atom) === ss
-        end
-        @test parent_secondary_structure(frag) === ss
-        @test parent_secondary_structure(nuc) === ss
-        @test parent_secondary_structure(res) === ss
-        @test parent_secondary_structure(Atom(frag, 1, Elements.H)) === ss
-        @test parent_secondary_structure(Atom(nuc, 2, Elements.C)) === ss
-        @test parent_secondary_structure(Atom(res, 3, Elements.O)) === ss
+        ss = SecondaryStructure(first(residues(chain4)), last(residues(chain4)), 1, SecondaryStructureElement.Coil)
+        at = atoms(ss)
+        @test a1.idx in at.idx
+        @test a2.idx in at.idx
+        @test a3.idx in at.idx
 
         # secondary structure bonds
         @test length(bonds(ss)) == 0
         @test nbonds(ss) == 0
 
-        Bond(chain, Atom(frag, 1, Elements.H).idx, Atom(frag, 2, Elements.C).idx, BondOrder.Single)
+        Bond(chain4, a1.idx, a2.idx, BondOrder.Single)
         @test length(bonds(ss)) == 1
         @test nbonds(ss) == 1
 
-        Bond(chain, Atom(nuc, 1, Elements.H).idx, Atom(nuc, 2, Elements.C).idx, BondOrder.Single)
-        @test length(bonds(ss)) == 2
-        @test nbonds(ss) == 2
-
-        Bond(chain, Atom(res, 1, Elements.H).idx, Atom(res, 2, Elements.C).idx, BondOrder.Single)
-        @test length(bonds(ss)) == 3
-        @test nbonds(ss) == 3
-
         # delete!
-        @test natoms(sys) == 12
-        @test nbonds(sys) == 3
+        @test natoms(sys) == 3
+        @test nbonds(sys) == 1
         @test nmolecules(sys) == 3
-        @test nchains(sys) == 3
+        @test nchains(sys) == 4
         @test nsecondary_structures(sys) == 4
-        @test nfragments(sys) == 3
+        @test nfragments(sys) == 9
 
         aidx = Set(atoms(ss).idx)
         @test delete!(ss; keep_fragments = true) === nothing
-        @test natoms(sys) == 12
-        @test nbonds(sys) == 3
+        @test natoms(sys) == 3
+        @test nbonds(sys) == 1
         @test nmolecules(sys) == 3
-        @test nchains(sys) == 3
+        @test nchains(sys) == 4
         @test nsecondary_structures(sys) == 3
-        @test nfragments(sys) == 3
+        @test nfragments(sys) == 9
         @test_throws KeyError ss.idx
-        @test all(isnothing, parent_secondary_structure.(atom_by_idx.(Ref(sys), aidx)))
-
-        frag = Fragment(ss2, 1)
-        Bond(Atom(frag, 1, Elements.H), Atom(frag, 2, Elements.C), BondOrder.Single)
-        @test natoms(sys) == 14
-        @test nbonds(sys) == 4
-        @test nmolecules(sys) == 3
-        @test nchains(sys) == 3
-        @test nsecondary_structures(sys) == 3
-        @test nfragments(sys) == 4
-
-        @test delete!(ss2; keep_fragments = false) === nothing
-        @test natoms(sys) == 12
-        @test nbonds(sys) == 3
-        @test nmolecules(sys) == 3
-        @test nchains(sys) == 3
-        @test nsecondary_structures(sys) == 2
-        @test nfragments(sys) == 3
-        @test_throws KeyError ss2.idx
     end
 end

--- a/tutorials/core_components.qmd
+++ b/tutorials/core_components.qmd
@@ -336,38 +336,40 @@ Now, that we learned about chains, we can take a look at the secondary structure
 s = System()
 chain = Chain(Molecule(s))
 ss1 = SecondaryStructure(
-    chain,
+    Residue(chain, 1),
+    Residue(chain, 2),
     1,
     SecondaryStructureElement.Helix;
     name="H1"
 )
 
 ss2 = SecondaryStructure(
-    chain,
+    Residue(chain, 3),
+    Residue(chain, 4),
     2,
     SecondaryStructureElement.Coil;
     name="C1"
 )
 
 ss3 = SecondaryStructure(
-    chain,
+    Residue(chain, 5),
+    Residue(chain, 6),
     3,
     SecondaryStructureElement.Strand;
     name="S1"
 )
 ss4 = SecondaryStructure(
-    chain,
+    Residue(chain, 7),
+    Residue(chain, 8),
     4,
     SecondaryStructureElement.Turn;
     name="T1"
 )
 
-ss3.type = SecondaryStructureElement.Helix
 println("Number of secondary structures: ", nsecondary_structures(s))
 
 # get all helices of the chain
-helices = (filter(sst -> sst.type == ss1.type, secondary_structures(chain)))
-
+filter(sst -> sst.type == SecondaryStructureElement.Helix, secondary_structures(chain))
 ```
 
 In addition, we can compute the secondary structures for an input file:


### PR DESCRIPTION
## Breaking changes:
- The private column/field `secondary_structure_idx` has been removed from `FragmentTable`/`Fragment`
- Instead, `SecondaryStructureTable`/`SecondaryStructure` has now two additional private columns/fields `first_fragment_idx` and `last_fragment_idx`
- `SecondaryStructure(...)` requires an initial fragment as well as an terminal fragment instead of a chain, similar to its representation in PDB files:
```julia
# old behavior
SecondaryStructure(chain, ...)

# new behavior
SecondaryStructure(first_fragment, last_fragment, ...)
```

- `Fragment(...)/Residue(...)/Nucleotide(...)` no longer accept a secondary structure as their first argument
- `parent_secondary_structure(...)` has been removed (and incorporated into `secondary_structures(...)`)
```julia
# old behavior
parent_secondary_structure(fragment)

# new behavior
secondary_structures(fragment)
```

- `push!(chain, secondary_structure)` has been removed without replacement
