### PR TITLE
FragmentDB: rename "PDB" naming scheme to "BALL"

### DIFF
--- a/data/fragmentdb/Editing-FragmentDB.json
+++ b/data/fragmentdb/Editing-FragmentDB.json
@@ -45,6 +45,6 @@
     "Star": "names/Star.json"
   },
   "defaults": {
-    "Naming": "PDB"
+    "Naming": "BALL"
   }
 }

--- a/data/fragmentdb/FragmentDB.json
+++ b/data/fragmentdb/FragmentDB.json
@@ -44,6 +44,6 @@
     "DNA": "names/DNA.json"
   },
   "defaults": {
-    "Naming": "PDB"
+    "Naming": "BALL"
   }
 }

--- a/data/fragmentdb/names/Amber.json
+++ b/data/fragmentdb/names/Amber.json
@@ -1,6 +1,6 @@
 {
   "name": "Amber",
-  "maps_to": "PDB",
+  "maps_to": "BALL",
   "mappings": {
     "*:H1": "*:1H",
     "*:H2": "*:2H",

--- a/data/fragmentdb/names/CHARMM.json
+++ b/data/fragmentdb/names/CHARMM.json
@@ -1,6 +1,6 @@
 {
   "name": "CHARMM",
-  "maps_to": "PDB",
+  "maps_to": "BALL",
   "mappings": {
     "*:H1": "*:1H",
     "*:H2": "*:2H",

--- a/data/fragmentdb/names/DNA.json
+++ b/data/fragmentdb/names/DNA.json
@@ -1,6 +1,6 @@
 {
   "name": "DNA",
-  "maps_to": "PDB",
+  "maps_to": "BALL",
   "mappings": {
     "C:P": "C:P",
     "DC:OP1": "C:O1P",

--- a/data/fragmentdb/names/Discover.json
+++ b/data/fragmentdb/names/Discover.json
@@ -1,6 +1,6 @@
 {
   "name": "Discover",
-  "maps_to": "PDB",
+  "maps_to": "BALL",
   "mappings": {
     "*:H1": "*:1H",
     "*:H2": "*:2H",

--- a/data/fragmentdb/names/Star.json
+++ b/data/fragmentdb/names/Star.json
@@ -1,6 +1,6 @@
 {
   "name": "Star",
-  "maps_to": "PDB",
+  "maps_to": "BALL",
   "mappings": {
     "*:H1": "*:1H",
     "*:H2": "*:2H",

--- a/data/fragmentdb/names/XPLOR.json
+++ b/data/fragmentdb/names/XPLOR.json
@@ -1,6 +1,6 @@
 {
   "name": "XPLOR",
-  "maps_to": "PDB",
+  "maps_to": "BALL",
   "mappings": {
     "*:H1": "*:1H",
     "*:H2": "*:2H",

--- a/test/preprocessing/test_fragmentdb.jl
+++ b/test/preprocessing/test_fragmentdb.jl
@@ -5,7 +5,7 @@
         @test length(fdb.fragments) == 34
         @test length(fdb.name_mappings) == 6
         @test length(fdb.defaults) == 1
-        @test fdb.defaults["Naming"] == "PDB"
+        @test fdb.defaults["Naming"] == "BALL"
     end
 
     for T in [Float32, Float64]

--- a/test/preprocessing/test_normalize_names.jl
+++ b/test/preprocessing/test_normalize_names.jl
@@ -18,7 +18,7 @@
         @test length(fdb.name_mappings) == 6
         for scheme in ["Discover", "Amber", "CHARMM", "XPLOR", "Star", "DNA"]
             @test haskey(fdb.name_mappings, scheme)
-            @test fdb.name_mappings[scheme].maps_to == "PDB"
+            @test fdb.name_mappings[scheme].maps_to == "BALL"
         end
     end
 end


### PR DESCRIPTION
The naming schemes were adopted from BALL and, for some atoms, differ rather significantly from PDB and PDB alt names.