### PR TITLE
AMBER structure-optimization performance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ authors = ["Andreas Hildebrandt <andreas.hildebrandt@uni-mainz.de> and contribut
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
-BioStructures = "de9282ab-8554-53be-b2d6-f6c222edabfc"
 BioSymbols = "3c28c6f8-a34d-59c4-9654-267d177fcfa9"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 CellListMap = "69e1c6dd-3888-40e6-b3c8-31ac5f578864"
@@ -39,7 +38,6 @@ UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 [compat]
 Aqua = "0.8.14"
 AutoHashEquals = "2"
-BioStructures = "4.2"
 BioSymbols = "5"
 CSV = "0.10.13"
 CellListMap = "0.9.5"

--- a/Project.toml
+++ b/Project.toml
@@ -35,12 +35,27 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
+[weakdeps]
+Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+
+[extensions]
+# device-agnostic GPU kernels; loaded once KernelAbstractions + Atomix are present
+BiochemicalAlgorithmsGPUExt = ["KernelAbstractions", "Atomix"]
+# device registration only (pull in KernelAbstractions/Atomix, triggering GPUExt)
+BiochemicalAlgorithmsCUDAExt = "CUDA"
+BiochemicalAlgorithmsMetalExt = "Metal"
+
 [compat]
 Aqua = "0.8.14"
+Atomix = "0.1, 1"
+CUDA = "5"
 AutoHashEquals = "2"
 BioSymbols = "5"
 CSV = "0.10.13"
-CellListMap = "0.9.5"
+CellListMap = "0.9.5, 0.10"
 DataFrames = "1.8"
 DataStructures = "0.18.13, 0.19"
 Dates = "1.10"
@@ -48,7 +63,9 @@ DocStringExtensions = "0.9"
 EnumX = "1"
 Graphs = "1.12"
 JSON = "1.4.0"
+KernelAbstractions = "0.9"
 LinearAlgebra = "1.10"
+Metal = "1"
 Mendeleev = "1"
 MetaGraphs = "0.8, 0.9"
 MolecularGraph = "0.22"

--- a/benchmark/OPTIMIZATION_BENCHMARKS.md
+++ b/benchmark/OPTIMIZATION_BENCHMARKS.md
@@ -1,0 +1,138 @@
+# AMBER structure-optimization performance
+
+Benchmark report for the cached, multi-backend force-field evaluator added on
+branch `anhi/optimization-performance`. All runs are on the same machine (Apple
+Silicon, 12 logical cores, Metal GPU). Timings are best-of-N wall-clock;
+absolute numbers drift with background load, so the **ratios within a single
+run** are the reliable figures.
+
+Primary structure: **`benchmark/data/AmberFF_bench.pdb`** — BPTI, 892 atoms,
+~634 k nonbonded pairs at the default 20 Å cut-off (AMBER96, Float32).
+
+---
+
+## TL;DR
+
+- **Up to ~36× faster on a single CPU thread and ~138× with 8 threads** than the
+  original `optimize_structure!`, for the same minimization.
+- The original was **~15–20× slower than BALL per evaluation** (it rebuilt the
+  whole pair list every energy/force call). The new code is **on par with BALL
+  single-threaded and faster with threads/GPU**.
+- **Forces match BALL to 0.1 %**, bonded energies to ~1 %.
+- The **GPU backend scales best**: at ~7 000 atoms / 5 M pairs it computes forces
+  ~3.8× faster than one CPU thread and overtakes the 8-thread CPU backend.
+
+---
+
+## 1. Speed-up vs. the original implementation
+
+The original `optimize_structure!` called `update!(ff)` *inside the objective*,
+so the entire nonbonded interaction list was torn down and rebuilt on every
+energy/force evaluation (≈ 42 ms and 85 MB allocated **per call**). The new
+evaluator builds the pair list once and rebuilds it only when atoms drift past a
+Verlet skin (the strategy BALL uses).
+
+200-iteration minimization of BPTI, measured back-to-back in one run:
+
+| Variant                         | Wall-clock | Speed-up |
+|---------------------------------|-----------:|---------:|
+| Original (`update!` every eval) |    68.5 s  |    1×    |
+| New — serial                    |    1.91 s  |  **36×** |
+| New — threads (8)               |    0.50 s  | **138×** |
+
+---
+
+## 2. Accuracy vs. BALL (BPTI, identical 892-atom structure)
+
+BALL (C++ reference) was built with its `devenv` (Nix) toolchain and run on the
+same PDB. Forces were converted from BALL's SI Newtons to kJ/(mol·Å).
+
+| Quantity                | BALL      | Julia (new) | Agreement |
+|-------------------------|----------:|------------:|-----------|
+| RMS force [kJ/(mol·Å)]  |   62.32   |    62.39    | **0.1 %** |
+| Bond stretches [kJ/mol] |   494.6   |    492.7    |  ~0.4 %   |
+| Angle bends             |   517.2   |    523.5    |  ~1.2 %   |
+| Torsions (prop+impr)    |  1171.5   |   1168.3    |  ~0.3 %   |
+| Non-bonded (vdW+HB+ES)  |  −7880    |   −8344     |  ~6 %     |
+| **Total**               | **−5697** |  **−6159**  |  ~8 %     |
+
+Forces and bonded energies agree closely. The ~6 % non-bonded gap lives entirely
+in the long-range electrostatic sum (it does **not** appear in the forces). This
+is a **pre-existing property of the Julia AMBER port** — the cached evaluator
+reproduces the Julia reference path exactly (Float64: bit-for-bit; Float32:
+rounding level), so the performance work did not change any energies.
+
+> Accuracy is validated in `test/forcefields/AMBER/test_compiled_amberff.jl`
+> (compiled vs. reference, both precisions and all backends) and the existing
+> `test_amberff.jl` / `test_optimize_structure.jl` oracle suites.
+
+---
+
+## 3. Speed vs. BALL (BPTI)
+
+**Per-evaluation cost** (cached pair list — the operation that dominates a
+minimization step):
+
+| Backend            | Energy (ms) | Forces (ms) |
+|--------------------|------------:|------------:|
+| BALL (C++, 1 core) |     1.5     |     2.1     |
+| Julia — serial     |     1.8     |     3.2     |
+| Julia — threads(8) |     0.26    |     0.52    |
+| Julia — GPU (Metal)|     1.5     |     2.6     |
+
+- Single-threaded, BALL is ~1.4–1.5× faster than our serial Julia (expected for
+  hand-tuned C++).
+- The threaded backend is **~4–6× faster than BALL**; the GPU matches BALL at
+  this small size and pulls ahead as the system grows (§4).
+
+**End-to-end 200-iteration minimization:** BALL (Strang L-BFGS) 0.9–1.2 s; Julia
+(L-BFGS-B) serial 1.9 s, threads 0.50 s. (Iteration semantics differ between the
+two minimizers, so per-evaluation cost above is the cleaner comparison.)
+
+---
+
+## 4. Backend scaling with system size
+
+To exercise larger systems, BPTI was replicated into *N* copies placed 120 Å
+apart (beyond the cut-off, so copies don't interact and pair count grows
+linearly). Per-evaluation timings (ms), Float32:
+
+| System  | Atoms | Pairs | serial E / F | threads(8) E / F | GPU E / F |
+|---------|------:|------:|-------------:|-----------------:|----------:|
+| BPTI ×1 |   892 | 0.63 M| 1.83 / 3.18  |  0.26 / 0.52     | 1.52 / 2.57 |
+| BPTI ×2 |  1790 | 1.28 M| 4.43 / 9.24  |  0.75 / 1.53     | 2.36 / 4.22 |
+| BPTI ×4 |  3586 | 2.56 M| 9.40 / 18.73 |  1.38 / 3.17     | 2.65 / 5.88 |
+| BPTI ×8 |  7178 | 5.14 M| 17.6 / 34.3  |  3.05 / 13.9     | 4.15 / 9.02 |
+
+- **Serial** scales linearly with pair count, as expected.
+- **GPU** has a fixed launch/transfer overhead that dominates the smallest
+  system (×1: GPU ≈ serial), but its compute barely grows: from ×1 to ×8 the
+  pair count rises 8× while GPU forces rise only ~3.5×.
+- **Crossover:** by ×4–×8 the GPU overtakes the 8-thread CPU backend. At ×8
+  (≈ 7 200 atoms, 5 M pairs) GPU forces (9.0 ms) beat serial (34.3 ms, **3.8×**)
+  and the threaded backend (13.9 ms).
+
+The takeaway: use `:serial`/`:threads` for typical proteins, and `:gpu` for large
+assemblies where its near-flat scaling wins.
+
+---
+
+## 5. Notes & caveats
+
+- **Larger head-to-head vs. BALL** on *identical* atoms was not achievable: the
+  Julia FragmentDB topology inference does not robustly handle multi-chain /
+  larger PDBs (e.g. 4hhb, 2ptc fail; 1tgh loads as 2956 atoms in Julia vs. 2355
+  in BALL), and the synthetic replicas are rejected by BALL's PDB reader. The
+  larger-system comparison is therefore the **Julia-internal scaling curve**
+  (§4); the rigorous cross-check vs. BALL is the BPTI head-to-head (§2–§3). For
+  reference, BALL on `1tgh` (2355 atoms) runs at 4.6 ms (energy) / 6.4 ms
+  (forces) per evaluation.
+- **Accumulation precision** is selectable (`accumulation = Float32 | Float64`).
+  Float64 reproduces the reference path bit-for-bit; Float32 (default for
+  `AmberFF`) differs only at rounding level.
+- **GPU** uses KernelAbstractions and works on **Metal and CUDA** via package
+  extensions (no GPU dependency for CPU-only users). Metal has no Float64, so the
+  GPU backend requires Float32 accumulation there.
+- Reproduce: `optimize_structure!(ff; backend = :serial | :threads | :gpu,
+  accumulation = Float32 | Float64)`. BALL reference built via
+  `cd tmp/BALL && devenv shell -- bash -c 'cd build/devenv && ninja …'`.

--- a/ext/BiochemicalAlgorithmsCUDAExt.jl
+++ b/ext/BiochemicalAlgorithmsCUDAExt.jl
@@ -1,0 +1,15 @@
+module BiochemicalAlgorithmsCUDAExt
+
+using BiochemicalAlgorithms
+using CUDA
+
+# Register NVIDIA GPUs for the `:gpu` evaluation backend. The kernels are
+# device-agnostic and live in the base package (ff_gpu.jl); this extension only
+# makes the KernelAbstractions device discoverable. CUDA supports Float64.
+function __init__()
+    if CUDA.functional()
+        BiochemicalAlgorithms._register_gpu_device!(CUDA.CUDABackend(); supports_f64 = true)
+    end
+end
+
+end # module

--- a/ext/BiochemicalAlgorithmsGPUExt.jl
+++ b/ext/BiochemicalAlgorithmsGPUExt.jl
@@ -1,0 +1,229 @@
+module BiochemicalAlgorithmsGPUExt
+
+# ============================================================================
+#  GPU backend for the CompiledForceField (device-agnostic).
+#
+#  Loaded automatically when KernelAbstractions + Atomix are available (which
+#  the Metal / CUDA package extensions pull in). A single kernel source thus
+#  runs on any KernelAbstractions device; the Metal/CUDA extensions only need to
+#  register their device via `_register_gpu_device!`.
+#
+#  Layout: scalar struct-of-arrays on the device (rx/ry/rz, Fx/Fy/Fz, pair
+#  arrays). Nonbonded forces use atomic scatter-add; the cheap, irregular bonded
+#  terms run on the host. The per-pair math is exactly the `_f_*_factor` /
+#  `_e_*_pair` helpers used by the CPU loops, so results match within Float32
+#  rounding.
+# ============================================================================
+
+using BiochemicalAlgorithms
+using KernelAbstractions
+using KernelAbstractions: @kernel, @index, @Const
+import Atomix
+
+import BiochemicalAlgorithms:
+    CompiledForceField, EvalBackend, ForceField, Vector3,
+    _GPU_DEVICE, _make_gpu_backend, _backend_init!, _backend_upload_pairs!,
+    compute_energy!, compute_forces!,
+    _finish_energy!, _force_bonded!, _apply_constraints!,
+    _f_lj_factor, _f_hb_factor, _f_es_factor, _e_lj_pair, _e_hb_pair, _e_es_pair
+
+const _KA = KernelAbstractions
+
+struct KAGPUBackend{Dev} <: EvalBackend
+    device::Dev
+    workgroupsize::Int
+end
+
+function _make_gpu_backend(::ForceField, ::Type{Acc}) where Acc
+    reg = _GPU_DEVICE[]
+    reg === nothing && throw(ArgumentError(
+        "the :gpu backend needs a GPU package loaded — run `using Metal` " *
+        "(Apple Silicon) or `using CUDA`"))
+    (Acc === Float64 && !reg.f64) && throw(ArgumentError(
+        "this GPU device does not support Float64; use accumulation=Float32"))
+    KAGPUBackend(reg.device, 256)
+end
+
+# device-resident mirror + host staging buffers (allocation-free per eval)
+mutable struct GPUState{FV, IV, HV}
+    rx::FV; ry::FV; rz::FV
+    Fx::FV; Fy::FV; Fz::FV
+    lj_i::IV; lj_j::IV; lj_A::FV; lj_B::FV; lj_s::FV; lj_e::FV
+    hb_i::IV; hb_j::IV; hb_A::FV; hb_B::FV; hb_s::FV; hb_e::FV
+    es_i::IV; es_j::IV; es_q::FV; es_s::FV; es_e::FV
+    hx::HV; hy::HV; hz::HV         # host staging for positions
+    hFx::HV; hFy::HV; hFz::HV      # host staging for forces
+end
+
+@inline _dev(cff::CompiledForceField{T, Acc, <:KAGPUBackend}) where {T, Acc} = cff.backend.device
+@inline _wg(cff::CompiledForceField{T, Acc, <:KAGPUBackend}) where {T, Acc} = cff.backend.workgroupsize
+
+_dalloc(dev, ::Type{E}, n) where E = _KA.allocate(dev, E, n)
+
+# ---- (re)allocate + upload the nonbonded pair arrays -----------------------
+function _upload_pairs!(cff::CompiledForceField{T, Acc, <:KAGPUBackend}) where {T, Acc}
+    dev = _dev(cff)
+    g = cff.gpu::GPUState
+    up_i(host) = (d = _dalloc(dev, Int32, length(host)); copyto!(d, host); d)
+    up_f(host) = (d = _dalloc(dev, Acc, length(host)); copyto!(d, Acc.(host)); d)
+    g.lj_i = up_i(cff.lj.i); g.lj_j = up_i(cff.lj.j)
+    g.lj_A = up_f(cff.lj.A); g.lj_B = up_f(cff.lj.B); g.lj_s = up_f(cff.lj.scaling)
+    g.lj_e = _dalloc(dev, Acc, length(cff.lj.i))
+    g.hb_i = up_i(cff.hb.i); g.hb_j = up_i(cff.hb.j)
+    g.hb_A = up_f(cff.hb.A); g.hb_B = up_f(cff.hb.B); g.hb_s = up_f(cff.hb.scaling)
+    g.hb_e = _dalloc(dev, Acc, length(cff.hb.i))
+    g.es_i = up_i(cff.es.i); g.es_j = up_i(cff.es.j)
+    g.es_q = up_f(cff.es.q1q2); g.es_s = up_f(cff.es.scaling)
+    g.es_e = _dalloc(dev, Acc, length(cff.es.i))
+    nothing
+end
+
+function _backend_init!(cff::CompiledForceField{T, Acc, <:KAGPUBackend}) where {T, Acc}
+    dev = _dev(cff); n = cff.natoms
+    FV = typeof(_dalloc(dev, Acc, 0)); IV = typeof(_dalloc(dev, Int32, 0))
+    pos() = _dalloc(dev, Acc, n)
+    cff.gpu = GPUState{FV, IV, Vector{Acc}}(
+        pos(), pos(), pos(), pos(), pos(), pos(),
+        _dalloc(dev, Int32, 0), _dalloc(dev, Int32, 0), _dalloc(dev, Acc, 0), _dalloc(dev, Acc, 0), _dalloc(dev, Acc, 0), _dalloc(dev, Acc, 0),
+        _dalloc(dev, Int32, 0), _dalloc(dev, Int32, 0), _dalloc(dev, Acc, 0), _dalloc(dev, Acc, 0), _dalloc(dev, Acc, 0), _dalloc(dev, Acc, 0),
+        _dalloc(dev, Int32, 0), _dalloc(dev, Int32, 0), _dalloc(dev, Acc, 0), _dalloc(dev, Acc, 0), _dalloc(dev, Acc, 0),
+        Vector{Acc}(undef, n), Vector{Acc}(undef, n), Vector{Acc}(undef, n),
+        Vector{Acc}(undef, n), Vector{Acc}(undef, n), Vector{Acc}(undef, n),
+    )
+    _upload_pairs!(cff)
+    nothing
+end
+
+_backend_upload_pairs!(cff::CompiledForceField{T, Acc, <:KAGPUBackend}) where {T, Acc} =
+    (cff.gpu isa GPUState && _upload_pairs!(cff); nothing)
+
+function _upload_positions!(cff::CompiledForceField{T, Acc, <:KAGPUBackend}) where {T, Acc}
+    g = cff.gpu::GPUState
+    @inbounds for k in 1:cff.natoms
+        rk = cff.r[k]; g.hx[k] = rk[1]; g.hy[k] = rk[2]; g.hz[k] = rk[3]
+    end
+    copyto!(g.rx, g.hx); copyto!(g.ry, g.hy); copyto!(g.rz, g.hz)
+    nothing
+end
+
+# ---------------------------------------------------------------------------
+#  Kernels (one source; per-pair math shared with the CPU loops)
+# ---------------------------------------------------------------------------
+@kernel function _k_force_lj!(Fx, Fy, Fz, @Const(rx), @Const(ry), @Const(rz),
+        @Const(I), @Const(J), @Const(A), @Const(B), @Const(S), sw, N)
+    n = @index(Global)
+    if n <= N
+        @inbounds begin
+            i = I[n]; j = J[n]
+            dx = rx[i] - rx[j]; dy = ry[i] - ry[j]; dz = rz[i] - rz[j]
+            factor = _f_lj_factor(dx*dx + dy*dy + dz*dz, A[n], B[n], S[n], sw)
+            fx = factor*dx; fy = factor*dy; fz = factor*dz
+            Atomix.@atomic Fx[i] += fx; Atomix.@atomic Fy[i] += fy; Atomix.@atomic Fz[i] += fz
+            Atomix.@atomic Fx[j] -= fx; Atomix.@atomic Fy[j] -= fy; Atomix.@atomic Fz[j] -= fz
+        end
+    end
+end
+
+@kernel function _k_force_hb!(Fx, Fy, Fz, @Const(rx), @Const(ry), @Const(rz),
+        @Const(I), @Const(J), @Const(A), @Const(B), @Const(S), sw, N)
+    n = @index(Global)
+    if n <= N
+        @inbounds begin
+            i = I[n]; j = J[n]
+            dx = rx[i] - rx[j]; dy = ry[i] - ry[j]; dz = rz[i] - rz[j]
+            factor = _f_hb_factor(dx*dx + dy*dy + dz*dz, A[n], B[n], S[n], sw)
+            fx = factor*dx; fy = factor*dy; fz = factor*dz
+            Atomix.@atomic Fx[i] += fx; Atomix.@atomic Fy[i] += fy; Atomix.@atomic Fz[i] += fz
+            Atomix.@atomic Fx[j] -= fx; Atomix.@atomic Fy[j] -= fy; Atomix.@atomic Fz[j] -= fz
+        end
+    end
+end
+
+@kernel function _k_force_es!(Fx, Fy, Fz, @Const(rx), @Const(ry), @Const(rz),
+        @Const(I), @Const(J), @Const(Q), @Const(S), sw, ddd, pref, N)
+    n = @index(Global)
+    if n <= N
+        @inbounds begin
+            i = I[n]; j = J[n]
+            dx = rx[i] - rx[j]; dy = ry[i] - ry[j]; dz = rz[i] - rz[j]
+            factor = _f_es_factor(dx*dx + dy*dy + dz*dz, Q[n], S[n], sw, ddd, pref)
+            fx = factor*dx; fy = factor*dy; fz = factor*dz
+            Atomix.@atomic Fx[i] += fx; Atomix.@atomic Fy[i] += fy; Atomix.@atomic Fz[i] += fz
+            Atomix.@atomic Fx[j] -= fx; Atomix.@atomic Fy[j] -= fy; Atomix.@atomic Fz[j] -= fz
+        end
+    end
+end
+
+@kernel function _k_energy_lj!(E, @Const(rx), @Const(ry), @Const(rz),
+        @Const(I), @Const(J), @Const(A), @Const(B), @Const(S), sw, N)
+    n = @index(Global)
+    if n <= N
+        @inbounds begin
+            i = I[n]; j = J[n]
+            dx = rx[i] - rx[j]; dy = ry[i] - ry[j]; dz = rz[i] - rz[j]
+            E[n] = _e_lj_pair(dx*dx + dy*dy + dz*dz, A[n], B[n], S[n], sw)
+        end
+    end
+end
+
+@kernel function _k_energy_hb!(E, @Const(rx), @Const(ry), @Const(rz),
+        @Const(I), @Const(J), @Const(A), @Const(B), @Const(S), sw, N)
+    n = @index(Global)
+    if n <= N
+        @inbounds begin
+            i = I[n]; j = J[n]
+            dx = rx[i] - rx[j]; dy = ry[i] - ry[j]; dz = rz[i] - rz[j]
+            E[n] = _e_hb_pair(dx*dx + dy*dy + dz*dz, A[n], B[n], S[n], sw)
+        end
+    end
+end
+
+@kernel function _k_energy_es!(E, @Const(rx), @Const(ry), @Const(rz),
+        @Const(I), @Const(J), @Const(Q), @Const(S), sw, ddd, pref, N)
+    n = @index(Global)
+    if n <= N
+        @inbounds begin
+            i = I[n]; j = J[n]
+            dx = rx[i] - rx[j]; dy = ry[i] - ry[j]; dz = rz[i] - rz[j]
+            E[n] = _e_es_pair(dx*dx + dy*dy + dz*dz, Q[n], S[n], sw, ddd, pref)
+        end
+    end
+end
+
+# ---------------------------------------------------------------------------
+#  GPU evaluation entry points
+# ---------------------------------------------------------------------------
+function compute_energy!(cff::CompiledForceField{T, Acc, <:KAGPUBackend}) where {T, Acc}
+    dev = _dev(cff); wg = _wg(cff); g = cff.gpu::GPUState
+    _upload_positions!(cff)
+    nlj = length(cff.lj.i); nhb = length(cff.hb.i); nes = length(cff.es.i)
+    nlj > 0 && _k_energy_lj!(dev, wg)(g.lj_e, g.rx, g.ry, g.rz, g.lj_i, g.lj_j, g.lj_A, g.lj_B, g.lj_s, cff.vdw_sw, nlj; ndrange=nlj)
+    nhb > 0 && _k_energy_hb!(dev, wg)(g.hb_e, g.rx, g.ry, g.rz, g.hb_i, g.hb_j, g.hb_A, g.hb_B, g.hb_s, cff.vdw_sw, nhb; ndrange=nhb)
+    nes > 0 && _k_energy_es!(dev, wg)(g.es_e, g.rx, g.ry, g.rz, g.es_i, g.es_j, g.es_q, g.es_s, cff.es_sw, cff.distance_dependent_dielectric, cff.es_prefactor, nes; ndrange=nes)
+    _KA.synchronize(dev)
+    vdw   = nlj > 0 ? Acc(sum(g.lj_e)) : zero(Acc)
+    hbond = nhb > 0 ? Acc(sum(g.hb_e)) : zero(Acc)
+    es    = nes > 0 ? Acc(sum(g.es_e)) : zero(Acc)
+    _finish_energy!(cff, vdw, hbond, es)
+end
+
+function compute_forces!(cff::CompiledForceField{T, Acc, <:KAGPUBackend}) where {T, Acc}
+    dev = _dev(cff); wg = _wg(cff); g = cff.gpu::GPUState
+    _upload_positions!(cff)
+    fill!(g.Fx, zero(Acc)); fill!(g.Fy, zero(Acc)); fill!(g.Fz, zero(Acc))
+    nlj = length(cff.lj.i); nhb = length(cff.hb.i); nes = length(cff.es.i)
+    nlj > 0 && _k_force_lj!(dev, wg)(g.Fx, g.Fy, g.Fz, g.rx, g.ry, g.rz, g.lj_i, g.lj_j, g.lj_A, g.lj_B, g.lj_s, cff.vdw_sw, nlj; ndrange=nlj)
+    nhb > 0 && _k_force_hb!(dev, wg)(g.Fx, g.Fy, g.Fz, g.rx, g.ry, g.rz, g.hb_i, g.hb_j, g.hb_A, g.hb_B, g.hb_s, cff.vdw_sw, nhb; ndrange=nhb)
+    nes > 0 && _k_force_es!(dev, wg)(g.Fx, g.Fy, g.Fz, g.rx, g.ry, g.rz, g.es_i, g.es_j, g.es_q, g.es_s, cff.es_sw, cff.distance_dependent_dielectric, cff.es_prefactor_force, nes; ndrange=nes)
+    _KA.synchronize(dev)
+    copyto!(g.hFx, g.Fx); copyto!(g.hFy, g.Fy); copyto!(g.hFz, g.Fz)
+    F = cff.F
+    @inbounds for k in 1:cff.natoms
+        F[k] = Vector3{Acc}(g.hFx[k], g.hFy[k], g.hFz[k])
+    end
+    _force_bonded!(F, cff)     # cheap, irregular -> host
+    _apply_constraints!(cff)
+    nothing
+end
+
+end # module

--- a/ext/BiochemicalAlgorithmsMetalExt.jl
+++ b/ext/BiochemicalAlgorithmsMetalExt.jl
@@ -1,0 +1,16 @@
+module BiochemicalAlgorithmsMetalExt
+
+using BiochemicalAlgorithms
+using Metal
+
+# Register Apple Silicon GPUs for the `:gpu` evaluation backend. The actual
+# kernels are device-agnostic and live in the base package (ff_gpu.jl); this
+# extension only makes the KernelAbstractions device discoverable. Metal does
+# not support Float64 in kernels, so Float64 accumulation is disallowed.
+function __init__()
+    if Metal.functional()
+        BiochemicalAlgorithms._register_gpu_device!(Metal.MetalBackend(); supports_f64 = false)
+    end
+end
+
+end # module

--- a/src/BiochemicalAlgorithms.jl
+++ b/src/BiochemicalAlgorithms.jl
@@ -86,6 +86,13 @@ include("fileformats/pdb/pdb_general.jl")
 include("fileformats/pdb/pdb_writer.jl")
 end
 
+include("fileformats/cif.jl")
+
+module MMCIFDetails
+include("fileformats/mmcif/mmcif_reader.jl")
+include("fileformats/mmcif/mmcif_writer.jl")
+end
+
 include("fileformats/sdfile.jl")
 
 # mappings

--- a/src/BiochemicalAlgorithms.jl
+++ b/src/BiochemicalAlgorithms.jl
@@ -107,6 +107,7 @@ include("forcefields/common/stretch_component.jl")
 include("forcefields/common/bend_component.jl")
 include("forcefields/common/torsion_component.jl")
 include("forcefields/common/nonbonded_component.jl")
+include("forcefields/common/compiled_forcefield.jl")
 
 include("forcefields/AMBER/amberff_parameters.jl")
 include("forcefields/AMBER/amberff.jl")

--- a/src/fileformats/cif.jl
+++ b/src/fileformats/cif.jl
@@ -1,0 +1,260 @@
+# CIF 1.1 / CIF 2.0 Parser in Julia
+# Includes in-memory model for structured access
+
+@enum CIFVersion v1_1 v2_0
+@enum ParserState begin
+    Start
+    InDataBlock
+    InLoopHeader
+    InLoopBody
+    InMultilineText
+    InTripleQuotedString
+    ExpectValue
+    Error
+end
+
+struct CIFLoop
+    tags::Vector{String}
+    rows::Vector{Vector{String}}
+end
+
+mutable struct CIFDataBlock
+    name::String
+    tags::Dict{String, String}
+    loops::Vector{CIFLoop}
+end
+
+mutable struct CIFFile
+    version::CIFVersion
+    blocks::Dict{String, CIFDataBlock}
+end
+
+mutable struct CIFParser
+    version::CIFVersion
+    state::ParserState
+    current_tag::Union{Nothing, String}
+    loop_tags::Vector{String}
+    loop_data::Vector{String}  # flat accumulation of all loop values
+    line_number::Int
+    in_text::Bool
+    text_buffer::Vector{String}
+    triple_quote_delim::Union{Nothing, String}
+    current_block::Union{Nothing, CIFDataBlock}
+    file::CIFFile
+    pre_text_state::ParserState  # state before entering text block
+end
+
+function CIFParser()
+    CIFParser(v1_1, Start, nothing, String[], String[], 0, false, String[], nothing, nothing, CIFFile(v1_1, Dict()), Start)
+end
+
+function parse_line!(parser::CIFParser, line::String)
+    parser.line_number += 1
+    stripped = strip(line)
+
+    if parser.line_number == 1 && startswith(stripped, "#\\#CIF_2.0")
+        parser.version = v2_0
+        parser.file.version = v2_0
+        return
+    end
+
+    if isempty(stripped) || startswith(stripped, '#')
+        return
+    end
+
+    if parser.version == v2_0 && !isnothing(parser.triple_quote_delim)
+        if occursin(parser.triple_quote_delim, line)
+            push!(parser.text_buffer, split(line, parser.triple_quote_delim)[1])
+            store_key_value(parser, parser.current_tag, join(parser.text_buffer, "\n"))
+            parser.triple_quote_delim = nothing
+            parser.current_tag = nothing
+            parser.state = InDataBlock
+        else
+            push!(parser.text_buffer, line)
+        end
+        return
+    end
+
+    if parser.in_text
+        if startswith(line, ";")
+            text_value = join(parser.text_buffer, "\n")
+            if parser.pre_text_state == InLoopBody
+                # Multiline text inside a loop — append to loop data
+                push!(parser.loop_data, text_value)
+                parser.state = InLoopBody
+            else
+                store_key_value(parser, parser.current_tag, text_value)
+                parser.state = InDataBlock
+            end
+            parser.current_tag = nothing
+            parser.text_buffer = String[]
+            parser.in_text = false
+        else
+            push!(parser.text_buffer, line)
+        end
+        return
+    end
+
+    if startswith(stripped, "data_")
+        # Finalize any pending loop before switching data blocks
+        finalize_loop!(parser)
+        name = stripped[6:end]
+        parser.current_block = CIFDataBlock(name, Dict(), CIFLoop[])
+        parser.file.blocks[name] = parser.current_block
+        parser.state = InDataBlock
+        return
+    elseif startswith(stripped, "loop_")
+        # Finalize any pending loop before starting a new one
+        finalize_loop!(parser)
+        parser.state = InLoopHeader
+        empty!(parser.loop_tags)
+        empty!(parser.loop_data)
+        return
+    elseif parser.state == InLoopHeader && startswith(stripped, "_")
+        push!(parser.loop_tags, String(stripped))
+        return
+    elseif parser.state in (InLoopHeader, InLoopBody) && !startswith(stripped, "_")
+        # Check for semicolon text block in loop data
+        if startswith(line, ";")
+            parser.pre_text_state = InLoopBody
+            parser.in_text = true
+            parser.text_buffer = [line[2:end]]
+            parser.state = InMultilineText
+            return
+        end
+        parser.state = InLoopBody
+        values = parse_compound_values(String(stripped))
+        append!(parser.loop_data, values)
+        return
+    elseif startswith(stripped, "_")
+        # If we were in a loop, finalize it first
+        if parser.state == InLoopBody
+            finalize_loop!(parser)
+        end
+        # Tag-value pair: may be on one line or split across two
+        tokens = parse_compound_values(String(stripped))
+        if length(tokens) >= 2
+            # Inline tag-value: _tag value
+            store_key_value(parser, tokens[1], join(tokens[2:end], " "))
+            parser.state = InDataBlock
+        else
+            parser.current_tag = tokens[1]
+            parser.state = ExpectValue
+        end
+        return
+    elseif parser.state == ExpectValue
+        if parser.version == v2_0 && (startswith(line, "\"\"\"") || startswith(line, "'''"))
+            delim = startswith(line, "\"\"\"") ? "\"\"\"" : "'''"
+            content = replace(line, delim => "")
+            parser.triple_quote_delim = delim
+            parser.text_buffer = [content]
+            parser.state = InTripleQuotedString
+            return
+        elseif startswith(line, ";")
+            parser.pre_text_state = ExpectValue
+            parser.in_text = true
+            parser.text_buffer = [line[2:end]]
+            parser.state = InMultilineText
+            return
+        else
+            store_key_value(parser, parser.current_tag, String(stripped))
+            parser.current_tag = nothing
+            parser.state = InDataBlock
+            return
+        end
+    else
+        parser.state = Error
+        @warn "Unexpected line at $(parser.line_number): $line"
+    end
+end
+
+function parse_compound_values(line::String)
+    result = String[]
+    buffer = IOBuffer()
+    in_list = false
+    in_table = false
+    in_quote = false
+    quote_char = ' '
+
+    for c in line
+        if c in ('"', '\'')
+            if in_quote && c == quote_char
+                in_quote = false
+                push!(result, String(take!(buffer)))
+            elseif !in_quote
+                in_quote = true
+                quote_char = c
+            else
+                write(buffer, c)
+            end
+        elseif c == '['
+            in_list = true
+            write(buffer, c)
+        elseif c == ']'
+            in_list = false
+            write(buffer, c)
+            push!(result, String(take!(buffer)))
+        elseif c == '{'
+            in_table = true
+            write(buffer, c)
+        elseif c == '}'
+            in_table = false
+            write(buffer, c)
+            push!(result, String(take!(buffer)))
+        elseif isspace(c) && !in_quote && !in_list && !in_table
+            if buffer.size > 0
+                push!(result, String(take!(buffer)))
+            end
+        else
+            write(buffer, c)
+        end
+    end
+    if buffer.size > 0
+        push!(result, String(take!(buffer)))
+    end
+    return result
+end
+
+function store_key_value(parser::CIFParser, tag::Union{Nothing, String}, value::String)
+    tag === nothing && return
+    if parser.current_block !== nothing
+        parser.current_block.tags[tag] = value
+    end
+end
+
+function finalize_loop!(parser::CIFParser)
+    if parser.current_block !== nothing && !isempty(parser.loop_tags) && !isempty(parser.loop_data)
+        ntags = length(parser.loop_tags)
+        nvals = length(parser.loop_data)
+
+        if nvals % ntags != 0
+            @warn "CIF loop has $(nvals) values for $(ntags) tags — not evenly divisible"
+        end
+
+        # Reshape flat values into rows of ntags columns
+        rows = Vector{Vector{String}}()
+        for i in 1:ntags:nvals
+            last_idx = min(i + ntags - 1, nvals)
+            push!(rows, parser.loop_data[i:last_idx])
+        end
+
+        push!(parser.current_block.loops, CIFLoop(copy(parser.loop_tags), rows))
+    end
+    empty!(parser.loop_tags)
+    empty!(parser.loop_data)
+end
+
+function parse_cif(io::IO)
+    parser = CIFParser()
+    for line in eachline(io)
+        parse_line!(parser, line)
+    end
+    finalize_loop!(parser)
+    return parser.file
+end
+
+function parse_cif_file(path::String)
+    open(path, "r") do io
+        parse_cif(io)
+    end
+end

--- a/src/fileformats/mmcif/mmcif_reader.jl
+++ b/src/fileformats/mmcif/mmcif_reader.jl
@@ -1,0 +1,434 @@
+using BiochemicalAlgorithms
+using BiochemicalAlgorithms: CIFFile, CIFDataBlock, CIFLoop, CIFParser,
+    parse_cif_file, parse_cif, parse_element_string, _fragment_variant
+import BiochemicalAlgorithms: PDBDetails
+using DataStructures: Deque
+
+"""
+    read_mmcif(fname_io::Union{AbstractString, IO}, ::Type{T} = Float32; create_coils::Bool = true) -> System{T}
+
+Read a PDBx/mmCIF file and return a System.
+
+Models are stored as frames, using the model number as `frame_id`.
+"""
+function read_mmcif(fname_io::Union{AbstractString, IO}, ::Type{T} = Float32;
+        create_coils::Bool = true) where {T <: Real}
+    cif = if fname_io isa AbstractString
+        parse_cif_file(fname_io)
+    else
+        parse_cif(fname_io)
+    end
+
+    if isempty(cif.blocks)
+        error("mmCIF file contains no data blocks")
+    end
+
+    block = first(values(cif.blocks))
+
+    # Set system name from data block name (or filename if available)
+    sys_name = if fname_io isa AbstractString
+        bn = basename(fname_io)
+        # strip extension
+        idx = findlast('.', bn)
+        isnothing(idx) ? bn : bn[1:idx-1]
+    else
+        block.name
+    end
+
+    sys = System{T}(sys_name)
+    mol = Molecule(sys; name = sys_name)
+
+    # Parse _atom_site loop
+    atom_loop = _find_loop(block, "_atom_site.")
+    if isnothing(atom_loop)
+        return sys
+    end
+
+    _build_atoms!(sys, mol, atom_loop, T)
+
+    # Build fragment cache for postprocessing
+    fragment_cache = Dict{PDBDetails.UniqueResidueID, Fragment{T}}()
+    for f in fragments(sys)
+        fragment_cache[PDBDetails.UniqueResidueID(
+            f.name,
+            parent_chain(f).name,
+            f.number,
+            get_property(f, :insertion_code, " ")
+        )] = f
+    end
+
+    # Parse disulfide bonds from _struct_conn
+    ssbonds = _parse_ssbonds(block)
+    PDBDetails.postprocess_ssbonds_!(sys, ssbonds, fragment_cache)
+
+    # Parse secondary structure from _struct_conf and _struct_sheet_range
+    ss_records = _parse_secondary_structures(block)
+    PDBDetails.postprocess_secondary_structures_!(sys, ss_records, fragment_cache, create_coils)
+
+    sys
+end
+
+# ─── Helpers ──────────────────────────────────────────────────────────
+
+"""Find a loop in the data block whose tags start with the given prefix."""
+function _find_loop(block::CIFDataBlock, prefix::String)
+    for loop in block.loops
+        if !isempty(loop.tags) && startswith(loop.tags[1], prefix)
+            return loop
+        end
+    end
+    return nothing
+end
+
+"""Build a tag→column-index map for a loop."""
+@inline function _col_map(loop::CIFLoop)
+    Dict(tag => i for (i, tag) in enumerate(loop.tags))
+end
+
+"""Get a value from a row, returning `nothing` for CIF missing values (? and .)."""
+@inline function _get(row::Vector{String}, col::Int)
+    v = row[col]
+    (v == "?" || v == ".") ? nothing : v
+end
+
+"""Get a value with a default for missing."""
+@inline function _get(row::Vector{String}, col::Int, default)
+    v = _get(row, col)
+    isnothing(v) ? default : v
+end
+
+"""Get an optional column index, returning nothing if the tag is not present."""
+@inline function _optcol(cols::Dict{String, Int}, tag::String)
+    get(cols, tag, nothing)
+end
+
+# ─── Atom Site Parsing ────────────────────────────────────────────────
+
+function _build_atoms!(sys::System{T}, mol::Molecule{T}, loop::CIFLoop, ::Type{T}) where {T <: Real}
+    cols = _col_map(loop)
+
+    # Required columns
+    c_group     = cols["_atom_site.group_PDB"]
+    c_id        = cols["_atom_site.id"]
+    c_symbol    = cols["_atom_site.type_symbol"]
+    c_atom_name = cols["_atom_site.label_atom_id"]
+    c_alt_id    = cols["_atom_site.label_alt_id"]
+    c_comp_id   = cols["_atom_site.label_comp_id"]
+    c_asym_id   = cols["_atom_site.label_asym_id"]
+    c_seq_id    = cols["_atom_site.label_seq_id"]
+    c_x         = cols["_atom_site.Cartn_x"]
+    c_y         = cols["_atom_site.Cartn_y"]
+    c_z         = cols["_atom_site.Cartn_z"]
+
+    # Optional columns (use auth_* when available, fall back to label_*)
+    c_auth_asym  = _optcol(cols, "_atom_site.auth_asym_id")
+    c_auth_comp  = _optcol(cols, "_atom_site.auth_comp_id")
+    c_auth_seq   = _optcol(cols, "_atom_site.auth_seq_id")
+    c_auth_atom  = _optcol(cols, "_atom_site.auth_atom_id")
+    c_ins_code   = _optcol(cols, "_atom_site.pdbx_PDB_ins_code")
+    c_occupancy  = _optcol(cols, "_atom_site.occupancy")
+    c_bfactor    = _optcol(cols, "_atom_site.B_iso_or_equiv")
+    c_charge     = _optcol(cols, "_atom_site.pdbx_formal_charge")
+    c_model      = _optcol(cols, "_atom_site.pdbx_PDB_model_num")
+
+    current_chain::Union{Chain{T}, Nothing} = nothing
+    current_frag::Union{Fragment{T}, Nothing} = nothing
+    current_chain_id = ""
+    current_frag_key = ("", 0, "")  # (comp_id, seq_id, ins_code)
+
+    altloc_warning = false
+    first_altloc_id = Dict{Tuple{String, Int, String, String}, String}()  # (chain, seq, ins, atom_name) -> first altloc
+
+    for row in loop.rows
+        # Alternate location handling
+        alt_id_raw = row[c_alt_id]
+        alt_id = (alt_id_raw == "." || alt_id_raw == "?") ? nothing : alt_id_raw
+
+        # Use auth_* fields when available (matches PDB convention)
+        chain_id = isnothing(c_auth_asym) ? row[c_asym_id] : _get(row, c_auth_asym, row[c_asym_id])
+        comp_id  = isnothing(c_auth_comp) ? row[c_comp_id] : _get(row, c_auth_comp, row[c_comp_id])
+        atom_name = isnothing(c_auth_atom) ? row[c_atom_name] : _get(row, c_auth_atom, row[c_atom_name])
+
+        seq_id_str = isnothing(c_auth_seq) ? _get(row, c_seq_id, "0") : _get(row, c_auth_seq, _get(row, c_seq_id, "0"))
+        seq_id = tryparse(Int, seq_id_str)
+        if isnothing(seq_id)
+            seq_id = 0
+        end
+
+        ins_code = isnothing(c_ins_code) ? " " : _get(row, c_ins_code, " ")
+
+        # Skip alternate locations beyond the first
+        if !isnothing(alt_id)
+            key = (chain_id, seq_id, ins_code, atom_name)
+            existing = get(first_altloc_id, key, nothing)
+            if isnothing(existing)
+                first_altloc_id[key] = alt_id
+            elseif alt_id != existing
+                if !altloc_warning
+                    @warn "load_mmcif: alternate locations other than $(existing) are currently not supported. Affected records have been ignored!"
+                    altloc_warning = true
+                end
+                continue
+            end
+        end
+
+        # Chain
+        if isnothing(current_chain) || chain_id != current_chain_id
+            current_chain = Chain(mol; name = chain_id)
+            current_chain_id = chain_id
+            current_frag = nothing
+            current_frag_key = ("", 0, "")
+        end
+
+        # Fragment
+        frag_key = (comp_id, seq_id, ins_code)
+        if isnothing(current_frag) || frag_key != current_frag_key
+            is_hetero = strip(row[c_group]) == "HETATM"
+            current_frag = Fragment(current_chain, seq_id;
+                name = comp_id,
+                variant = _fragment_variant(comp_id),
+                properties = Properties([
+                    :is_hetero_fragment => is_hetero,
+                    :insertion_code => ins_code
+                ])
+            )
+            current_frag_key = frag_key
+        end
+
+        # Atom
+        serial = parse(Int, row[c_id])
+        element = parse_element_string(strip(row[c_symbol]))
+
+        x = parse(T, row[c_x])
+        y = parse(T, row[c_y])
+        z = parse(T, row[c_z])
+
+        occupancy = isnothing(c_occupancy) ? T(1.0) : T(parse(Float64, _get(row, c_occupancy, "1.0")))
+        tempfactor = isnothing(c_bfactor) ? T(0.0) : T(parse(Float64, _get(row, c_bfactor, "0.0")))
+
+        charge_str = isnothing(c_charge) ? nothing : _get(row, c_charge)
+        formal_charge = isnothing(charge_str) ? Int(0) : (tryparse(Int, charge_str) === nothing ? 0 : parse(Int, charge_str))
+
+        model_num = isnothing(c_model) ? 1 : parse(Int, _get(row, c_model, "1"))
+
+        is_hetero_atom = strip(row[c_group]) == "HETATM"
+        is_deuterium = strip(row[c_symbol]) == "D"
+
+        flags = Flags()
+        is_hetero_atom && push!(flags, :is_hetero_atom)
+        is_deuterium && push!(flags, :is_deuterium)
+
+        Atom(current_frag, serial, element;
+            name = atom_name,
+            r = Vector3{T}(x, y, z),
+            formal_charge = formal_charge,
+            properties = Properties([
+                :tempfactor => tempfactor,
+                :occupancy => occupancy,
+                :is_hetero_atom => is_hetero_atom,
+                :insertion_code => ins_code
+            ]),
+            flags = flags,
+            frame_id = model_num
+        )
+    end
+end
+
+# ─── SSBond Parsing ──────────────────────────────────────────────────
+
+function _parse_ssbonds(block::CIFDataBlock)
+    ssbonds = Deque{PDBDetails.SSBondRecord}()
+    loop = _find_loop(block, "_struct_conn.")
+    isnothing(loop) && return ssbonds
+
+    cols = _col_map(loop)
+
+    c_type = cols["_struct_conn.conn_type_id"]
+
+    # Use auth fields for residue identification
+    c_p1_asym = get(cols, "_struct_conn.ptnr1_auth_asym_id", get(cols, "_struct_conn.ptnr1_label_asym_id", 0))
+    c_p1_comp = get(cols, "_struct_conn.ptnr1_auth_comp_id", get(cols, "_struct_conn.ptnr1_label_comp_id", 0))
+    c_p1_seq  = get(cols, "_struct_conn.ptnr1_auth_seq_id", get(cols, "_struct_conn.ptnr1_label_seq_id", 0))
+    c_p2_asym = get(cols, "_struct_conn.ptnr2_auth_asym_id", get(cols, "_struct_conn.ptnr2_label_asym_id", 0))
+    c_p2_comp = get(cols, "_struct_conn.ptnr2_auth_comp_id", get(cols, "_struct_conn.ptnr2_label_comp_id", 0))
+    c_p2_seq  = get(cols, "_struct_conn.ptnr2_auth_seq_id", get(cols, "_struct_conn.ptnr2_label_seq_id", 0))
+
+    c_p1_ins  = _optcol(cols, "_struct_conn.pdbx_ptnr1_PDB_ins_code")
+    c_p2_ins  = _optcol(cols, "_struct_conn.pdbx_ptnr2_PDB_ins_code")
+    c_sym1    = _optcol(cols, "_struct_conn.ptnr1_symmetry")
+    c_sym2    = _optcol(cols, "_struct_conn.ptnr2_symmetry")
+    c_dist    = _optcol(cols, "_struct_conn.pdbx_dist_value")
+
+    n = 0
+    for row in loop.rows
+        strip(row[c_type]) == "disulf" || continue
+        n += 1
+
+        p1_ins = isnothing(c_p1_ins) ? " " : _get(row, c_p1_ins, " ")
+        p2_ins = isnothing(c_p2_ins) ? " " : _get(row, c_p2_ins, " ")
+
+        first_res = PDBDetails.UniqueResidueID(
+            strip(row[c_p1_comp]),
+            strip(row[c_p1_asym]),
+            parse(Int, strip(row[c_p1_seq])),
+            p1_ins
+        )
+        second_res = PDBDetails.UniqueResidueID(
+            strip(row[c_p2_comp]),
+            strip(row[c_p2_asym]),
+            parse(Int, strip(row[c_p2_seq])),
+            p2_ins
+        )
+
+        sym1 = isnothing(c_sym1) ? 0 : _parse_symmetry_operator(_get(row, c_sym1, "0"))
+        sym2 = isnothing(c_sym2) ? 0 : _parse_symmetry_operator(_get(row, c_sym2, "0"))
+        dist = isnothing(c_dist) ? 0.0 : parse(Float64, _get(row, c_dist, "0.0"))
+
+        push!(ssbonds, PDBDetails.SSBondRecord(n, first_res, second_res, sym1, sym2, dist))
+    end
+
+    return ssbonds
+end
+
+"""Parse CIF symmetry operator string like '1_555' into an integer."""
+function _parse_symmetry_operator(s::String)
+    s = strip(s)
+    (s == "?" || s == "." || isempty(s)) && return 0
+    # Try parsing as integer directly
+    v = tryparse(Int, replace(s, "_" => ""))
+    isnothing(v) ? 0 : v
+end
+
+# ─── Secondary Structure Parsing ─────────────────────────────────────
+
+function _parse_secondary_structures(block::CIFDataBlock)
+    records = Deque{Union{PDBDetails.HelixRecord, PDBDetails.SheetRecord, PDBDetails.TurnRecord}}()
+
+    _parse_helices!(records, block)
+    _parse_sheets!(records, block)
+
+    return records
+end
+
+function _parse_helices!(records, block::CIFDataBlock)
+    loop = _find_loop(block, "_struct_conf.")
+    isnothing(loop) && return
+
+    cols = _col_map(loop)
+
+    c_id = cols["_struct_conf.id"]
+
+    # Use auth fields when available
+    c_beg_comp = get(cols, "_struct_conf.beg_auth_comp_id", get(cols, "_struct_conf.beg_label_comp_id", 0))
+    c_beg_asym = get(cols, "_struct_conf.beg_auth_asym_id", get(cols, "_struct_conf.beg_label_asym_id", 0))
+    c_beg_seq  = get(cols, "_struct_conf.beg_auth_seq_id", get(cols, "_struct_conf.beg_label_seq_id", 0))
+    c_end_comp = get(cols, "_struct_conf.end_auth_comp_id", get(cols, "_struct_conf.end_label_comp_id", 0))
+    c_end_asym = get(cols, "_struct_conf.end_auth_asym_id", get(cols, "_struct_conf.end_label_asym_id", 0))
+    c_end_seq  = get(cols, "_struct_conf.end_auth_seq_id", get(cols, "_struct_conf.end_label_seq_id", 0))
+
+    c_helix_id    = _optcol(cols, "_struct_conf.pdbx_PDB_helix_id")
+    c_helix_class = _optcol(cols, "_struct_conf.pdbx_PDB_helix_class")
+    c_details     = _optcol(cols, "_struct_conf.details")
+    c_beg_ins     = _optcol(cols, "_struct_conf.pdbx_beg_PDB_ins_code")
+    c_end_ins     = _optcol(cols, "_struct_conf.pdbx_end_PDB_ins_code")
+
+    n = 0
+    for row in loop.rows
+        n += 1
+
+        helix_name = isnothing(c_helix_id) ? _get(row, c_id, "H$n") : _get(row, c_helix_id, "H$n")
+        beg_ins = isnothing(c_beg_ins) ? " " : _get(row, c_beg_ins, " ")
+        end_ins = isnothing(c_end_ins) ? " " : _get(row, c_end_ins, " ")
+
+        initial = PDBDetails.UniqueResidueID(
+            strip(row[c_beg_comp]),
+            strip(row[c_beg_asym]),
+            parse(Int, strip(row[c_beg_seq])),
+            beg_ins
+        )
+        terminal = PDBDetails.UniqueResidueID(
+            strip(row[c_end_comp]),
+            strip(row[c_end_asym]),
+            parse(Int, strip(row[c_end_seq])),
+            end_ins
+        )
+
+        helix_class = isnothing(c_helix_class) ? 1 : (tryparse(Int, _get(row, c_helix_class, "1")) === nothing ? 1 : parse(Int, _get(row, c_helix_class, "1")))
+        details = isnothing(c_details) ? "" : _get(row, c_details, "")
+
+        push!(records, PDBDetails.HelixRecord(n, helix_name, initial, terminal, helix_class, details))
+    end
+end
+
+function _parse_sheets!(records, block::CIFDataBlock)
+    loop = _find_loop(block, "_struct_sheet_range.")
+    isnothing(loop) && return
+
+    cols = _col_map(loop)
+
+    c_sheet_id = cols["_struct_sheet_range.sheet_id"]
+    c_range_id = cols["_struct_sheet_range.id"]
+
+    # Use auth fields when available
+    c_beg_comp = get(cols, "_struct_sheet_range.beg_auth_comp_id", get(cols, "_struct_sheet_range.beg_label_comp_id", 0))
+    c_beg_asym = get(cols, "_struct_sheet_range.beg_auth_asym_id", get(cols, "_struct_sheet_range.beg_label_asym_id", 0))
+    c_beg_seq  = get(cols, "_struct_sheet_range.beg_auth_seq_id", get(cols, "_struct_sheet_range.beg_label_seq_id", 0))
+    c_end_comp = get(cols, "_struct_sheet_range.end_auth_comp_id", get(cols, "_struct_sheet_range.end_label_comp_id", 0))
+    c_end_asym = get(cols, "_struct_sheet_range.end_auth_asym_id", get(cols, "_struct_sheet_range.end_label_asym_id", 0))
+    c_end_seq  = get(cols, "_struct_sheet_range.end_auth_seq_id", get(cols, "_struct_sheet_range.end_label_seq_id", 0))
+
+    c_beg_ins = _optcol(cols, "_struct_sheet_range.pdbx_beg_PDB_ins_code")
+    c_end_ins = _optcol(cols, "_struct_sheet_range.pdbx_end_PDB_ins_code")
+
+    # Try to get sense from _struct_sheet_order
+    sense_map = _parse_sheet_order_sense(block)
+
+    for row in loop.rows
+        sheet_id = strip(row[c_sheet_id])
+        range_id = parse(Int, strip(row[c_range_id]))
+
+        beg_ins = isnothing(c_beg_ins) ? " " : _get(row, c_beg_ins, " ")
+        end_ins = isnothing(c_end_ins) ? " " : _get(row, c_end_ins, " ")
+
+        initial = PDBDetails.UniqueResidueID(
+            strip(row[c_beg_comp]),
+            strip(row[c_beg_asym]),
+            parse(Int, strip(row[c_beg_seq])),
+            beg_ins
+        )
+        terminal = PDBDetails.UniqueResidueID(
+            strip(row[c_end_comp]),
+            strip(row[c_end_asym]),
+            parse(Int, strip(row[c_end_seq])),
+            end_ins
+        )
+
+        sense = get(sense_map, (sheet_id, range_id), 0)
+
+        push!(records, PDBDetails.SheetRecord(range_id, sheet_id, initial, terminal, sense))
+    end
+end
+
+"""Parse _struct_sheet_order to get sense values for each sheet range."""
+function _parse_sheet_order_sense(block::CIFDataBlock)
+    sense_map = Dict{Tuple{String, Int}, Int}()
+    loop = _find_loop(block, "_struct_sheet_order.")
+    isnothing(loop) && return sense_map
+
+    cols = _col_map(loop)
+    c_sheet = cols["_struct_sheet_order.sheet_id"]
+    c_range2 = cols["_struct_sheet_order.range_id_2"]
+    c_sense = _optcol(cols, "_struct_sheet_order.sense")
+
+    isnothing(c_sense) && return sense_map
+
+    for row in loop.rows
+        sheet_id = strip(row[c_sheet])
+        range_id = parse(Int, strip(row[c_range2]))
+        sense_str = _get(row, c_sense, "parallel")
+        sense = sense_str == "anti-parallel" ? -1 : (sense_str == "parallel" ? 1 : 0)
+        sense_map[(sheet_id, range_id)] = sense
+    end
+
+    return sense_map
+end

--- a/src/fileformats/mmcif/mmcif_writer.jl
+++ b/src/fileformats/mmcif/mmcif_writer.jl
@@ -1,0 +1,242 @@
+using Printf
+
+using BiochemicalAlgorithms
+
+"""
+    write_mmcif_impl(io::IO, ac::AbstractAtomContainer{T})
+
+Write an atom container as PDBx/mmCIF format to the given IO stream.
+"""
+function write_mmcif_impl(io::IO, ac::AbstractAtomContainer{T}) where T
+    name = replace(ac.name, r"\s+" => "_")
+    isempty(name) && (name = "unnamed")
+
+    println(io, "data_", name)
+    println(io, "#")
+
+    _write_atom_site(io, ac)
+    _write_struct_conn(io, ac)
+    _write_struct_conf(io, ac)
+    _write_struct_sheet_range(io, ac)
+end
+
+# ─── CIF value quoting ───────────────────────────────────────────────
+
+"""Quote a string value for CIF output."""
+function _cif_quote(s::String)
+    isempty(s) && return "."
+    # No quoting needed for simple values
+    if !any(c -> isspace(c), s) && !startswith(s, '_') && !startswith(s, '#') &&
+       !startswith(s, '\'') && !startswith(s, '"') && s != "." && s != "?"
+        return s
+    end
+    # Use single quotes if possible
+    if !occursin('\'', s)
+        return "'$s'"
+    end
+    # Use double quotes
+    if !occursin('"', s)
+        return "\"$s\""
+    end
+    # Fall back to semicolon text block
+    return ";\n$s\n;"
+end
+
+# ─── _atom_site ───────────────────────────────────────────────────────
+
+function _write_atom_site(io::IO, ac::AbstractAtomContainer{T}) where T
+    all_atoms = atoms(ac)
+    isempty(all_atoms) && return
+
+    println(io, "loop_")
+    println(io, "_atom_site.group_PDB")
+    println(io, "_atom_site.id")
+    println(io, "_atom_site.type_symbol")
+    println(io, "_atom_site.label_atom_id")
+    println(io, "_atom_site.label_alt_id")
+    println(io, "_atom_site.label_comp_id")
+    println(io, "_atom_site.label_asym_id")
+    println(io, "_atom_site.label_entity_id")
+    println(io, "_atom_site.label_seq_id")
+    println(io, "_atom_site.pdbx_PDB_ins_code")
+    println(io, "_atom_site.Cartn_x")
+    println(io, "_atom_site.Cartn_y")
+    println(io, "_atom_site.Cartn_z")
+    println(io, "_atom_site.occupancy")
+    println(io, "_atom_site.B_iso_or_equiv")
+    println(io, "_atom_site.pdbx_formal_charge")
+    println(io, "_atom_site.auth_seq_id")
+    println(io, "_atom_site.auth_comp_id")
+    println(io, "_atom_site.auth_asym_id")
+    println(io, "_atom_site.auth_atom_id")
+    println(io, "_atom_site.pdbx_PDB_model_num")
+
+    # Build entity ID map (one entity per unique chain name)
+    entity_map = Dict{String, Int}()
+    entity_count = 0
+    for c in chains(ac)
+        if !haskey(entity_map, c.name)
+            entity_count += 1
+            entity_map[c.name] = entity_count
+        end
+    end
+
+    for a in all_atoms
+        frag = parent_fragment(a)
+        chain = isnothing(frag) ? nothing : parent_chain(frag)
+
+        group = is_hetero_atom(a) ? "HETATM" : "ATOM"
+        type_sym = string(a.element)
+        atom_name = _cif_quote(a.name)
+        alt_id = "."
+
+        comp_id = isnothing(frag) ? "UNK" : frag.name
+        chain_id = isnothing(chain) ? "." : chain.name
+        entity_id = isnothing(chain) ? 1 : get(entity_map, chain.name, 1)
+        seq_id = isnothing(frag) ? 0 : frag.number
+        ins_code = isnothing(frag) ? "?" : _cif_quote(get_property(frag, :insertion_code, "?"))
+
+        x = @sprintf("%.3f", a.r[1])
+        y = @sprintf("%.3f", a.r[2])
+        z = @sprintf("%.3f", a.r[3])
+
+        occ = @sprintf("%.2f", get_property(a, :occupancy, 1.0))
+        bfac = @sprintf("%.2f", get_property(a, :tempfactor, 0.0))
+
+        charge = a.formal_charge == 0 ? "?" : string(a.formal_charge)
+
+        model_num = a.frame_id
+
+        println(io, "$group $( a.number) $type_sym $atom_name $alt_id $comp_id $chain_id $entity_id $seq_id $ins_code $x $y $z $occ $bfac $charge $seq_id $comp_id $chain_id $atom_name $model_num")
+    end
+
+    println(io, "#")
+end
+
+# ─── _struct_conn (disulfide bonds) ──────────────────────────────────
+
+function _write_struct_conn(io::IO, ac::AbstractAtomContainer{T}) where T
+    # Find disulfide bonds
+    disulfides = filter(b -> has_flag(b, :TYPE__DISULPHIDE_BOND), bonds(ac))
+    isempty(disulfides) && return
+
+    println(io, "loop_")
+    println(io, "_struct_conn.id")
+    println(io, "_struct_conn.conn_type_id")
+    println(io, "_struct_conn.ptnr1_label_asym_id")
+    println(io, "_struct_conn.ptnr1_label_comp_id")
+    println(io, "_struct_conn.ptnr1_label_seq_id")
+    println(io, "_struct_conn.ptnr1_label_atom_id")
+    println(io, "_struct_conn.ptnr1_symmetry")
+    println(io, "_struct_conn.ptnr2_label_asym_id")
+    println(io, "_struct_conn.ptnr2_label_comp_id")
+    println(io, "_struct_conn.ptnr2_label_seq_id")
+    println(io, "_struct_conn.ptnr2_label_atom_id")
+    println(io, "_struct_conn.ptnr2_symmetry")
+    println(io, "_struct_conn.pdbx_dist_value")
+
+    sys = parent_system(ac)
+
+    for (i, b) in enumerate(disulfides)
+        a1 = atom_by_idx(sys, b.a1)
+        a2 = atom_by_idx(sys, b.a2)
+        f1 = parent_fragment(a1)
+        f2 = parent_fragment(a2)
+        c1 = parent_chain(a1)
+        c2 = parent_chain(a2)
+
+        sym1 = get_property(b, :SYMMETRY_OPERATOR_0, 0)
+        sym2 = get_property(b, :SYMMETRY_OPERATOR_1, 0)
+        dist = get_property(b, :BOND_LENGTH, 0.0)
+
+        sym1_str = sym1 == 0 ? "?" : string(sym1)
+        sym2_str = sym2 == 0 ? "?" : string(sym2)
+        dist_str = dist == 0.0 ? "?" : @sprintf("%.3f", dist)
+
+        println(io, "disulf$(i) disulf $(c1.name) $(f1.name) $(f1.number) $(a1.name) $(sym1_str) $(c2.name) $(f2.name) $(f2.number) $(a2.name) $(sym2_str) $(dist_str)")
+    end
+
+    println(io, "#")
+end
+
+# ─── _struct_conf (helices) ──────────────────────────────────────────
+
+function _write_struct_conf(io::IO, ac::AbstractAtomContainer{T}) where T
+    helices = filter(ss -> ss.element == SecondaryStructureElement.Helix, secondary_structures(ac))
+    isempty(helices) && return
+
+    println(io, "loop_")
+    println(io, "_struct_conf.conf_type_id")
+    println(io, "_struct_conf.id")
+    println(io, "_struct_conf.pdbx_PDB_helix_id")
+    println(io, "_struct_conf.beg_label_comp_id")
+    println(io, "_struct_conf.beg_label_asym_id")
+    println(io, "_struct_conf.beg_label_seq_id")
+    println(io, "_struct_conf.pdbx_beg_PDB_ins_code")
+    println(io, "_struct_conf.end_label_comp_id")
+    println(io, "_struct_conf.end_label_asym_id")
+    println(io, "_struct_conf.end_label_seq_id")
+    println(io, "_struct_conf.pdbx_end_PDB_ins_code")
+    println(io, "_struct_conf.pdbx_PDB_helix_class")
+    println(io, "_struct_conf.details")
+    println(io, "_struct_conf.pdbx_PDB_helix_length")
+
+    for ss in helices
+        frags = fragments(ss)
+        isempty(frags) && continue
+
+        first_frag = first(frags)
+        last_frag = last(frags)
+        chain = parent_chain(ss)
+
+        helix_class = get_property(ss, :HELIX_CLASS, 1)
+        details = _cif_quote(get_property(ss, :COMMENT, "?"))
+        helix_length = length(frags)
+
+        beg_ins = get_property(first_frag, :insertion_code, "?")
+        end_ins = get_property(last_frag, :insertion_code, "?")
+
+        println(io, "HELX_P HELX_P$(ss.number) $(ss.name) $(first_frag.name) $(chain.name) $(first_frag.number) $(_cif_quote(beg_ins)) $(last_frag.name) $(chain.name) $(last_frag.number) $(_cif_quote(end_ins)) $(helix_class) $(details) $(helix_length)")
+    end
+
+    println(io, "#")
+end
+
+# ─── _struct_sheet_range (sheets) ────────────────────────────────────
+
+function _write_struct_sheet_range(io::IO, ac::AbstractAtomContainer{T}) where T
+    strands = filter(ss -> ss.element == SecondaryStructureElement.Strand, secondary_structures(ac))
+    isempty(strands) && return
+
+    println(io, "loop_")
+    println(io, "_struct_sheet_range.sheet_id")
+    println(io, "_struct_sheet_range.id")
+    println(io, "_struct_sheet_range.beg_label_comp_id")
+    println(io, "_struct_sheet_range.beg_label_asym_id")
+    println(io, "_struct_sheet_range.beg_label_seq_id")
+    println(io, "_struct_sheet_range.pdbx_beg_PDB_ins_code")
+    println(io, "_struct_sheet_range.end_label_comp_id")
+    println(io, "_struct_sheet_range.end_label_asym_id")
+    println(io, "_struct_sheet_range.end_label_seq_id")
+    println(io, "_struct_sheet_range.pdbx_end_PDB_ins_code")
+
+    for ss in strands
+        frags = fragments(ss)
+        isempty(frags) && continue
+
+        first_frag = first(frags)
+        last_frag = last(frags)
+        chain = parent_chain(ss)
+
+        # Extract sheet name from "SheetName:RangeId" format used by PDB reader
+        name_parts = split(ss.name, ":")
+        sheet_id = length(name_parts) >= 1 ? name_parts[1] : "S1"
+
+        beg_ins = get_property(first_frag, :insertion_code, "?")
+        end_ins = get_property(last_frag, :insertion_code, "?")
+
+        println(io, "$(sheet_id) $(ss.number) $(first_frag.name) $(chain.name) $(first_frag.number) $(_cif_quote(beg_ins)) $(last_frag.name) $(chain.name) $(last_frag.number) $(_cif_quote(end_ins))")
+    end
+
+    println(io, "#")
+end

--- a/src/fileformats/pdb.jl
+++ b/src/fileformats/pdb.jl
@@ -5,21 +5,6 @@ export
     write_mmcif,
     write_pdb
 
-using BioStructures:
-    read,
-    writemmcif,
-    writepdb,
-    collectatoms,
-    collectchains,
-    collectresidues,
-    PDBFormat,
-    MMCIFFormat,
-    MolecularStructure,
-    Model,
-    unsafe_addatomtomodel!,
-    AtomRecord,
-    fixlists!
-
 using Printf
 
 function is_hetero_atom(a::Atom)
@@ -27,7 +12,7 @@ function is_hetero_atom(a::Atom)
     has_flag(a, :is_hetero_atom) || isnothing(f) || !is_amino_acid(f)
 end
 
-function parse_element_string(es::String)
+function parse_element_string(es::AbstractString)
     result = Elements.Unknown
 
     # handle special cases
@@ -73,118 +58,6 @@ function extract_element(pdb_element::String, atom_name::String)
     end
 
     return element
-end
-
-function Base.convert(::Type{System{T}}, orig_pdb::MolecularStructure) where T
-    orig_df  = DataFrame(collectatoms(orig_pdb))
-
-    # then, convert to our representation
-    sys = System{T}(orig_pdb.name)
-    mol = Molecule(sys; name = sys.name)
-
-    ### convert the atom positions
-    r = Vector3{T}.(T.(orig_df.x), T.(orig_df.y), T.(orig_df.z))
-
-    ### extracting the elements is a little more complicated than it could be,
-    ### as the DataFrame-conversion strips whitespaces from atom names
-    elements = extract_element.(orig_df.element, getproperty.(collectatoms(orig_pdb, expand_disordered=true), :name))
-
-    atoms = DataFrame(
-        number=orig_df.serial,
-        name=orig_df.atomname,
-        element=elements,
-        r = r,
-        formal_charge = orig_df.charge
-    )
-
-    # convert other columns of interest to atom properties
-    atoms.properties = Properties.(
-        collect(
-                zip(
-                    Pair.(:tempfactor,            orig_df.tempfactor),
-                    Pair.(:occupancy,             orig_df.occupancy),
-                    Pair.(:is_hetero_atom,        orig_df.ishetero),
-                    Pair.(:insertion_code,        orig_df.inscode),
-                    Pair.(:alternate_location_id, orig_df.altlocid)
-                )
-        )
-    )
-
-    atoms.flags = map(
-        h -> h ? Flags([:is_hetero_atom]) : Flags(),
-        orig_df.ishetero
-    ) .∪ map(
-        d -> d ? Flags([:is_deuterium]) : Flags(),
-        orig_df.element .== "D"
-    )
-
-    atoms.frame_id = orig_df.modelnumber
-    atoms.chain_idx = orig_df.chainid
-    atoms.fragment_idx = orig_df.resnumber
-    atoms.inscode = orig_df.inscode
-
-    # note: we will remove this column as soon as we have filtered out alternates
-    atoms.altlocid = orig_df.altlocid
-
-    # collect fragment information
-    for orig_chain in collectchains(orig_pdb)
-        chain = Chain(mol; name = orig_chain.id)
-        for orig_frag in collectresidues(orig_chain)
-            Fragment(chain, orig_frag.number;
-                name = orig_frag.name,
-                properties = Properties([
-                    :is_hetero_fragment => orig_frag.het_res,
-                    :insertion_code => orig_frag.ins_code
-                ]),
-                variant = _fragment_variant(strip(orig_frag.name))
-            )
-        end
-    end
-
-    # now, handle alternate location ids
-
-    # we try to be as tolerant as possible, as the PDB file format does not
-    # seem to formalize many restrictions here.
-    # general idea:
-    #   - for each atom that has alternative locations, find them
-    #   - find the smallest alternate location id and use this as the base case
-    #   - store all other variants as properties
-    all_altlocs = groupby(filter(:altlocid => !=(' '), atoms, view=true), [:chain_idx, :fragment_idx, :name])
-    for altlocs in all_altlocs
-        sorted_altlocs = sort(altlocs, :altlocid, view=true)
-
-        base_case = sorted_altlocs[1, :]
-        base_case.altlocid = ' '
-
-        if nrow(sorted_altlocs) > 1
-            for altloc in eachrow(sorted_altlocs[2:end, :])
-                atoms.properties[base_case.number][Symbol("alternate_location_$(altloc.altlocid)")] = altloc
-            end
-        end
-    end
-
-    # drop all alternates
-    atoms = filter(:altlocid => ==(' '), atoms)
-
-    # add all remaining atoms to the system
-    grp_atoms = groupby(atoms, [:chain_idx, :fragment_idx, :inscode])
-    for frag in fragments(mol)
-        for atom in eachrow(grp_atoms[(
-            chain_idx = parent_chain(frag).name,
-            fragment_idx = frag.number,
-            inscode = frag.properties[:insertion_code]
-        )])
-            Atom(frag, atom.number, atom.element;
-                name = atom.name,
-                r = atom.r,
-                properties = atom.properties,
-                flags = atom.flags,
-                frame_id = atom.frame_id
-            )
-        end
-    end
-
-    sys
 end
 
 
@@ -255,63 +128,9 @@ Read a PDBx/mmCIF file.
 !!! note
     Models are stored as frames, using the model number as `frame_id`.
 """
-function load_mmcif(fname_io::Union{AbstractString, IO}, ::Type{T} = Float32) where {T <: Real}
-    # TODO: how to handle disordered atoms properly?
-
-    # first, read the structure using BioStructures.jl
-    orig_mmcif = read(fname_io, MMCIFFormat)
-    convert(System{T}, orig_mmcif)
-end
-
-function _to_atom_record(a::Atom)
-    # TODO: handle alternative location identifiers!
-    f = parent_fragment(a)
-
-    AtomRecord(
-        is_hetero_atom(a),
-        a.number,
-        @sprintf("%4s", a.name),
-        ' ',
-        f.name,
-        parent_chain(a).name,
-        f.number,
-        only(get_property(a, :insertion_code, ' ')),
-        Vector{Float64}(a.r),
-        get_property(a, :occupancy, 1.0),
-        get_property(a, :tempfactor, 0.0),
-        string(a.element),
-        string(a.formal_charge)
-    )
-end
-
-function Base.convert(::Type{MolecularStructure}, ac::AbstractAtomContainer{T}) where T
-    # Build a MolecularStructure and add to it incrementally
-    struc = MolecularStructure(ac.name)
-
-    # figure out if all molecules in the atom container have the same frames
-    sys_frame_ids = frame_ids(ac)
-
-    if ac isa System{T}
-        for m in molecules(ac)
-            if frame_ids(m) != sys_frame_ids
-                error("pdb.jl: cannot convert System containing molecules with different numbers of frames")
-            end
-        end
-    end
-
-    for (i, frame_id) in enumerate(sys_frame_ids)
-        struc[i] = Model(i, struc)
-
-        for a in atoms(ac; frame_id=frame_id)
-            unsafe_addatomtomodel!(
-                struc[i],
-                _to_atom_record(a)
-            )
-        end
-    end
-
-    fixlists!(struc)
-    struc
+function load_mmcif(fname_io::Union{AbstractString, IO}, ::Type{T} = Float32;
+        create_coils::Bool = true) where {T <: Real}
+    MMCIFDetails.read_mmcif(fname_io, T; create_coils=create_coils)
 end
 
 function write_pdb(io::IO, ac::Union{Chain{T}, Fragment{T}}) where T
@@ -359,7 +178,10 @@ end
 
 Save an atom container as PDBx/mmCIF file.
 """
-function write_mmcif(fname_io::Union{AbstractString, IO}, ac::AbstractAtomContainer)
-    ps = convert(MolecularStructure, ac)
-    writemmcif(fname_io, ps)
+function write_mmcif(io::IO, ac::AbstractAtomContainer)
+    MMCIFDetails.write_mmcif_impl(io, ac)
+end
+
+function write_mmcif(fname::AbstractString, ac::AbstractAtomContainer)
+    open(io -> write_mmcif(io, ac), fname, "w")
 end

--- a/src/fileformats/pdb/pdb_general.jl
+++ b/src/fileformats/pdb/pdb_general.jl
@@ -546,8 +546,12 @@ function interpret_record(record_type, tag, record_data...; sys, pdb_info, kwarg
     push!(pdb_info.records, PDBRecord(tag, record_data))
 end
 
-function postprocess_ssbonds_!(sys, pdb_info, fragment_cache)
-    for ssbond in pdb_info.ssbonds
+function postprocess_ssbonds_!(sys, pdb_info::PDBInfo, fragment_cache)
+    postprocess_ssbonds_!(sys, pdb_info.ssbonds, fragment_cache)
+end
+
+function postprocess_ssbonds_!(sys, ssbonds, fragment_cache)
+    for ssbond in ssbonds
         f1 = fragment_cache[ssbond.first]
         f2 = fragment_cache[ssbond.second]
 
@@ -584,8 +588,12 @@ function postprocess_ssbonds_!(sys, pdb_info, fragment_cache)
     end
 end
 
-function postprocess_secondary_structures_!(sys, pdb_info, fragment_cache, create_coils)
-    for ss in pdb_info.secondary_structures
+function postprocess_secondary_structures_!(sys, pdb_info::PDBInfo, fragment_cache, create_coils)
+    postprocess_secondary_structures_!(sys, pdb_info.secondary_structures, fragment_cache, create_coils)
+end
+
+function postprocess_secondary_structures_!(sys, ss_records, fragment_cache, create_coils)
+    for ss in ss_records
         initial_res  = get(fragment_cache, ss.initial_residue, nothing)
         terminal_res = get(fragment_cache, ss.terminal_residue, nothing)
 

--- a/src/forcefields/common/compiled_forcefield.jl
+++ b/src/forcefields/common/compiled_forcefield.jl
@@ -1,0 +1,419 @@
+export
+    CompiledForceField,
+    compile,
+    rebuild_pairlist!
+
+# ============================================================================
+#  Cached, struct-of-arrays (SoA), index-based evaluator for a `ForceField`.
+#
+#  Rationale: the reference path in `optimize_structure!` rebuilds
+#  the entire nonbonded interaction list on *every* energy evaluation and
+#  accesses atom coordinates/forces through `Atom{T}` row-views (each a
+#  `Dict{Int,Int}` lookup). This evaluator lowers the already-correct output of
+#  `setup!`/`update!` into flat arrays indexed by *row number* into contiguous
+#  coordinate/force buffers, so per-evaluation cost is a tight allocation-free
+#  loop. The pair list is rebuilt only on demand (BALL-style), not every eval.
+#
+#  The existing per-component `compute_energy!`/`compute_forces!`/`update!`
+#  remain the slow *reference* path and are untouched; this is purely additive.
+#
+#  All energy/force formulas below are transcribed VERBATIM from
+#  stretch_component.jl / bend_component.jl / torsion_component.jl /
+#  nonbonded_component.jl so results match the reference path bit-for-bit when
+#  the accumulation type `Acc` equals the storage type `T`.
+# ============================================================================
+
+# --- evaluation backends -----------------------------------------------------
+abstract type EvalBackend end
+struct SerialBackend   <: EvalBackend end
+
+# --- per-component SoA payloads (row numbers into r/F buffers) ---------------
+struct StretchArrays{Acc}
+    i::Vector{Int32}
+    j::Vector{Int32}
+    r0::Vector{Acc}
+    k::Vector{Acc}
+end
+StretchArrays{Acc}() where Acc = StretchArrays{Acc}(Int32[], Int32[], Acc[], Acc[])
+
+struct BendArrays{Acc}
+    i::Vector{Int32}   # a1
+    j::Vector{Int32}   # a2 (center)
+    l::Vector{Int32}   # a3
+    θ0::Vector{Acc}
+    k::Vector{Acc}
+end
+BendArrays{Acc}() where Acc = BendArrays{Acc}(Int32[], Int32[], Int32[], Acc[], Acc[])
+
+# Torsions have a variable number of Fourier terms; store CSR-flattened.
+struct TorsionArrays{Acc}
+    i::Vector{Int32}
+    j::Vector{Int32}
+    k::Vector{Int32}
+    l::Vector{Int32}
+    term_offset::Vector{Int32}   # length nt+1, CSR offsets into V/ϕ0/f/div
+    V::Vector{Acc}
+    ϕ0::Vector{Acc}
+    f::Vector{Int32}
+    div::Vector{Int32}
+end
+TorsionArrays{Acc}() where Acc =
+    TorsionArrays{Acc}(Int32[], Int32[], Int32[], Int32[], Int32[1], Acc[], Acc[], Int32[], Int32[])
+
+# vdW (12-6) and hydrogen bonds (12-10) share this layout; `es_*` carries the
+# matching electrostatic contribution so a pair contributes both in one pass is
+# *not* assumed here — electrostatics are kept in their own array to mirror the
+# reference exactly.
+struct PairLJArrays{Acc}
+    i::Vector{Int32}
+    j::Vector{Int32}
+    A::Vector{Acc}
+    B::Vector{Acc}
+    scaling::Vector{Acc}
+end
+PairLJArrays{Acc}() where Acc = PairLJArrays{Acc}(Int32[], Int32[], Acc[], Acc[], Acc[])
+
+struct PairESArrays{Acc}
+    i::Vector{Int32}
+    j::Vector{Int32}
+    q1q2::Vector{Acc}
+    scaling::Vector{Acc}
+end
+PairESArrays{Acc}() where Acc = PairESArrays{Acc}(Int32[], Int32[], Acc[], Acc[])
+
+# --- the compiled evaluator --------------------------------------------------
+mutable struct CompiledForceField{T, Acc, B <: EvalBackend}
+    ff::ForceField{T}
+    backend::B
+
+    # bonded (never rebuilt during minimization)
+    stretch::StretchArrays{Acc}
+    bend::BendArrays{Acc}
+    proper::TorsionArrays{Acc}
+    improper::TorsionArrays{Acc}
+
+    # nonbonded (rebuilt on demand)
+    lj::PairLJArrays{Acc}
+    hb::PairLJArrays{Acc}
+    es::PairESArrays{Acc}
+
+    # cached nonbonded scalars
+    vdw_sw::CubicSwitchingFunction{Acc}
+    es_sw::CubicSwitchingFunction{Acc}
+    es_prefactor::Acc
+    es_prefactor_force::Acc
+    distance_dependent_dielectric::Bool
+
+    # coordinate / force scratch (row-indexed, Acc precision)
+    r::Vector{Vector3{Acc}}
+    F::Vector{Vector3{Acc}}
+
+    # per-category energies (keys match ForceField reference path)
+    energy::Dict{String, Acc}
+
+    # idx <-> row bookkeeping
+    idx2row::Dict{Int, Int32}
+    natoms::Int
+
+    # constrained atoms, as a per-row mask
+    constrained_mask::Vector{Bool}
+
+    # BALL-style pair-list rebuild policy
+    update_frequency::Int
+    max_displacement::Acc
+    r_at_last_build::Vector{Vector3{Acc}}
+    iters_since_build::Int
+end
+
+@inline accumulation_type(::CompiledForceField{T, Acc}) where {T, Acc} = Acc
+
+function Base.show(io::IO, cff::CompiledForceField{T, Acc, B}) where {T, Acc, B}
+    print(io, "CompiledForceField{$T, acc=$Acc, $(nameof(B))}: ",
+        cff.natoms, " atoms, ",
+        length(cff.stretch.k), " stretches, ",
+        length(cff.bend.k), " bends, ",
+        length(cff.proper.i), "+", length(cff.improper.i), " torsions, ",
+        length(cff.lj.i), " vdW / ", length(cff.hb.i), " hbond / ",
+        length(cff.es.i), " electrostatic pairs")
+end
+
+# ----------------------------------------------------------------------------
+#  Compilation: lower the reference components into SoA arrays.
+# ----------------------------------------------------------------------------
+"""
+    compile(ff::ForceField{T}; acc=T, backend=:serial, update_frequency=1, max_displacement=8)
+
+Build a [`CompiledForceField`](@ref) from `ff`: a cached, struct-of-arrays
+evaluator suitable for repeated energy/force evaluation (e.g. inside
+`optimize_structure!`). `acc` selects the accumulation precision (`Float32` or
+`Float64`); `backend` selects `:serial` (more backends added in later stages).
+
+Calls `update!(ff)` once to obtain the correct interaction list, then lowers it.
+The atom topology (and therefore row numbering) must not change for the lifetime
+of the returned object.
+"""
+function compile(ff::ForceField{T};
+        acc::Type{Acc} = T,
+        backend::Symbol = :serial,
+        update_frequency::Integer = 0,
+        max_displacement::Real = -1) where {T, Acc <: Real}
+
+    b = _select_backend(Val(backend), ff, Acc)
+
+    at = atoms(ff.system)
+    natoms = length(at.idx)
+    idx2row = Dict{Int, Int32}(idx => Int32(k) for (k, idx) in enumerate(at.idx))
+
+    r = Vector{Vector3{Acc}}(undef, natoms)
+    F = Vector{Vector3{Acc}}(undef, natoms)
+
+    constrained_mask = falses(natoms)
+    for a in ff.constrained_atoms
+        # `constrained_atoms` holds row positions into atoms(system); mirror the
+        # reference path which indexes atoms(ff.system)[constrained_atoms].
+        if 1 <= a <= natoms
+            constrained_mask[a] = true
+        end
+    end
+
+    cff = CompiledForceField{T, Acc, typeof(b)}(
+        ff, b,
+        StretchArrays{Acc}(), BendArrays{Acc}(), TorsionArrays{Acc}(), TorsionArrays{Acc}(),
+        PairLJArrays{Acc}(), PairLJArrays{Acc}(), PairESArrays{Acc}(),
+        CubicSwitchingFunction{Acc}(zero(Acc), zero(Acc)),
+        CubicSwitchingFunction{Acc}(zero(Acc), zero(Acc)),
+        Acc(ES_Prefactor), Acc(ES_Prefactor_force), false,
+        r, F,
+        Dict{String, Acc}(),
+        idx2row, natoms,
+        constrained_mask,
+        Int(update_frequency), Acc(max_displacement),
+        Vector{Vector3{Acc}}(undef, natoms), 0,
+    )
+
+    # auto-derive a safe Verlet skin from the cutoffs unless overridden: a pair
+    # absent from the list was >= nonbonded_cutoff apart at build time; it can
+    # only reach the (vdw/es) cutoff if atoms move > (nonbonded_cutoff-cutoff)/2.
+    if max_displacement < 0
+        nb  = Acc(ff.options[:nonbonded_cutoff])
+        cut = max(Acc(ff.options[:vdw_cutoff]), Acc(ff.options[:electrostatic_cutoff]))
+        cff.max_displacement = max(zero(Acc), (nb - cut) / 2)
+    end
+
+    _lower_bonded!(cff)
+    sync_positions_from_table!(cff)   # fill cff.r from the table FIRST
+    rebuild_pairlist!(cff)            # then lower nonbonded + snapshot positions
+    cff
+end
+
+_select_backend(::Val{:serial}, ::ForceField, ::Type) = SerialBackend()
+_select_backend(::Val{B}, ::ForceField, ::Type) where B =
+    throw(ArgumentError("unknown backend :$B (available: :serial)"))
+
+@inline _row(cff::CompiledForceField, atom) = cff.idx2row[atom.idx]
+
+# --- bonded lowering (done once) --------------------------------------------
+function _lower_bonded!(cff::CompiledForceField{T, Acc}) where {T, Acc}
+    for c in cff.ff.components
+        _lower_component!(cff, c)
+    end
+    cff
+end
+
+_lower_component!(::CompiledForceField, ::AbstractForceFieldComponent) = nothing
+
+function _lower_component!(cff::CompiledForceField{T, Acc}, c::QuadraticStretchComponent{T}) where {T, Acc}
+    s = cff.stretch
+    for qbs in c.stretches
+        push!(s.i, _row(cff, qbs.a1)); push!(s.j, _row(cff, qbs.a2))
+        push!(s.r0, Acc(qbs.r0));      push!(s.k, Acc(qbs.k))
+    end
+    nothing
+end
+
+function _lower_component!(cff::CompiledForceField{T, Acc}, c::QuadraticBendComponent{T}) where {T, Acc}
+    b = cff.bend
+    for qab in c.bends
+        push!(b.i, _row(cff, qab.a1)); push!(b.j, _row(cff, qab.a2)); push!(b.l, _row(cff, qab.a3))
+        push!(b.θ0, Acc(qab.θ₀));       push!(b.k, Acc(qab.k))
+    end
+    nothing
+end
+
+function _lower_component!(cff::CompiledForceField{T, Acc}, c::TorsionComponent{T}) where {T, Acc}
+    _lower_torsions!(cff, cff.proper, c.proper_torsions)
+    _lower_torsions!(cff, cff.improper, c.improper_torsions)
+    nothing
+end
+
+function _lower_torsions!(cff::CompiledForceField{T, Acc}, t::TorsionArrays{Acc}, torsions) where {T, Acc}
+    for ct in torsions
+        push!(t.i, _row(cff, ct.a1)); push!(t.j, _row(cff, ct.a2))
+        push!(t.k, _row(cff, ct.a3)); push!(t.l, _row(cff, ct.a4))
+        for n in eachindex(ct.V)
+            push!(t.V, Acc(ct.V[n])); push!(t.ϕ0, Acc(ct.ϕ₀[n]))
+            push!(t.f, Int32(ct.f[n])); push!(t.div, Int32(ct.div[n]))
+        end
+        push!(t.term_offset, Int32(length(t.V) + 1))
+    end
+    nothing
+end
+
+# --- nonbonded lowering (rebuilt on demand) ---------------------------------
+"""
+    rebuild_pairlist!(cff::CompiledForceField)
+
+Recompute the cached nonbonded pair list (vdW / hydrogen-bond / electrostatic)
+from the force field's current coordinates. This is the expensive operation;
+during minimization it is invoked only periodically (see `update_frequency` /
+`max_displacement`).
+"""
+function rebuild_pairlist!(cff::CompiledForceField{T, Acc}) where {T, Acc}
+    ff = cff.ff
+    nbc = nothing
+    for c in ff.components
+        c isa NonBondedComponent && (nbc = c)
+    end
+    nbc === nothing && return cff
+
+    # Push the evaluator's current coordinates into the canonical table so the
+    # reference `update!` (which reads atoms(system).r and the CellListMap
+    # neighbor search) sees the right positions. This also keeps the table
+    # current at every rebuild (good for observables / visualization).
+    sync_to_table!(cff; forces=false)
+
+    # Re-run the reference nonbonded update (applies exclusions, HB/vdW
+    # classification, 1-4 scaling, switching assignment). Single-sourced.
+    update!(nbc)
+
+    cff.vdw_sw = _convert_sw(Acc, nbc.cache.vdw_switching_function)
+    cff.es_sw  = _convert_sw(Acc, nbc.cache.es_switching_function)
+    cff.distance_dependent_dielectric = ff.options[:distance_dependent_dielectric]::Bool
+
+    _lower_lj!(cff, cff.lj, nbc.lj_interactions)
+    _lower_lj!(cff, cff.hb, nbc.hydrogen_bonds)
+    _lower_es!(cff, cff.es, nbc.electrostatic_interactions)
+
+    # snapshot positions for the displacement check
+    resize!(cff.r_at_last_build, cff.natoms)
+    @inbounds for k in 1:cff.natoms
+        cff.r_at_last_build[k] = cff.r[k]
+    end
+    cff.iters_since_build = 0
+    cff
+end
+
+# largest atomic displacement since the last pair-list build
+function _max_displacement(cff::CompiledForceField{T, Acc}) where {T, Acc}
+    maxd2 = zero(Acc)
+    @inbounds for k in 1:cff.natoms
+        d2 = squared_norm(cff.r[k] - cff.r_at_last_build[k])
+        d2 > maxd2 && (maxd2 = d2)
+    end
+    sqrt(maxd2)
+end
+
+"""
+    maybe_rebuild!(cff::CompiledForceField) -> Bool
+
+Rebuild the nonbonded pair list if atoms have drifted past the Verlet skin
+(`max_displacement`) since the last build, or — when `update_frequency > 0` —
+every `update_frequency` calls. Returns `true` if a rebuild happened. This is
+the BALL-style decoupling of pair-list maintenance from per-evaluation cost.
+"""
+function maybe_rebuild!(cff::CompiledForceField{T, Acc}) where {T, Acc}
+    need = _max_displacement(cff) > cff.max_displacement
+    if cff.update_frequency > 0
+        cff.iters_since_build += 1
+        need |= cff.iters_since_build >= cff.update_frequency
+    end
+    need && rebuild_pairlist!(cff)
+    need
+end
+
+"""
+    prepare_eval!(cff, r)
+
+Load the flat optimizer coordinate vector `r` into the evaluator and refresh the
+pair list if necessary. Call before `compute_energy!`/`compute_forces!`.
+"""
+@inline function prepare_eval!(cff::CompiledForceField, r::AbstractVector)
+    set_positions_flat!(cff, r)
+    maybe_rebuild!(cff)
+    cff
+end
+
+_convert_sw(::Type{Acc}, sw::CubicSwitchingFunction) where Acc =
+    CubicSwitchingFunction{Acc}(Acc(sw.cutoff), Acc(sw.cuton))
+
+function _lower_lj!(cff::CompiledForceField{T, Acc}, p::PairLJArrays{Acc}, interactions) where {T, Acc}
+    empty!(p.i); empty!(p.j); empty!(p.A); empty!(p.B); empty!(p.scaling)
+    for lji in interactions
+        push!(p.i, _row(cff, lji.a1)); push!(p.j, _row(cff, lji.a2))
+        push!(p.A, Acc(lji.A)); push!(p.B, Acc(lji.B)); push!(p.scaling, Acc(lji.scaling_factor))
+    end
+    nothing
+end
+
+function _lower_es!(cff::CompiledForceField{T, Acc}, p::PairESArrays{Acc}, interactions) where {T, Acc}
+    empty!(p.i); empty!(p.j); empty!(p.q1q2); empty!(p.scaling)
+    for esi in interactions
+        push!(p.i, _row(cff, esi.a1)); push!(p.j, _row(cff, esi.a2))
+        push!(p.q1q2, Acc(esi.q1q2)); push!(p.scaling, Acc(esi.scaling_factor))
+    end
+    nothing
+end
+
+# ----------------------------------------------------------------------------
+#  Coordinate / force synchronisation with the canonical atom table.
+#  The hot loop never touches the table; these run only at sync points
+#  (notify callbacks, end of optimization).
+# ----------------------------------------------------------------------------
+function sync_positions_from_table!(cff::CompiledForceField{T, Acc}) where {T, Acc}
+    at = atoms(cff.ff.system)
+    @inbounds for k in 1:cff.natoms
+        cff.r[k] = Vector3{Acc}(at.r[k])
+    end
+    cff
+end
+
+"""
+    sync_to_table!(cff; forces=true)
+
+Write the evaluator's coordinates (and, by default, forces) back into the
+canonical atom table so the rest of the library and any registered observables
+see consistent state.
+"""
+function sync_to_table!(cff::CompiledForceField{T, Acc}; forces::Bool=true) where {T, Acc}
+    at = atoms(cff.ff.system)
+    @inbounds for k in 1:cff.natoms
+        at.r[k] = Vector3{T}(cff.r[k])
+    end
+    if forces
+        @inbounds for k in 1:cff.natoms
+            at.F[k] = Vector3{T}(cff.F[k])
+        end
+    end
+    cff
+end
+
+# pull positions from a flat optimizer vector (Float64) into the Acc SoA buffer
+function set_positions_flat!(cff::CompiledForceField{T, Acc}, r::AbstractVector) where {T, Acc}
+    @inbounds for k in 1:cff.natoms
+        b = 3 * (k - 1)
+        cff.r[k] = Vector3{Acc}(Acc(r[b+1]), Acc(r[b+2]), Acc(r[b+3]))
+    end
+    cff
+end
+
+# write the negative force (= energy gradient) into a flat optimizer vector
+function gradient_flat!(grad::AbstractVector, cff::CompiledForceField{T, Acc}) where {T, Acc}
+    @inbounds for k in 1:cff.natoms
+        b = 3 * (k - 1)
+        Fk = cff.F[k]
+        grad[b+1] = -Fk[1]; grad[b+2] = -Fk[2]; grad[b+3] = -Fk[3]
+    end
+    grad
+end
+
+include("ff_kernels.jl")

--- a/src/forcefields/common/compiled_forcefield.jl
+++ b/src/forcefields/common/compiled_forcefield.jl
@@ -133,6 +133,9 @@ mutable struct CompiledForceField{T, Acc, B <: EvalBackend}
 
     # device-resident state for the GPU backend (nothing for CPU backends)
     gpu::Any
+
+    # cached CellListMap in-place neighbor list (built once, updated in place)
+    nl::Any
 end
 
 @inline accumulation_type(::CompiledForceField{T, Acc}) where {T, Acc} = Acc
@@ -203,7 +206,7 @@ function compile(ff::ForceField{T};
         constrained_mask,
         Int(update_frequency), Acc(max_displacement),
         Vector{Vector3{Acc}}(undef, natoms), 0,
-        nothing,
+        nothing, nothing,
     )
 
     # auto-derive a safe Verlet skin from the cutoffs unless overridden: a pair
@@ -321,23 +324,16 @@ function rebuild_pairlist!(cff::CompiledForceField{T, Acc}) where {T, Acc}
     end
     nbc === nothing && return cff
 
-    # Push the evaluator's current coordinates into the canonical table so the
-    # reference `update!` (which reads atoms(system).r and the CellListMap
-    # neighbor search) sees the right positions. This also keeps the table
-    # current at every rebuild (good for observables / visualization).
-    sync_to_table!(cff; forces=false)
-
-    # Re-run the reference nonbonded update (applies exclusions, HB/vdW
-    # classification, 1-4 scaling, switching assignment). Single-sourced.
-    update!(nbc)
-
     cff.vdw_sw = _convert_sw(Acc, nbc.cache.vdw_switching_function)
     cff.es_sw  = _convert_sw(Acc, nbc.cache.es_switching_function)
     cff.distance_dependent_dielectric = ff.options[:distance_dependent_dielectric]::Bool
 
-    _lower_lj!(cff, cff.lj, nbc.lj_interactions)
-    _lower_lj!(cff, cff.hb, nbc.hydrogen_bonds)
-    _lower_es!(cff, cff.es, nbc.electrostatic_interactions)
+    # Build the SoA pair arrays directly from a cached in-place neighbor list,
+    # reusing the exclusion/classification caches that `setup!(nbc)` produced.
+    # This avoids the reference `update!`'s fresh `neighborlist` allocation and
+    # its Deque-of-row-view reconstruction. `setup!` (run by the AmberFF
+    # constructor) must have populated `nbc.cache`.
+    _build_nonbonded_soa!(cff, nbc)
 
     # snapshot positions for the displacement check
     resize!(cff.r_at_last_build, cff.natoms)
@@ -392,20 +388,81 @@ end
 _convert_sw(::Type{Acc}, sw::CubicSwitchingFunction) where Acc =
     CubicSwitchingFunction{Acc}(Acc(sw.cutoff), Acc(sw.cuton))
 
-function _lower_lj!(cff::CompiledForceField{T, Acc}, p::PairLJArrays{Acc}, interactions) where {T, Acc}
-    empty!(p.i); empty!(p.j); empty!(p.A); empty!(p.B); empty!(p.scaling)
-    for lji in interactions
-        push!(p.i, _row(cff, lji.a1)); push!(p.j, _row(cff, lji.a2))
-        push!(p.A, Acc(lji.A)); push!(p.B, Acc(lji.B)); push!(p.scaling, Acc(lji.scaling_factor))
-    end
-    nothing
-end
+# Build the vdW / hydrogen-bond / electrostatic SoA arrays directly from a
+# cached in-place neighbor list. This is a faithful port of `update!(nbc)`
+# (nonbonded_component.jl): same exclusions (bond/geminal), same HB-vs-vdW
+# classification, same 1-4 scaling — but it emits the row-indexed SoA arrays
+# directly and reuses the neighbor list across rebuilds. The neighbor search
+# runs on `cff.r` (no atom-table round-trip). Validated against the reference
+# Deque path by test_compiled_amberff.jl.
+function _build_nonbonded_soa!(cff::CompiledForceField{T, Acc}, nbc::NonBondedComponent{T}) where {T, Acc}
+    ff = cff.ff
+    c  = nbc.cache
+    cutoff = Acc(c.nonbonded_cutoff)
+    pbc = ff.options[:periodic_boundary_conditions]::Bool
 
-function _lower_es!(cff::CompiledForceField{T, Acc}, p::PairESArrays{Acc}, interactions) where {T, Acc}
-    empty!(p.i); empty!(p.j); empty!(p.q1q2); empty!(p.scaling)
-    for esi in interactions
-        push!(p.i, _row(cff, esi.a1)); push!(p.j, _row(cff, esi.a2))
-        push!(p.q1q2, Acc(esi.q1q2)); push!(p.scaling, Acc(esi.scaling_factor))
+    if cff.nl === nothing
+        cff.nl = pbc ?
+            CellListMap.InPlaceNeighborList(positions=cff.r, cutoff=cutoff, unitcell=Acc.(c.periodic_box)) :
+            CellListMap.InPlaceNeighborList(positions=cff.r, cutoff=cutoff)
+    elseif pbc
+        CellListMap.update!(cff.nl; positions=cff.r, unitcell=Acc.(c.periodic_box))
+    else
+        CellListMap.update!(cff.nl; positions=cff.r)
+    end
+    # concrete type annotations: cff.nl is stored as Any and atoms(...) is not
+    # inferred, so without these the 634k-iteration loop boxes every access.
+    pairs::Vector{Tuple{Int, Int, Acc}} = CellListMap.neighborlist!(cff.nl)
+
+    at    = atoms(ff.system)::AtomTable{T}
+    idxc  = at.idx
+    chgc  = at.charge
+    typc  = at.atom_type
+    bond  = c.bond_cache; gem = c.geminal_cache; vic = c.vicinal_cache
+    ljc   = c.lj_combinations; hbc = c.hydrogen_bond_combinations
+    s_es  = Acc(c.scaling_es_1_4)
+    s_vdw = Acc(c.scaling_vdw_1_4)
+
+    lj = cff.lj; hb = cff.hb; es = cff.es
+    empty!(lj.i); empty!(lj.j); empty!(lj.A); empty!(lj.B); empty!(lj.scaling)
+    empty!(hb.i); empty!(hb.j); empty!(hb.A); empty!(hb.B); empty!(hb.scaling)
+    empty!(es.i); empty!(es.j); empty!(es.q1q2); empty!(es.scaling)
+
+    @inbounds for cand in pairs
+        i = cand[1]::Int; j = cand[2]::Int
+        ii = idxc[i]; jj = idxc[j]
+        # exclude 1-2 (bond) and 1-3 (geminal) interactions
+        ((ii => jj) in bond || (ii => jj) in gem) && continue
+        vicinal = (ii => jj) in vic
+
+        q1q2 = Acc(chgc[i]) * Acc(chgc[j])
+        if q1q2 != zero(Acc)
+            push!(es.i, Int32(i)); push!(es.j, Int32(j))
+            push!(es.q1q2, q1q2); push!(es.scaling, vicinal ? s_es : one(Acc))
+        end
+
+        t1 = typc[i]; t2 = typc[j]
+        if !vicinal
+            h = get(hbc, (I=t1, J=t2), missing)
+            ismissing(h) && (h = get(hbc, (I=t2, J=t1), missing))
+            if !ismissing(h)
+                push!(hb.i, Int32(i)); push!(hb.j, Int32(j))
+                push!(hb.A, Acc(only(h.A))); push!(hb.B, Acc(only(h.B))); push!(hb.scaling, one(Acc))
+            else
+                p = get(ljc, (I=t1, J=t2), missing)
+                if !ismissing(p)
+                    push!(lj.i, Int32(i)); push!(lj.j, Int32(j))
+                    push!(lj.A, Acc(p.A_ij)); push!(lj.B, Acc(p.B_ij)); push!(lj.scaling, one(Acc))
+                end
+            end
+        else
+            # 1-4 (torsion) pair: scaled vdW
+            p = get(ljc, (I=t1, J=t2), missing)
+            if !ismissing(p)
+                push!(lj.i, Int32(i)); push!(lj.j, Int32(j))
+                push!(lj.A, Acc(p.A_ij)); push!(lj.B, Acc(p.B_ij)); push!(lj.scaling, s_vdw)
+            end
+        end
     end
     nothing
 end

--- a/src/forcefields/common/compiled_forcefield.jl
+++ b/src/forcefields/common/compiled_forcefield.jl
@@ -26,6 +26,9 @@ export
 # --- evaluation backends -----------------------------------------------------
 abstract type EvalBackend end
 struct SerialBackend   <: EvalBackend end
+struct ThreadedBackend <: EvalBackend
+    nthreads::Int
+end
 
 # --- per-component SoA payloads (row numbers into r/F buffers) ---------------
 struct StretchArrays{Acc}
@@ -108,6 +111,10 @@ mutable struct CompiledForceField{T, Acc, B <: EvalBackend}
     r::Vector{Vector3{Acc}}
     F::Vector{Vector3{Acc}}
 
+    # per-thread scratch for the ThreadedBackend (empty for SerialBackend)
+    F_threads::Vector{Vector{Vector3{Acc}}}
+    e_threads::Vector{Acc}
+
     # per-category energies (keys match ForceField reference path)
     energy::Dict{String, Acc}
 
@@ -167,6 +174,10 @@ function compile(ff::ForceField{T};
     r = Vector{Vector3{Acc}}(undef, natoms)
     F = Vector{Vector3{Acc}}(undef, natoms)
 
+    nthreads = b isa ThreadedBackend ? b.nthreads : 0
+    F_threads = [Vector{Vector3{Acc}}(undef, natoms) for _ in 1:nthreads]
+    e_threads = zeros(Acc, nthreads)
+
     constrained_mask = falses(natoms)
     for a in ff.constrained_atoms
         # `constrained_atoms` holds row positions into atoms(system); mirror the
@@ -183,7 +194,7 @@ function compile(ff::ForceField{T};
         CubicSwitchingFunction{Acc}(zero(Acc), zero(Acc)),
         CubicSwitchingFunction{Acc}(zero(Acc), zero(Acc)),
         Acc(ES_Prefactor), Acc(ES_Prefactor_force), false,
-        r, F,
+        r, F, F_threads, e_threads,
         Dict{String, Acc}(),
         idx2row, natoms,
         constrained_mask,
@@ -207,8 +218,9 @@ function compile(ff::ForceField{T};
 end
 
 _select_backend(::Val{:serial}, ::ForceField, ::Type) = SerialBackend()
+_select_backend(::Val{:threads}, ::ForceField, ::Type) = ThreadedBackend(Threads.nthreads())
 _select_backend(::Val{B}, ::ForceField, ::Type) where B =
-    throw(ArgumentError("unknown backend :$B (available: :serial)"))
+    throw(ArgumentError("unknown backend :$B (available: :serial, :threads)"))
 
 @inline _row(cff::CompiledForceField, atom) = cff.idx2row[atom.idx]
 

--- a/src/forcefields/common/compiled_forcefield.jl
+++ b/src/forcefields/common/compiled_forcefield.jl
@@ -130,6 +130,9 @@ mutable struct CompiledForceField{T, Acc, B <: EvalBackend}
     max_displacement::Acc
     r_at_last_build::Vector{Vector3{Acc}}
     iters_since_build::Int
+
+    # device-resident state for the GPU backend (nothing for CPU backends)
+    gpu::Any
 end
 
 @inline accumulation_type(::CompiledForceField{T, Acc}) where {T, Acc} = Acc
@@ -200,6 +203,7 @@ function compile(ff::ForceField{T};
         constrained_mask,
         Int(update_frequency), Acc(max_displacement),
         Vector{Vector3{Acc}}(undef, natoms), 0,
+        nothing,
     )
 
     # auto-derive a safe Verlet skin from the cutoffs unless overridden: a pair
@@ -214,13 +218,42 @@ function compile(ff::ForceField{T};
     _lower_bonded!(cff)
     sync_positions_from_table!(cff)   # fill cff.r from the table FIRST
     rebuild_pairlist!(cff)            # then lower nonbonded + snapshot positions
+    _backend_init!(cff)               # GPU extensions allocate/upload device state here
     cff
 end
 
 _select_backend(::Val{:serial}, ::ForceField, ::Type) = SerialBackend()
 _select_backend(::Val{:threads}, ::ForceField, ::Type) = ThreadedBackend(Threads.nthreads())
+function _select_backend(::Val{:gpu}, ff::ForceField, ::Type{Acc}) where Acc
+    hasmethod(_make_gpu_backend, Tuple{ForceField, Type}) || throw(ArgumentError(
+        "the :gpu backend needs `using KernelAbstractions` plus a device package " *
+        "(`using Metal` on Apple Silicon, or `using CUDA`)"))
+    _make_gpu_backend(ff, Acc)
+end
 _select_backend(::Val{B}, ::ForceField, ::Type) where B =
-    throw(ArgumentError("unknown backend :$B (available: :serial, :threads)"))
+    throw(ArgumentError("unknown backend :$B (available: :serial, :threads, :gpu)"))
+
+# Implemented by the KernelAbstractions extension (BiochemicalAlgorithmsGPUExt).
+function _make_gpu_backend end
+
+# GPU device registry. Filled by the Metal/CUDA package extensions when loaded;
+# the device-agnostic KernelAbstractions kernels live in the GPU extension.
+const _GPU_DEVICE = Ref{Any}(nothing)
+
+"""
+    _register_gpu_device!(device; supports_f64)
+
+Called by the Metal/CUDA package extensions on load to register a
+KernelAbstractions device for the `:gpu` backend.
+"""
+function _register_gpu_device!(device; supports_f64::Bool)
+    _GPU_DEVICE[] = (device = device, f64 = supports_f64)
+    nothing
+end
+
+# Hooks specialized for the GPU backend in ff_gpu.jl (no-ops for CPU backends).
+_backend_init!(::CompiledForceField) = nothing        # called at end of compile
+_backend_upload_pairs!(::CompiledForceField) = nothing # called at end of rebuild_pairlist!
 
 @inline _row(cff::CompiledForceField, atom) = cff.idx2row[atom.idx]
 
@@ -312,6 +345,7 @@ function rebuild_pairlist!(cff::CompiledForceField{T, Acc}) where {T, Acc}
         cff.r_at_last_build[k] = cff.r[k]
     end
     cff.iters_since_build = 0
+    _backend_upload_pairs!(cff)   # GPU extensions re-upload the new pair arrays
     cff
 end
 

--- a/src/forcefields/common/ff_kernels.jl
+++ b/src/forcefields/common/ff_kernels.jl
@@ -60,14 +60,78 @@ function _energy_torsion(cff::CompiledForceField{T, Acc}, t::TorsionArrays{Acc})
 end
 
 # ---------------------------------------------------------------------------
+#  Per-pair nonbonded math (scalar; shared by serial / threaded / GPU loops).
+#
+#  Energy helpers return the pair's energy contribution given the squared
+#  distance `sq`. Force helpers return a scalar `factor` such that the force on
+#  atom i is `factor * (r_i - r_j)` (and `-factor * (r_i - r_j)` on j) — every
+#  nonbonded force in the reference has exactly this form, so a single scalar
+#  unifies the CPU (SVector) and GPU (scalar SoA) loops.
+# ---------------------------------------------------------------------------
+@inline function _e_lj_pair(sq::Acc, A, B, scaling, sw::CubicSwitchingFunction{Acc}) where Acc
+    inv6 = sq^-3
+    inv6 * (inv6 * A - B) * scaling * switching_function(sw, sq)
+end
+
+@inline function _e_hb_pair(sq::Acc, A, B, scaling, sw::CubicSwitchingFunction{Acc}) where Acc
+    # precedence transcribed verbatim: scaling/switching multiply 2nd term only
+    sq^-6 * A - sq^-5 * B * scaling * switching_function(sw, sq)
+end
+
+@inline function _e_es_pair(sq::Acc, q1q2, scaling, sw::CubicSwitchingFunction{Acc},
+                            ddd::Bool, pref::Acc) where Acc
+    inner = ddd ? q1q2 / 4 / sq : q1q2 / sqrt(sq)
+    inner * scaling * switching_function(sw, sq) * pref
+end
+
+@inline function _f_lj_factor(sq::Acc, A, B, scaling, sw::CubicSwitchingFunction{Acc}) where Acc
+    (sq > zero(Acc) && sq <= sw.sq_cutoff) || return zero(Acc)
+    inv6 = sq^-3
+    factor = (one(Acc) / sq) * inv6 * scaling * (12 * A * inv6 - 6 * B)
+    if sq > sw.sq_cuton
+        sval, sder = switching_derivative(sw, sq)
+        factor *= sval
+        factor += sder * (-scaling * inv6 * (inv6 * A - B))
+    end
+    factor
+end
+
+@inline function _f_hb_factor(sq::Acc, A, B, scaling, sw::CubicSwitchingFunction{Acc}) where Acc
+    (sq > zero(Acc) && sq <= sw.sq_cutoff) || return zero(Acc)
+    inv2 = one(Acc) / sq
+    factor = inv2 * sq^-6 * (12 * A * inv2 - 10 * B)
+    if sq > sw.sq_cuton
+        sval, sder = switching_derivative(sw, sq)
+        factor *= sval
+        factor += sder * (-scaling * sq^-5 * (A * inv2 - B))
+    end
+    factor
+end
+
+@inline function _f_es_factor(sq::Acc, q1q2, scaling, sw::CubicSwitchingFunction{Acc},
+                              ddd::Bool, pref::Acc) where Acc
+    (sq > zero(Acc) && sq <= sw.sq_cutoff) || return zero(Acc)
+    inv2 = one(Acc) / sq
+    inv = sqrt(inv2)
+    factor = q1q2 * inv2 * scaling * pref
+    factor *= ddd ? Acc(0.5) * inv2 : inv
+    if sq > sw.sq_cuton
+        sval, sder = switching_derivative(sw, sq)
+        factor *= sval
+        ddf = ddd ? Acc(0.25) * inv : one(Acc)
+        factor += sder * (-pref * scaling * ddf * inv * q1q2)
+    end
+    factor
+end
+
+# ---------------------------------------------------------------------------
 #  Nonbonded ENERGY over a pair-index range [lo, hi] (returns Acc partial sum)
 # ---------------------------------------------------------------------------
 @inline function _sum_lj(r, p::PairLJArrays{Acc}, sw::CubicSwitchingFunction{Acc}, lo, hi) where Acc
     e = zero(Acc)
     @inbounds for n in lo:hi
         sq = squared_norm(r[p.i[n]] - r[p.j[n]])
-        inv6 = sq^-3
-        e += inv6 * (inv6 * p.A[n] - p.B[n]) * p.scaling[n] * switching_function(sw, sq)
+        e += _e_lj_pair(sq, p.A[n], p.B[n], p.scaling[n], sw)
     end
     e
 end
@@ -76,8 +140,7 @@ end
     e = zero(Acc)
     @inbounds for n in lo:hi
         sq = squared_norm(r[p.i[n]] - r[p.j[n]])
-        # precedence transcribed verbatim: scaling/switching multiply 2nd term only
-        e += sq^-6 * p.A[n] - sq^-5 * p.B[n] * p.scaling[n] * switching_function(sw, sq)
+        e += _e_hb_pair(sq, p.A[n], p.B[n], p.scaling[n], sw)
     end
     e
 end
@@ -87,8 +150,7 @@ end
     e = zero(Acc)
     @inbounds for n in lo:hi
         sq = squared_norm(r[p.i[n]] - r[p.j[n]])
-        inner = ddd ? p.q1q2[n] / 4 / sq : p.q1q2[n] / sqrt(sq)
-        e += inner * p.scaling[n] * switching_function(sw, sq) * pref
+        e += _e_es_pair(sq, p.q1q2[n], p.scaling[n], sw, ddd, pref)
     end
     e
 end
@@ -175,17 +237,7 @@ end
     @inbounds for n in lo:hi
         i = p.i[n]; j = p.j[n]
         direction = r[i] - r[j]
-        sq = squared_norm(direction)
-        (sq > zero(Acc) && sq <= sw.sq_cutoff) || continue
-        factor = one(Acc) / sq
-        inv6 = sq^-3
-        factor *= inv6 * p.scaling[n] * (12 * p.A[n] * inv6 - 6 * p.B[n])
-        if sq > sw.sq_cuton
-            sval, sder = switching_derivative(sw, sq)
-            factor *= sval
-            energy = -p.scaling[n] * inv6 * (inv6 * p.A[n] - p.B[n])
-            factor += sder * energy
-        end
+        factor = _f_lj_factor(squared_norm(direction), p.A[n], p.B[n], p.scaling[n], sw)
         force = factor * direction
         F[i] += force
         F[j] -= force
@@ -197,19 +249,7 @@ end
     @inbounds for n in lo:hi
         i = p.i[n]; j = p.j[n]
         direction = r[i] - r[j]
-        sq = squared_norm(direction)
-        (sq > zero(Acc) && sq <= sw.sq_cutoff) || continue
-        inv2 = one(Acc) / sq
-        inv10 = sq^-5
-        inv12 = sq^-6
-        factor = inv2
-        factor *= inv12 * (12 * p.A[n] * inv2 - 10 * p.B[n])
-        if sq > sw.sq_cuton
-            sval, sder = switching_derivative(sw, sq)
-            factor *= sval
-            energy = -p.scaling[n] * inv10 * (p.A[n] * inv2 - p.B[n])
-            factor += sder * energy
-        end
+        factor = _f_hb_factor(squared_norm(direction), p.A[n], p.B[n], p.scaling[n], sw)
         force = factor * direction
         F[i] += force
         F[j] -= force
@@ -222,23 +262,7 @@ end
     @inbounds for n in lo:hi
         i = p.i[n]; j = p.j[n]
         direction = r[i] - r[j]
-        sq = squared_norm(direction)
-        (sq > zero(Acc) && sq <= sw.sq_cutoff) || continue
-        inv2 = one(Acc) / sq
-        inv = sqrt(inv2)
-        factor = p.q1q2[n] * inv2 * p.scaling[n] * pref
-        if ddd
-            factor *= Acc(0.5) * inv2
-        else
-            factor *= inv
-        end
-        if sq > sw.sq_cuton
-            sval, sder = switching_derivative(sw, sq)
-            factor *= sval
-            ddf = ddd ? Acc(0.25) * inv : one(Acc)
-            energy = -pref * p.scaling[n] * ddf * inv * p.q1q2[n]
-            factor += sder * energy
-        end
+        factor = _f_es_factor(squared_norm(direction), p.q1q2[n], p.scaling[n], sw, ddd, pref)
         force = factor * direction
         F[i] += force
         F[j] -= force

--- a/src/forcefields/common/ff_kernels.jl
+++ b/src/forcefields/common/ff_kernels.jl
@@ -1,0 +1,305 @@
+# ============================================================================
+#  Energy / force kernels for the CompiledForceField.
+#
+#  Every formula here is a verbatim transcription of the corresponding
+#  `compute_energy` / `compute_forces!` in the reference components, rewritten
+#  to read positions from `cff.r[row]` and accumulate forces into `cff.F[row]`
+#  (no `Atom{T}` row-views, no Dict lookups). With acc == storage type the
+#  results match the reference path bit-for-bit.
+#
+#  Stage 1 provides the SerialBackend; later stages add threaded / GPU loops
+#  that call the same per-interaction math.
+# ============================================================================
+
+# ---------------------------------------------------------------------------
+#  Per-component ENERGY (serial accumulation in Acc)
+# ---------------------------------------------------------------------------
+function _energy_stretch(cff::CompiledForceField{T, Acc}) where {T, Acc}
+    s = cff.stretch; r = cff.r
+    e = zero(Acc)
+    @inbounds for n in eachindex(s.k)
+        d = norm(r[s.i[n]] - r[s.j[n]])
+        e += s.k[n] * (d - s.r0[n])^2
+    end
+    e
+end
+
+function _energy_bend(cff::CompiledForceField{T, Acc}) where {T, Acc}
+    b = cff.bend; r = cff.r
+    e = zero(Acc)
+    @inbounds for n in eachindex(b.k)
+        v1 = r[b.i[n]] - r[b.j[n]]
+        v2 = r[b.l[n]] - r[b.j[n]]
+        sq_length = squared_norm(v1) * squared_norm(v2)
+        iszero(sq_length) && continue
+        cos_θ = dot(v1, v2) / sqrt(sq_length)
+        θ = cos_θ > one(Acc) ? zero(Acc) : cos_θ < -one(Acc) ? Acc(π) : acos(cos_θ)
+        e += b.k[n] * (θ - b.θ0[n])^2
+    end
+    e
+end
+
+function _energy_torsion(cff::CompiledForceField{T, Acc}, t::TorsionArrays{Acc}) where {T, Acc}
+    r = cff.r
+    e = zero(Acc)
+    @inbounds for n in eachindex(t.i)
+        a23 = r[t.k[n]] - r[t.j[n]]
+        cross2321 = normalize(cross(a23, r[t.i[n]] - r[t.j[n]]))
+        cross2334 = normalize(cross(a23, r[t.l[n]] - r[t.k[n]]))
+        (isnan(cross2321[1]) || isnan(cross2334[1])) && continue
+        cos_ϕ = clamp(dot(cross2321, cross2334), -one(Acc), one(Acc))
+        acϕ = acos(cos_ϕ)
+        lo = t.term_offset[n]; hi = t.term_offset[n+1] - one(Int32)
+        for m in lo:hi
+            e += t.V[m] / t.div[m] * (one(Acc) + cos(t.f[m] * acϕ - t.ϕ0[m]))
+        end
+    end
+    e
+end
+
+function _energy_lj(cff::CompiledForceField{T, Acc}) where {T, Acc}
+    p = cff.lj; r = cff.r; sw = cff.vdw_sw
+    e = zero(Acc)
+    @inbounds for n in eachindex(p.i)
+        sq = squared_norm(r[p.i[n]] - r[p.j[n]])
+        inv6 = sq^-3
+        e += inv6 * (inv6 * p.A[n] - p.B[n]) * p.scaling[n] * switching_function(sw, sq)
+    end
+    e
+end
+
+function _energy_hb(cff::CompiledForceField{T, Acc}) where {T, Acc}
+    p = cff.hb; r = cff.r; sw = cff.vdw_sw
+    e = zero(Acc)
+    @inbounds for n in eachindex(p.i)
+        sq = squared_norm(r[p.i[n]] - r[p.j[n]])
+        # NOTE: precedence transcribed verbatim from the reference (scaling and
+        # switching multiply only the second term).
+        e += sq^-6 * p.A[n] - sq^-5 * p.B[n] * p.scaling[n] * switching_function(sw, sq)
+    end
+    e
+end
+
+function _energy_es(cff::CompiledForceField{T, Acc}) where {T, Acc}
+    p = cff.es; r = cff.r; sw = cff.es_sw
+    ddd = cff.distance_dependent_dielectric
+    pref = cff.es_prefactor
+    e = zero(Acc)
+    @inbounds for n in eachindex(p.i)
+        sq = squared_norm(r[p.i[n]] - r[p.j[n]])
+        inner = ddd ? p.q1q2[n] / 4 / sq : p.q1q2[n] / sqrt(sq)
+        e += inner * p.scaling[n] * switching_function(sw, sq) * pref
+    end
+    e
+end
+
+# ---------------------------------------------------------------------------
+#  Per-component FORCES (serial accumulation into cff.F)
+# ---------------------------------------------------------------------------
+function _force_stretch!(cff::CompiledForceField{T, Acc}) where {T, Acc}
+    s = cff.stretch; r = cff.r; F = cff.F
+    @inbounds for n in eachindex(s.k)
+        i = s.i[n]; j = s.j[n]
+        direction = r[i] - r[j]
+        d = norm(direction)
+        d == zero(Acc) && continue
+        direction *= 2 * s.k[n] * (d - s.r0[n]) / d
+        F[i] -= direction
+        F[j] += direction
+    end
+    nothing
+end
+
+function _force_bend!(cff::CompiledForceField{T, Acc}) where {T, Acc}
+    b = cff.bend; r = cff.r; F = cff.F
+    @inbounds for n in eachindex(b.k)
+        i = b.i[n]; j = b.j[n]; l = b.l[n]
+        v1 = r[i] - r[j]
+        v2 = r[l] - r[j]
+        v1_length = norm(v1); v2_length = norm(v2)
+        (v1_length == zero(Acc) || v2_length == zero(Acc)) && continue
+        v1 = v1 / v1_length
+        v2 = v2 / v2_length
+        cos_θ = dot(v1, v2)
+        θ = cos_θ > one(Acc) ? zero(Acc) : cos_θ < -one(Acc) ? Acc(π) : acos(cos_θ)
+        factor = 2 * b.k[n] * (θ - b.θ0[n])
+        crossv1v2 = normalize(cross(v1, v2))
+        isnan(crossv1v2[1]) && continue
+        n1 = cross(v1, crossv1v2) .* factor ./ v1_length
+        n2 = cross(v2, crossv1v2) .* factor ./ v2_length
+        F[i] -= n1
+        F[j] += n1
+        F[j] -= n2
+        F[l] += n2
+    end
+    nothing
+end
+
+function _force_torsion!(cff::CompiledForceField{T, Acc}, t::TorsionArrays{Acc}) where {T, Acc}
+    r = cff.r; F = cff.F
+    @inbounds for n in eachindex(t.i)
+        i = t.i[n]; j = t.j[n]; k = t.k[n]; l = t.l[n]
+        a21 = r[i] - r[j]
+        a23 = r[k] - r[j]
+        a34 = r[l] - r[k]
+        cross2321 = cross(a23, a21)
+        cross2334 = cross(a23, a34)
+        len1 = norm(cross2321); len2 = norm(cross2334)
+        (len1 == zero(Acc) || len2 == zero(Acc)) && continue
+        cos_ϕ = clamp(dot(cross2321, cross2334) / (len1 * len2), -one(Acc), one(Acc))
+        acϕ = acos(cos_ϕ)
+        lo = t.term_offset[n]; hi = t.term_offset[n+1] - one(Int32)
+        ∂E∂ϕ = zero(Acc)
+        for m in lo:hi
+            ∂E∂ϕ += -t.V[m] / t.div[m] * t.f[m] * sin(t.f[m] * acϕ - t.ϕ0[m])
+        end
+        direction = dot(cross(cross2321, cross2334), a23)
+        direction > zero(Acc) && (∂E∂ϕ = -∂E∂ϕ)
+        a13 = r[k] - r[i]
+        a24 = r[l] - r[j]
+        na23 = norm(a23)
+        dEdt =  (∂E∂ϕ / (len1^2 * na23)) * cross(cross2321, a23)
+        dEdu = -(∂E∂ϕ / (len2^2 * na23)) * cross(cross2334, a23)
+        F[i] += cross(dEdt, a23)
+        F[j] += cross(a13, dEdt) + cross(dEdu, a34)
+        F[k] += cross(a21, dEdt) + cross(a24, dEdu)
+        F[l] += cross(dEdu, a23)
+    end
+    nothing
+end
+
+function _force_lj!(cff::CompiledForceField{T, Acc}) where {T, Acc}
+    p = cff.lj; r = cff.r; F = cff.F; sw = cff.vdw_sw
+    @inbounds for n in eachindex(p.i)
+        i = p.i[n]; j = p.j[n]
+        direction = r[i] - r[j]
+        sq = squared_norm(direction)
+        (sq > zero(Acc) && sq <= sw.sq_cutoff) || continue
+        factor = one(Acc) / sq
+        inv6 = sq^-3
+        factor *= inv6 * p.scaling[n] * (12 * p.A[n] * inv6 - 6 * p.B[n])
+        if sq > sw.sq_cuton
+            sval, sder = switching_derivative(sw, sq)
+            factor *= sval
+            energy = -p.scaling[n] * inv6 * (inv6 * p.A[n] - p.B[n])
+            factor += sder * energy
+        end
+        force = factor * direction
+        F[i] += force
+        F[j] -= force
+    end
+    nothing
+end
+
+function _force_hb!(cff::CompiledForceField{T, Acc}) where {T, Acc}
+    p = cff.hb; r = cff.r; F = cff.F; sw = cff.vdw_sw
+    @inbounds for n in eachindex(p.i)
+        i = p.i[n]; j = p.j[n]
+        direction = r[i] - r[j]
+        sq = squared_norm(direction)
+        (sq > zero(Acc) && sq <= sw.sq_cutoff) || continue
+        inv2 = one(Acc) / sq
+        inv10 = sq^-5
+        inv12 = sq^-6
+        factor = inv2
+        factor *= inv12 * (12 * p.A[n] * inv2 - 10 * p.B[n])
+        if sq > sw.sq_cuton
+            sval, sder = switching_derivative(sw, sq)
+            factor *= sval
+            energy = -p.scaling[n] * inv10 * (p.A[n] * inv2 - p.B[n])
+            factor += sder * energy
+        end
+        force = factor * direction
+        F[i] += force
+        F[j] -= force
+    end
+    nothing
+end
+
+function _force_es!(cff::CompiledForceField{T, Acc}) where {T, Acc}
+    p = cff.es; r = cff.r; F = cff.F; sw = cff.es_sw
+    ddd = cff.distance_dependent_dielectric
+    pref = cff.es_prefactor_force
+    @inbounds for n in eachindex(p.i)
+        i = p.i[n]; j = p.j[n]
+        direction = r[i] - r[j]
+        sq = squared_norm(direction)
+        (sq > zero(Acc) && sq <= sw.sq_cutoff) || continue
+        inv2 = one(Acc) / sq
+        inv = sqrt(inv2)
+        factor = p.q1q2[n] * inv2 * p.scaling[n] * pref
+        if ddd
+            factor *= Acc(0.5) * inv2
+        else
+            factor *= inv
+        end
+        if sq > sw.sq_cuton
+            sval, sder = switching_derivative(sw, sq)
+            factor *= sval
+            ddf = ddd ? Acc(0.25) * inv : one(Acc)
+            energy = -pref * p.scaling[n] * ddf * inv * p.q1q2[n]
+            factor += sder * energy
+        end
+        force = factor * direction
+        F[i] += force
+        F[j] -= force
+    end
+    nothing
+end
+
+# ---------------------------------------------------------------------------
+#  Public evaluation entry points (dispatch on backend)
+# ---------------------------------------------------------------------------
+"""
+    compute_energy!(cff::CompiledForceField) -> Acc
+
+Evaluate the total energy at the evaluator's current coordinates, filling
+`cff.energy` with the per-category breakdown (same keys as the reference
+`ForceField` path).
+"""
+function compute_energy!(cff::CompiledForceField{T, Acc, SerialBackend}) where {T, Acc}
+    stretch   = _energy_stretch(cff)
+    bend      = _energy_bend(cff)
+    proper    = _energy_torsion(cff, cff.proper)
+    improper  = _energy_torsion(cff, cff.improper)
+    vdw       = _energy_lj(cff)
+    hbond     = _energy_hb(cff)
+    es        = _energy_es(cff)
+
+    cff.energy["Bond Stretches"]   = stretch
+    cff.energy["Angle Bends"]      = bend
+    cff.energy["Proper Torsion"]   = proper
+    cff.energy["Improper Torsion"] = improper
+    cff.energy["Van der Waals"]    = vdw
+    cff.energy["Hydrogen Bonds"]   = hbond
+    cff.energy["Electrostatic"]    = es
+
+    stretch + bend + proper + improper + vdw + hbond + es
+end
+
+"""
+    compute_forces!(cff::CompiledForceField)
+
+Zero and recompute forces at the current coordinates, accumulating into
+`cff.F`. Forces on constrained atoms are zeroed afterwards.
+"""
+function compute_forces!(cff::CompiledForceField{T, Acc, SerialBackend}) where {T, Acc}
+    fill!(cff.F, zero(Vector3{Acc}))
+    _force_stretch!(cff)
+    _force_bend!(cff)
+    _force_torsion!(cff, cff.proper)
+    _force_torsion!(cff, cff.improper)
+    _force_lj!(cff)
+    _force_hb!(cff)
+    _force_es!(cff)
+    _apply_constraints!(cff)
+    nothing
+end
+
+@inline function _apply_constraints!(cff::CompiledForceField{T, Acc}) where {T, Acc}
+    any(cff.constrained_mask) || return nothing
+    @inbounds for k in 1:cff.natoms
+        cff.constrained_mask[k] && (cff.F[k] = zero(Vector3{Acc}))
+    end
+    nothing
+end

--- a/src/forcefields/common/ff_kernels.jl
+++ b/src/forcefields/common/ff_kernels.jl
@@ -3,16 +3,18 @@
 #
 #  Every formula here is a verbatim transcription of the corresponding
 #  `compute_energy` / `compute_forces!` in the reference components, rewritten
-#  to read positions from `cff.r[row]` and accumulate forces into `cff.F[row]`
-#  (no `Atom{T}` row-views, no Dict lookups). With acc == storage type the
-#  results match the reference path bit-for-bit.
+#  to read positions from `cff.r[row]` and accumulate forces into a row-indexed
+#  force buffer (no `Atom{T}` row-views, no Dict lookups). With acc == storage
+#  type the results match the reference path bit-for-bit.
 #
-#  Stage 1 provides the SerialBackend; later stages add threaded / GPU loops
-#  that call the same per-interaction math.
+#  The nonbonded loops are written over an index range [lo, hi] so the same code
+#  serves the serial backend (one range) and the threaded backend (one range
+#  per thread, into per-thread force buffers). Bonded terms are cheap and remain
+#  serial.
 # ============================================================================
 
 # ---------------------------------------------------------------------------
-#  Per-component ENERGY (serial accumulation in Acc)
+#  Bonded ENERGY (serial accumulation in Acc)
 # ---------------------------------------------------------------------------
 function _energy_stretch(cff::CompiledForceField{T, Acc}) where {T, Acc}
     s = cff.stretch; r = cff.r
@@ -57,10 +59,12 @@ function _energy_torsion(cff::CompiledForceField{T, Acc}, t::TorsionArrays{Acc})
     e
 end
 
-function _energy_lj(cff::CompiledForceField{T, Acc}) where {T, Acc}
-    p = cff.lj; r = cff.r; sw = cff.vdw_sw
+# ---------------------------------------------------------------------------
+#  Nonbonded ENERGY over a pair-index range [lo, hi] (returns Acc partial sum)
+# ---------------------------------------------------------------------------
+@inline function _sum_lj(r, p::PairLJArrays{Acc}, sw::CubicSwitchingFunction{Acc}, lo, hi) where Acc
     e = zero(Acc)
-    @inbounds for n in eachindex(p.i)
+    @inbounds for n in lo:hi
         sq = squared_norm(r[p.i[n]] - r[p.j[n]])
         inv6 = sq^-3
         e += inv6 * (inv6 * p.A[n] - p.B[n]) * p.scaling[n] * switching_function(sw, sq)
@@ -68,24 +72,20 @@ function _energy_lj(cff::CompiledForceField{T, Acc}) where {T, Acc}
     e
 end
 
-function _energy_hb(cff::CompiledForceField{T, Acc}) where {T, Acc}
-    p = cff.hb; r = cff.r; sw = cff.vdw_sw
+@inline function _sum_hb(r, p::PairLJArrays{Acc}, sw::CubicSwitchingFunction{Acc}, lo, hi) where Acc
     e = zero(Acc)
-    @inbounds for n in eachindex(p.i)
+    @inbounds for n in lo:hi
         sq = squared_norm(r[p.i[n]] - r[p.j[n]])
-        # NOTE: precedence transcribed verbatim from the reference (scaling and
-        # switching multiply only the second term).
+        # precedence transcribed verbatim: scaling/switching multiply 2nd term only
         e += sq^-6 * p.A[n] - sq^-5 * p.B[n] * p.scaling[n] * switching_function(sw, sq)
     end
     e
 end
 
-function _energy_es(cff::CompiledForceField{T, Acc}) where {T, Acc}
-    p = cff.es; r = cff.r; sw = cff.es_sw
-    ddd = cff.distance_dependent_dielectric
-    pref = cff.es_prefactor
+@inline function _sum_es(r, p::PairESArrays{Acc}, sw::CubicSwitchingFunction{Acc},
+                         ddd::Bool, pref::Acc, lo, hi) where Acc
     e = zero(Acc)
-    @inbounds for n in eachindex(p.i)
+    @inbounds for n in lo:hi
         sq = squared_norm(r[p.i[n]] - r[p.j[n]])
         inner = ddd ? p.q1q2[n] / 4 / sq : p.q1q2[n] / sqrt(sq)
         e += inner * p.scaling[n] * switching_function(sw, sq) * pref
@@ -94,10 +94,10 @@ function _energy_es(cff::CompiledForceField{T, Acc}) where {T, Acc}
 end
 
 # ---------------------------------------------------------------------------
-#  Per-component FORCES (serial accumulation into cff.F)
+#  Bonded FORCES (serial accumulation into a row-indexed buffer F)
 # ---------------------------------------------------------------------------
-function _force_stretch!(cff::CompiledForceField{T, Acc}) where {T, Acc}
-    s = cff.stretch; r = cff.r; F = cff.F
+function _force_stretch!(F, cff::CompiledForceField{T, Acc}) where {T, Acc}
+    s = cff.stretch; r = cff.r
     @inbounds for n in eachindex(s.k)
         i = s.i[n]; j = s.j[n]
         direction = r[i] - r[j]
@@ -110,8 +110,8 @@ function _force_stretch!(cff::CompiledForceField{T, Acc}) where {T, Acc}
     nothing
 end
 
-function _force_bend!(cff::CompiledForceField{T, Acc}) where {T, Acc}
-    b = cff.bend; r = cff.r; F = cff.F
+function _force_bend!(F, cff::CompiledForceField{T, Acc}) where {T, Acc}
+    b = cff.bend; r = cff.r
     @inbounds for n in eachindex(b.k)
         i = b.i[n]; j = b.j[n]; l = b.l[n]
         v1 = r[i] - r[j]
@@ -135,8 +135,8 @@ function _force_bend!(cff::CompiledForceField{T, Acc}) where {T, Acc}
     nothing
 end
 
-function _force_torsion!(cff::CompiledForceField{T, Acc}, t::TorsionArrays{Acc}) where {T, Acc}
-    r = cff.r; F = cff.F
+function _force_torsion!(F, cff::CompiledForceField{T, Acc}, t::TorsionArrays{Acc}) where {T, Acc}
+    r = cff.r
     @inbounds for n in eachindex(t.i)
         i = t.i[n]; j = t.j[n]; k = t.k[n]; l = t.l[n]
         a21 = r[i] - r[j]
@@ -168,9 +168,11 @@ function _force_torsion!(cff::CompiledForceField{T, Acc}, t::TorsionArrays{Acc})
     nothing
 end
 
-function _force_lj!(cff::CompiledForceField{T, Acc}) where {T, Acc}
-    p = cff.lj; r = cff.r; F = cff.F; sw = cff.vdw_sw
-    @inbounds for n in eachindex(p.i)
+# ---------------------------------------------------------------------------
+#  Nonbonded FORCES over a pair-index range [lo, hi] into buffer F
+# ---------------------------------------------------------------------------
+@inline function _accum_lj!(F, r, p::PairLJArrays{Acc}, sw::CubicSwitchingFunction{Acc}, lo, hi) where Acc
+    @inbounds for n in lo:hi
         i = p.i[n]; j = p.j[n]
         direction = r[i] - r[j]
         sq = squared_norm(direction)
@@ -191,9 +193,8 @@ function _force_lj!(cff::CompiledForceField{T, Acc}) where {T, Acc}
     nothing
 end
 
-function _force_hb!(cff::CompiledForceField{T, Acc}) where {T, Acc}
-    p = cff.hb; r = cff.r; F = cff.F; sw = cff.vdw_sw
-    @inbounds for n in eachindex(p.i)
+@inline function _accum_hb!(F, r, p::PairLJArrays{Acc}, sw::CubicSwitchingFunction{Acc}, lo, hi) where Acc
+    @inbounds for n in lo:hi
         i = p.i[n]; j = p.j[n]
         direction = r[i] - r[j]
         sq = squared_norm(direction)
@@ -216,11 +217,9 @@ function _force_hb!(cff::CompiledForceField{T, Acc}) where {T, Acc}
     nothing
 end
 
-function _force_es!(cff::CompiledForceField{T, Acc}) where {T, Acc}
-    p = cff.es; r = cff.r; F = cff.F; sw = cff.es_sw
-    ddd = cff.distance_dependent_dielectric
-    pref = cff.es_prefactor_force
-    @inbounds for n in eachindex(p.i)
+@inline function _accum_es!(F, r, p::PairESArrays{Acc}, sw::CubicSwitchingFunction{Acc},
+                            ddd::Bool, pref::Acc, lo, hi) where Acc
+    @inbounds for n in lo:hi
         i = p.i[n]; j = p.j[n]
         direction = r[i] - r[j]
         sq = squared_norm(direction)
@@ -247,6 +246,29 @@ function _force_es!(cff::CompiledForceField{T, Acc}) where {T, Acc}
     nothing
 end
 
+# even split of 1:N into `nt` contiguous chunks; returns (lo, hi) for chunk t
+@inline function _chunk(N::Integer, nt::Integer, t::Integer)
+    lo = ((t - 1) * N) ÷ nt + 1
+    hi = (t * N) ÷ nt
+    (lo, hi)
+end
+
+# ---------------------------------------------------------------------------
+#  Bonded energy/force convenience (shared by all backends)
+# ---------------------------------------------------------------------------
+function _energy_bonded(cff::CompiledForceField{T, Acc}) where {T, Acc}
+    _energy_stretch(cff), _energy_bend(cff),
+    _energy_torsion(cff, cff.proper), _energy_torsion(cff, cff.improper)
+end
+
+function _force_bonded!(F, cff::CompiledForceField)
+    _force_stretch!(F, cff)
+    _force_bend!(F, cff)
+    _force_torsion!(F, cff, cff.proper)
+    _force_torsion!(F, cff, cff.improper)
+    nothing
+end
+
 # ---------------------------------------------------------------------------
 #  Public evaluation entry points (dispatch on backend)
 # ---------------------------------------------------------------------------
@@ -258,14 +280,30 @@ Evaluate the total energy at the evaluator's current coordinates, filling
 `ForceField` path).
 """
 function compute_energy!(cff::CompiledForceField{T, Acc, SerialBackend}) where {T, Acc}
-    stretch   = _energy_stretch(cff)
-    bend      = _energy_bend(cff)
-    proper    = _energy_torsion(cff, cff.proper)
-    improper  = _energy_torsion(cff, cff.improper)
-    vdw       = _energy_lj(cff)
-    hbond     = _energy_hb(cff)
-    es        = _energy_es(cff)
+    r = cff.r
+    nlj = length(cff.lj.i); nhb = length(cff.hb.i); nes = length(cff.es.i)
+    vdw   = _sum_lj(r, cff.lj, cff.vdw_sw, 1, nlj)
+    hbond = _sum_hb(r, cff.hb, cff.vdw_sw, 1, nhb)
+    es    = _sum_es(r, cff.es, cff.es_sw, cff.distance_dependent_dielectric, cff.es_prefactor, 1, nes)
+    _finish_energy!(cff, vdw, hbond, es)
+end
 
+function compute_energy!(cff::CompiledForceField{T, Acc, ThreadedBackend}) where {T, Acc}
+    r = cff.r
+    nt = length(cff.F_threads)
+    vdwp = zeros(Acc, nt); hbp = zeros(Acc, nt); esp = zeros(Acc, nt)
+    nlj = length(cff.lj.i); nhb = length(cff.hb.i); nes = length(cff.es.i)
+    Threads.@threads :static for t in 1:nt
+        lo, hi = _chunk(nlj, nt, t); vdwp[t] = _sum_lj(r, cff.lj, cff.vdw_sw, lo, hi)
+        lo, hi = _chunk(nhb, nt, t); hbp[t]  = _sum_hb(r, cff.hb, cff.vdw_sw, lo, hi)
+        lo, hi = _chunk(nes, nt, t); esp[t]  = _sum_es(r, cff.es, cff.es_sw,
+            cff.distance_dependent_dielectric, cff.es_prefactor, lo, hi)
+    end
+    _finish_energy!(cff, sum(vdwp), sum(hbp), sum(esp))
+end
+
+function _finish_energy!(cff::CompiledForceField{T, Acc}, vdw, hbond, es) where {T, Acc}
+    stretch, bend, proper, improper = _energy_bonded(cff)
     cff.energy["Bond Stretches"]   = stretch
     cff.energy["Angle Bends"]      = bend
     cff.energy["Proper Torsion"]   = proper
@@ -273,25 +311,49 @@ function compute_energy!(cff::CompiledForceField{T, Acc, SerialBackend}) where {
     cff.energy["Van der Waals"]    = vdw
     cff.energy["Hydrogen Bonds"]   = hbond
     cff.energy["Electrostatic"]    = es
-
     stretch + bend + proper + improper + vdw + hbond + es
 end
 
 """
     compute_forces!(cff::CompiledForceField)
 
-Zero and recompute forces at the current coordinates, accumulating into
-`cff.F`. Forces on constrained atoms are zeroed afterwards.
+Zero and recompute forces at the current coordinates. Forces on constrained
+atoms are zeroed afterwards.
 """
 function compute_forces!(cff::CompiledForceField{T, Acc, SerialBackend}) where {T, Acc}
-    fill!(cff.F, zero(Vector3{Acc}))
-    _force_stretch!(cff)
-    _force_bend!(cff)
-    _force_torsion!(cff, cff.proper)
-    _force_torsion!(cff, cff.improper)
-    _force_lj!(cff)
-    _force_hb!(cff)
-    _force_es!(cff)
+    F = cff.F
+    fill!(F, zero(Vector3{Acc}))
+    _force_bonded!(F, cff)
+    _accum_lj!(F, cff.r, cff.lj, cff.vdw_sw, 1, length(cff.lj.i))
+    _accum_hb!(F, cff.r, cff.hb, cff.vdw_sw, 1, length(cff.hb.i))
+    _accum_es!(F, cff.r, cff.es, cff.es_sw, cff.distance_dependent_dielectric,
+               cff.es_prefactor_force, 1, length(cff.es.i))
+    _apply_constraints!(cff)
+    nothing
+end
+
+function compute_forces!(cff::CompiledForceField{T, Acc, ThreadedBackend}) where {T, Acc}
+    r = cff.r
+    nt = length(cff.F_threads)
+    nlj = length(cff.lj.i); nhb = length(cff.hb.i); nes = length(cff.es.i)
+    Threads.@threads :static for t in 1:nt
+        Ft = cff.F_threads[t]
+        fill!(Ft, zero(Vector3{Acc}))
+        lo, hi = _chunk(nlj, nt, t); _accum_lj!(Ft, r, cff.lj, cff.vdw_sw, lo, hi)
+        lo, hi = _chunk(nhb, nt, t); _accum_hb!(Ft, r, cff.hb, cff.vdw_sw, lo, hi)
+        lo, hi = _chunk(nes, nt, t); _accum_es!(Ft, r, cff.es, cff.es_sw,
+            cff.distance_dependent_dielectric, cff.es_prefactor_force, lo, hi)
+    end
+    # bonded into the main buffer, then reduce the per-thread nonbonded buffers
+    F = cff.F
+    fill!(F, zero(Vector3{Acc}))
+    _force_bonded!(F, cff)
+    @inbounds for t in 1:nt
+        Ft = cff.F_threads[t]
+        for k in 1:cff.natoms
+            F[k] += Ft[k]
+        end
+    end
     _apply_constraints!(cff)
     nothing
 end

--- a/src/forcefields/common/ff_kernels.jl
+++ b/src/forcefields/common/ff_kernels.jl
@@ -238,6 +238,7 @@ end
         i = p.i[n]; j = p.j[n]
         direction = r[i] - r[j]
         factor = _f_lj_factor(squared_norm(direction), p.A[n], p.B[n], p.scaling[n], sw)
+        iszero(factor) && continue          # skip the (zero) force write for out-of-cutoff pairs
         force = factor * direction
         F[i] += force
         F[j] -= force
@@ -250,6 +251,7 @@ end
         i = p.i[n]; j = p.j[n]
         direction = r[i] - r[j]
         factor = _f_hb_factor(squared_norm(direction), p.A[n], p.B[n], p.scaling[n], sw)
+        iszero(factor) && continue
         force = factor * direction
         F[i] += force
         F[j] -= force
@@ -263,6 +265,7 @@ end
         i = p.i[n]; j = p.j[n]
         direction = r[i] - r[j]
         factor = _f_es_factor(squared_norm(direction), p.q1q2[n], p.scaling[n], sw, ddd, pref)
+        iszero(factor) && continue
         force = factor * direction
         F[i] += force
         F[j] -= force

--- a/src/forcefields/common/nonbonded_component.jl
+++ b/src/forcefields/common/nonbonded_component.jl
@@ -371,8 +371,8 @@ function update!(nbc::NonBondedComponent{T}) where T
 
     atom_cache::AtomTable{T} = atoms(ff.system)
     neighbors::Vector{Tuple{Int, Int, T}} = ff.options[:periodic_boundary_conditions]::Bool ?
-        neighborlist(atom_cache.r, unitcell=periodic_box, nonbonded_cutoff) :
-        neighborlist(atom_cache.r, nonbonded_cutoff)
+        neighborlist(positions=atom_cache.r, cutoff=nonbonded_cutoff, unitcell=periodic_box) :
+        neighborlist(positions=atom_cache.r, cutoff=nonbonded_cutoff)
 
     distance_dependent_dielectric = ff.options[:distance_dependent_dielectric]::Bool
 

--- a/src/optimization/optimize_structure.jl
+++ b/src/optimization/optimize_structure.jl
@@ -67,9 +67,15 @@ function optimize_structure!(ff::ForceField{T};
 
     # write the final optimized state back into the canonical atom table
     set_positions_flat!(cff, solution.u)
-    rebuild_pairlist!(cff)
-    compute_forces!(cff)
-    sync_to_table!(cff; forces=true)
+    sync_to_table!(cff; forces=false)
+
+    # Leave the force field consistent with the optimized geometry for the
+    # reference path: `update!` refreshes each component's cached state (the
+    # nonbonded interaction list stores per-pair distances), and
+    # `compute_forces!` repopulates `atoms(system).F`. After this, the usual
+    # `compute_energy!(ff)` / `compute_forces!(ff)` report the minimized state.
+    update!(ff)
+    compute_forces!(ff)
 
     solution
 end

--- a/src/optimization/optimize_structure.jl
+++ b/src/optimization/optimize_structure.jl
@@ -7,33 +7,71 @@ export
 
 Attempts to solve the energy optimization problem represented by the given force field object.
 
+Internally `ff` is compiled into a cached, struct-of-arrays evaluator (see
+[`compile`](@ref)) so the nonbonded pair list is reused across evaluations and
+rebuilt only when atoms drift past a Verlet skin — instead of being rebuilt on
+every energy/force evaluation. The canonical atom table (`atoms(system).r`/`.F`)
+is kept current at every pair-list rebuild and fully synchronized when the
+optimization finishes, so the rest of the library and any registered observables
+see consistent state.
+
 # Supported keyword arguments
-This function passes all keyword arguments to
-[Optimization.solve](https://docs.sciml.ai/Optimization/stable/API/solve/),
-with the following default values:
  - `alg = OptimizationLBFGSB.LBFGSB()`
+ - `accumulation::Type = T` — accumulation precision (`Float32`/`Float64`)
+ - `backend::Symbol = :serial` — evaluation backend
+ - `update_frequency::Integer = 0` — force a rebuild every N evaluations (0 = skin-only)
+ - `max_displacement::Real = -1` — Verlet skin in Å (-1 = auto-derive from cutoffs)
+
+All other keyword arguments are forwarded to
+[Optimization.solve](https://docs.sciml.ai/Optimization/stable/API/solve/).
 """
-function optimize_structure!(ff::ForceField; alg = OptimizationLBFGSB.LBFGSB(), kwargs...)
+function optimize_structure!(ff::ForceField{T};
+        alg = OptimizationLBFGSB.LBFGSB(),
+        accumulation::Type = T,
+        backend::Symbol = :serial,
+        update_frequency::Integer = 0,
+        max_displacement::Real = -1,
+        callback = nothing,
+        kwargs...) where T
+
+    cff = compile(ff; acc=accumulation, backend=backend,
+                  update_frequency=update_frequency, max_displacement=max_displacement)
+
     r0 = collect(Float64, Iterators.flatten(atoms(ff.system).r))
 
     optf = Optimization.OptimizationFunction(
         (r, _ = nothing) -> begin
-            atoms(ff.system).r .= eachcol(reshape(r, 3, :))
-            update!(ff)
-            compute_energy!(ff)
+            prepare_eval!(cff, r)
+            Float64(compute_energy!(cff))
         end,
         grad = (grad, r, _) -> begin
-            update!(ff)
-            compute_forces!(ff)
-            F = atoms(ff.system).F
-            F[ff.constrained_atoms] .= Ref(zeros(3))
-            grad .= -collect(Float64, Iterators.flatten(F))
+            prepare_eval!(cff, r)
+            compute_forces!(cff)
+            gradient_flat!(grad, cff)
             nothing
         end
     )
     prob = Optimization.OptimizationProblem(optf, r0)
 
-    Optimization.solve(prob, alg; kwargs...)
+    # Wrap any user callback so the canonical atom table is synchronized before
+    # the callback fires (the Observable path notifies inside its callback, so
+    # observers/visualization must see current coordinates and forces).
+    solve_cb = callback === nothing ? nothing : (state, loss) -> begin
+        sync_to_table!(cff; forces=true)
+        callback(state, loss)
+    end
+
+    solution = solve_cb === nothing ?
+        Optimization.solve(prob, alg; kwargs...) :
+        Optimization.solve(prob, alg; callback=solve_cb, kwargs...)
+
+    # write the final optimized state back into the canonical atom table
+    set_positions_flat!(cff, solution.u)
+    rebuild_pairlist!(cff)
+    compute_forces!(cff)
+    sync_to_table!(cff; forces=true)
+
+    solution
 end
 
 """

--- a/test/fileformats/test_pdb.jl
+++ b/test/fileformats/test_pdb.jl
@@ -1,11 +1,4 @@
 @testitem "Read PDB" begin
-    using BioStructures:
-        PDBFormat,
-        countatoms,
-        countchains,
-        countresidues,
-        read
-
     for T in [Float32, Float64]
         sys = load_pdb(ball_data_path("../test/data/bpti.pdb"), T)
         @test sys isa System{T}
@@ -181,26 +174,45 @@ end
     for T in [Float32, Float64]
         sys = load_mmcif(ball_data_path("../test/data/5pti.cif"), T)
         @test sys isa System{T}
-        @test sys.name == "5pti.cif"
+        @test sys.name == "5pti"
         @test natoms(sys) == 1087
-        @test nbonds(sys) == 0
+        @test nbonds(sys) == 3  # 3 disulfide bonds from _struct_conn
         @test nmolecules(sys) == 1
         @test nchains(sys) == 1
         @test nfragments(sys) == 123
         @test nnucleotides(sys) == 0
         @test nresidues(sys) == 58
 
-        sys = open(io -> load_mmcif(io, T), ball_data_path("../test/data/5pti.cif"))
-        @test sys isa System{T}
-        @test_broken sys.name == "5pti.cif" # BioStructures does not set a name here...
-        @test natoms(sys) == 1087
-        @test nbonds(sys) == 0
-        @test nmolecules(sys) == 1
-        @test nchains(sys) == 1
-        @test nfragments(sys) == 123
-        @test nnucleotides(sys) == 0
-        @test nresidues(sys) == 58
+        # verify disulfide bonds have correct flags
+        for b in bonds(sys)
+            @test has_flag(b, :TYPE__DISULPHIDE_BOND)
+        end
+
+        # verify coordinates of first atom (ARG-1 N)
+        a1 = first(atoms(sys))
+        @test a1.name == "N"
+        @test a1.element == Elements.N
+        @test isapprox(a1.r, Vector3{T}(32.231, 15.281, -13.143); atol=T(0.001))
+
+        # secondary structures (2 helices + 3 sheet ranges + coils)
+        @test nsecondary_structures(sys) > 0
+
+        # IO loading
+        sys2 = open(io -> load_mmcif(io, T), ball_data_path("../test/data/5pti.cif"))
+        @test sys2 isa System{T}
+        @test sys2.name == "5PTI"  # from data block name when reading from IO
+        @test natoms(sys2) == 1087
+        @test nbonds(sys2) == 3
+        @test nmolecules(sys2) == 1
+        @test nchains(sys2) == 1
+        @test nfragments(sys2) == 123
+        @test nnucleotides(sys2) == 0
+        @test nresidues(sys2) == 58
     end
+end
+
+@testitem "Read PDBx/mmCIF nonexistent" begin
+    @test_throws SystemError load_mmcif("nonexistent_file.cif")
 end
 
 @testitem "Write PDBx/mmCIF" begin
@@ -223,6 +235,11 @@ end
         @test nchains(sys2) == 1
         @test first(chains(sys2)).name == "A"
         @test nmolecules(sys2) == 1
+
+        # coordinate round-trip
+        for (a1, a2) in zip(atoms(sys), atoms(sys2))
+            @test isapprox(a1.r, a2.r; atol=T(0.001))
+        end
 
         open(io -> write_mmcif(io, sys), fname, "w")
         sys2 = load_mmcif(fname, T)

--- a/test/forcefields/AMBER/test_compiled_amberff.jl
+++ b/test/forcefields/AMBER/test_compiled_amberff.jl
@@ -67,4 +67,21 @@
         rebuild_pairlist!(cff)
         @test compute_energy!(cff) ≈ E0
     end
+
+    # Threaded backend must agree with serial (deterministic per-thread buffers;
+    # Float64 matches to ~rounding, Float32 differs only by summation order).
+    let p = load_pdb(ball_data_path("../test/data/AlaAla.pdb"))
+        infer_topology!(p)
+        ff = AmberFF(p)
+        for acc in (Float32, Float64)
+            cs = compile(ff; acc = acc, backend = :serial)
+            ct = compile(ff; acc = acc, backend = :threads)
+            Es = compute_energy!(cs); Et = compute_energy!(ct)
+            compute_forces!(cs); compute_forces!(ct)
+            etol = acc === Float64 ? 1e-6 : 1e-1
+            ftol = acc === Float64 ? 1e-6 : 1e-1
+            @test isapprox(Float64(Es), Float64(Et); atol = etol, rtol = etol)
+            @test maxabs([Float64(maxabs(cs.F[n] - ct.F[n])) for n in eachindex(cs.F)]) <= ftol
+        end
+    end
 end

--- a/test/forcefields/AMBER/test_compiled_amberff.jl
+++ b/test/forcefields/AMBER/test_compiled_amberff.jl
@@ -1,0 +1,70 @@
+@testitem "CompiledForceField" begin
+    using BiochemicalAlgorithms: compile, compute_energy!, compute_forces!, rebuild_pairlist!
+
+    maxabs(x) = isempty(x) ? 0.0 : maximum(abs, x)
+
+    # Compiled evaluator must reproduce the reference path. With acc == T the
+    # results are bit-faithful; with acc == Float64 they match within tolerance.
+    function check_against_reference(ff::ForceField{T}, acc; etol, ftol) where T
+        update!(ff)
+        Eref = compute_energy!(ff)
+        eref = copy(ff.energy)
+        compute_forces!(ff)
+        Fref = copy(atoms(ff.system).F)
+
+        cff = compile(ff; acc = acc)
+        Ecmp = compute_energy!(cff)
+        compute_forces!(cff)
+
+        @test isapprox(Float64(Ecmp), Float64(Eref); atol = etol, rtol = etol)
+        for (k, v) in eref
+            @test isapprox(Float64(cff.energy[k]), Float64(v); atol = etol, rtol = etol)
+        end
+        df = maxabs([Float64(maxabs(Fref[n] - cff.F[n])) for n in eachindex(cff.F)])
+        @test df <= ftol
+    end
+
+    # AlaAla (PDB, amber96, Float32)
+    let p = load_pdb(ball_data_path("../test/data/AlaAla.pdb"))
+        infer_topology!(p)
+        ff = AmberFF(p)
+        check_against_reference(ff, Float32; etol = 1e-3, ftol = 1e-1)
+        check_against_reference(ff, Float64; etol = 1e-2, ftol = 1e-1)
+    end
+
+    # BALL .hin systems, both storage precisions, acc == T -> exact match
+    for T in (Float32, Float64)
+        fdb = FragmentDB{T}()
+        ff91 = ball_data_path("forcefields/AMBER/amber91.ini")
+        ff96 = ball_data_path("forcefields/AMBER/amber96.ini")
+        for (nm, parm, noassign) in [
+                ("AmberFF_test_1.hin", ff91, true),
+                ("AmberFF_test_2.hin", ff91, true),
+                ("AmberFF_test_3.hin", ff91, true),
+                ("AmberFF_test_4.hin", ff91, true),
+                ("AlaGlySer.hin",      ff96, false),
+            ]
+            sys = load_hinfile(ball_data_path("../test/data/$nm"), T)
+            normalize_names!(sys, fdb)
+            label_terminal_fragments!(sys, fdb)
+            ff = AmberFF(sys, parm; assign_charges = !noassign, assign_typenames = !noassign)
+            etol = T === Float64 ? 1e-9 : 1e-2
+            ftol = T === Float64 ? 1e-6 : 1e-1
+            check_against_reference(ff, T; etol = etol, ftol = ftol)
+        end
+    end
+
+    # Pair-list rebuild policy: a wide skin with a large move must still match a
+    # full rebuild (skin guarantees no in-cutoff pair is missed).
+    let
+        fdb = FragmentDB{Float64}()
+        sys = load_hinfile(ball_data_path("../test/data/AlaGlySer.hin"), Float64)
+        normalize_names!(sys, fdb); label_terminal_fragments!(sys, fdb)
+        ff = AmberFF(sys, ball_data_path("forcefields/AMBER/amber96.ini"))
+        cff = compile(ff)
+        E0 = compute_energy!(cff)
+        # full rebuild at the same coordinates -> identical energy
+        rebuild_pairlist!(cff)
+        @test compute_energy!(cff) ≈ E0
+    end
+end


### PR DESCRIPTION
# AMBER structure-optimization performance

Benchmark report for the cached, multi-backend force-field evaluator added on
branch `anhi/optimization-performance`. All runs are on the same machine (Apple
Silicon, 12 logical cores, Metal GPU). Timings are best-of-N wall-clock;
absolute numbers drift with background load, so the **ratios within a single
run** are the reliable figures.

Primary structure: **`benchmark/data/AmberFF_bench.pdb`** — BPTI, 892 atoms,
~634 k nonbonded pairs at the default 20 Å cut-off (AMBER96, Float32).

---

## TL;DR

- **Up to ~36× faster on a single CPU thread and ~138× with 8 threads** than the
  original `optimize_structure!`, for the same minimization.
- The original was **~15–20× slower than BALL per evaluation** (it rebuilt the
  whole pair list every energy/force call). The new code is **on par with BALL
  single-threaded and faster with threads/GPU**.
- **Forces match BALL to 0.1 %**, bonded energies to ~1 %.
- The **GPU backend scales best**: at ~7 000 atoms / 5 M pairs it computes forces
  ~3.8× faster than one CPU thread and overtakes the 8-thread CPU backend.

---

## 1. Speed-up vs. the original implementation

The original `optimize_structure!` called `update!(ff)` *inside the objective*,
so the entire nonbonded interaction list was torn down and rebuilt on every
energy/force evaluation (≈ 42 ms and 85 MB allocated **per call**). The new
evaluator builds the pair list once and rebuilds it only when atoms drift past a
Verlet skin (the strategy BALL uses).

200-iteration minimization of BPTI, measured back-to-back in one run:

| Variant                         | Wall-clock | Speed-up |
|---------------------------------|-----------:|---------:|
| Original (`update!` every eval) |    68.5 s  |    1×    |
| New — serial                    |    1.91 s  |  **36×** |
| New — threads (8)               |    0.50 s  | **138×** |

---

## 2. Accuracy vs. BALL (BPTI, identical 892-atom structure)

BALL (C++ reference) was built with its `devenv` (Nix) toolchain and run on the
same PDB. Forces were converted from BALL's SI Newtons to kJ/(mol·Å).

| Quantity                | BALL      | Julia (new) | Agreement |
|-------------------------|----------:|------------:|-----------|
| RMS force [kJ/(mol·Å)]  |   62.32   |    62.39    | **0.1 %** |
| Bond stretches [kJ/mol] |   494.6   |    492.7    |  ~0.4 %   |
| Angle bends             |   517.2   |    523.5    |  ~1.2 %   |
| Torsions (prop+impr)    |  1171.5   |   1168.3    |  ~0.3 %   |
| Non-bonded (vdW+HB+ES)  |  −7880    |   −8344     |  ~6 %     |
| **Total**               | **−5697** |  **−6159**  |  ~8 %     |

Forces and bonded energies agree closely. The ~6 % non-bonded gap lives entirely
in the long-range electrostatic sum (it does **not** appear in the forces). This
is a **pre-existing property of the Julia AMBER port** — the cached evaluator
reproduces the Julia reference path exactly (Float64: bit-for-bit; Float32:
rounding level), so the performance work did not change any energies.

> Accuracy is validated in `test/forcefields/AMBER/test_compiled_amberff.jl`
> (compiled vs. reference, both precisions and all backends) and the existing
> `test_amberff.jl` / `test_optimize_structure.jl` oracle suites.

---

## 3. Speed vs. BALL (BPTI)

**Per-evaluation cost** (cached pair list — the operation that dominates a
minimization step):

| Backend            | Energy (ms) | Forces (ms) |
|--------------------|------------:|------------:|
| BALL (C++, 1 core) |     1.5     |     2.1     |
| Julia — serial     |     1.8     |     3.2     |
| Julia — threads(8) |     0.26    |     0.52    |
| Julia — GPU (Metal)|     1.5     |     2.6     |

- Single-threaded, BALL is ~1.4–1.5× faster than our serial Julia (expected for
  hand-tuned C++).
- The threaded backend is **~4–6× faster than BALL**; the GPU matches BALL at
  this small size and pulls ahead as the system grows (§4).

**End-to-end 200-iteration minimization:** BALL (Strang L-BFGS) 0.9–1.2 s; Julia
(L-BFGS-B) serial 1.9 s, threads 0.50 s. (Iteration semantics differ between the
two minimizers, so per-evaluation cost above is the cleaner comparison.)

---

## 4. Backend scaling with system size

To exercise larger systems, BPTI was replicated into *N* copies placed 120 Å
apart (beyond the cut-off, so copies don't interact and pair count grows
linearly). Per-evaluation timings (ms), Float32:

| System  | Atoms | Pairs | serial E / F | threads(8) E / F | GPU E / F |
|---------|------:|------:|-------------:|-----------------:|----------:|
| BPTI ×1 |   892 | 0.63 M| 1.83 / 3.18  |  0.26 / 0.52     | 1.52 / 2.57 |
| BPTI ×2 |  1790 | 1.28 M| 4.43 / 9.24  |  0.75 / 1.53     | 2.36 / 4.22 |
| BPTI ×4 |  3586 | 2.56 M| 9.40 / 18.73 |  1.38 / 3.17     | 2.65 / 5.88 |
| BPTI ×8 |  7178 | 5.14 M| 17.6 / 34.3  |  3.05 / 13.9     | 4.15 / 9.02 |

- **Serial** scales linearly with pair count, as expected.
- **GPU** has a fixed launch/transfer overhead that dominates the smallest
  system (×1: GPU ≈ serial), but its compute barely grows: from ×1 to ×8 the
  pair count rises 8× while GPU forces rise only ~3.5×.
- **Crossover:** by ×4–×8 the GPU overtakes the 8-thread CPU backend. At ×8
  (≈ 7 200 atoms, 5 M pairs) GPU forces (9.0 ms) beat serial (34.3 ms, **3.8×**)
  and the threaded backend (13.9 ms).

The takeaway: use `:serial`/`:threads` for typical proteins, and `:gpu` for large
assemblies where its near-flat scaling wins.

---

## 5. Notes & caveats

- **Larger head-to-head vs. BALL** on *identical* atoms was not achievable: the
  Julia FragmentDB topology inference does not robustly handle multi-chain /
  larger PDBs (e.g. 4hhb, 2ptc fail; 1tgh loads as 2956 atoms in Julia vs. 2355
  in BALL), and the synthetic replicas are rejected by BALL's PDB reader. The
  larger-system comparison is therefore the **Julia-internal scaling curve**
  (§4); the rigorous cross-check vs. BALL is the BPTI head-to-head (§2–§3). For
  reference, BALL on `1tgh` (2355 atoms) runs at 4.6 ms (energy) / 6.4 ms
  (forces) per evaluation.
- **Accumulation precision** is selectable (`accumulation = Float32 | Float64`).
  Float64 reproduces the reference path bit-for-bit; Float32 (default for
  `AmberFF`) differs only at rounding level.
- **GPU** uses KernelAbstractions and works on **Metal and CUDA** via package
  extensions (no GPU dependency for CPU-only users). Metal has no Float64, so the
  GPU backend requires Float32 accumulation there.
- Reproduce: `optimize_structure!(ff; backend = :serial | :threads | :gpu,
  accumulation = Float32 | Float64)`. BALL reference built via
  `cd tmp/BALL && devenv shell -- bash -c 'cd build/devenv && ninja …'`.
