### PR TITLE
Backports v0.6.9

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,7 @@ jobs:
             experimental: true
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -63,7 +63,7 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1'
       - uses: julia-actions/cache@v3

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -35,7 +35,7 @@ jobs:
       RESOLVER_PATH: "/tmp/resolver"
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/src/preprocessing/reconstruct_fragments.jl
+++ b/src/preprocessing/reconstruct_fragments.jl
@@ -65,7 +65,7 @@ function reconstruct_fragment_!(f::Fragment{T}, template::DBVariant) where {T<:R
             # later on.
 			new_atom = Atom(
                 f,
-                maximum(atoms(parent_system(f)).number)+1, # does this make sense?
+                maximum(atoms(parent_system(f)).number; init = 0)+1, # does this make sense?
                 tpl_atom.element;
                 name = tpl_atom.name,
                 r = tpl_atom.r


### PR DESCRIPTION
- [x] [Bump julia-actions/setup-julia from 2 to 3](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/commit/ce9a0a73cb22c70ab368ad7b5b2590f920518c87)
- [x] [FragmentDB: fix `reconstruct_fragments!` for empty fragments](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/commit/2217d0d118cdb8e3f0a5fe9bad35d4f3ada84f9e)