### PR TITLE
FragmentDB: fix `reconstruct_fragments!` for empty fragments

### DIFF
--- a/src/preprocessing/reconstruct_fragments.jl
+++ b/src/preprocessing/reconstruct_fragments.jl
@@ -64,7 +64,7 @@ function _reconstruct_fragment!(f::Fragment{T}, template::DBFragmentVariant{T}) 
             # later on.
             new_atom = Atom(
                 f,
-                maximum(atoms(parent_system(f)).number)+1, # does this make sense?
+                maximum(atoms(parent_system(f)).number; init = 0)+1, # does this make sense?
                 tpl_atom.element;
                 name = tpl_atom.name,
                 r = Vector3{T}(tpl_atom.r)


### PR DESCRIPTION
Fixes: #292