### PR TITLE
Backports v0.7.3

### DIFF
--- a/src/core/atom.jl
+++ b/src/core/atom.jl
@@ -207,6 +207,7 @@ end
 end
 
 """
+    atoms(::Bond)
     atoms(::Chain)
     atoms(::Fragment)
     atoms(::Molecule)

--- a/src/core/bond.jl
+++ b/src/core/bond.jl
@@ -256,6 +256,10 @@ function get_partner(bond, atom)
     end
 end
 
+@inline function atoms(bond::Bond{T}; kwargs...) where T
+    filter(a -> a.idx == bond.a1 || a.idx == bond.a2, atoms(parent(bond); kwargs...))
+end
+
 function get_partners(bond)
     s = parent(bond)
     atom_by_idx(s, bond.a1), atom_by_idx(s, bond.a2)

--- a/src/core/fragment.jl
+++ b/src/core/fragment.jl
@@ -67,20 +67,6 @@ Fragment(
 )
 ```
 Creates a new `Fragment{T}` in the given chain.
-
-```julia
-Fragment(
-    secondary_structure::SecondaryStructure{T},
-    number::Int;
-    # keyword arguments
-    name::AbstractString = "",
-    variant::FragmentVariantType = FragmentVariant.None,
-    properties::Properties = Properties(),
-    flags::Flags = Flags()
-)
-```
-Creates a new `Fragment{T}` in the given secondary structure.
-
 """
 const Fragment{T} = AtomContainer{T, :Fragment}
 

--- a/src/fileformats/pdb/pdb_general.jl
+++ b/src/fileformats/pdb/pdb_general.jl
@@ -238,7 +238,7 @@ function interpret_record(
     formal_charge = tryparse(Int, charge)
     formal_charge = isnothing(formal_charge) ? 0 : formal_charge
 
-    pdb_info.atom_cache[serial_number] = Atom(
+    a = Atom(
         pdb_info.current_residue,
         serial_number,
         parse_element_string(strip(element_symbol), atom_name);
@@ -255,6 +255,12 @@ function interpret_record(
         flags=Flags(),
         frame_id=pdb_info.current_model
     )
+
+    if (pdb_info.current_model == 1 || pdb_info.selected_model != -1)
+        pdb_info.atom_cache[serial_number] = a
+    end
+
+    a
 end
 
 

--- a/src/fileformats/pdb/pdb_writer.jl
+++ b/src/fileformats/pdb/pdb_writer.jl
@@ -272,6 +272,8 @@ function write_sheet_section(io::IO, pdb_info::PDBInfo, ac::AbstractAtomContaine
         secondary_structures(ac)
     )
 
+    records = []
+    strands_per_sheet   = Dict{SubString{String}, Int}()
     for strand in strands
         rs = fragments(strand)
 
@@ -287,15 +289,21 @@ function write_sheet_section(io::IO, pdb_info::PDBInfo, ac::AbstractAtomContaine
                     1
                 end
             end
-        strand_name = name_parts[1]
+        sheet_name = name_parts[1]
+        strands_per_sheet[sheet_name] = max(strand_number, get(strands_per_sheet, sheet_name, 1))
 
         strand_start = first(rs)
         strand_end   =  last(rs)
 
         strand_sense = get_property(strand, :STRAND_SENSE, 0)
 
+        push!(records, (strand_number, sheet_name, strand_start, strand_end, strand_sense))
+    end
+
+    sort!(records; by = t -> (t[2], t[1]))
+    for (strand_number, sheet_name, strand_start, strand_end, strand_sense) in records
         write_record(io, pdb_info, Val(RECORD_TYPE__SHEET),
-            strand_number, strand_name, length(strands),
+            strand_number, sheet_name, strands_per_sheet[sheet_name],
             residue_details(strand_start)...,
             residue_details(strand_end)...,
             strand_sense

--- a/src/substructures/substructure.jl
+++ b/src/substructures/substructure.jl
@@ -44,7 +44,7 @@ end
 
 function Base.copy(substruct::Substructure{T}) where T
     sys = System{T}(substruct.name)
-    sys._curr_idx = sys._curr_idx
+    sys._curr_idx = parent(substruct)._curr_idx
 
     sys.properties = copy(substruct.properties)
     sys.flags      = copy(substruct.parent.flags)

--- a/src/substructures/substructure.jl
+++ b/src/substructures/substructure.jl
@@ -89,34 +89,50 @@ end
 
 @inline function molecules(substruct::Substructure; kwargs...)
     midx = Set(atoms(substruct; kwargs...).molecule_idx)
-    filter(row -> row.idx in midx, molecules(substruct.parent))
+    filter(row -> row.idx in midx, molecules(parent(substruct)))
+end
+
+@inline function proteins(substruct::Substructure; kwargs...)
+    midx = Set(atoms(substruct; kwargs...).molecule_idx)
+    filter(row -> row.idx in midx, proteins(parent(substruct)))
 end
 
 @inline function chains(substruct::Substructure; kwargs...)
     cidx = Set(atoms(substruct; kwargs...).chain_idx)
-    filter(row -> row.idx in cidx, chains(substruct.parent))
+    filter(row -> row.idx in cidx, chains(parent(substruct)))
 end
 
-@inline function secondary_structures(substruct::Substructure; kwargs...)
-    cidx = Set(atoms(substruct; kwargs...).chain_idx)
-    filter(row -> row.idx in cidx, secondary_structures(substruct.parent))
+@inline function secondary_structures(substruct::Substructure{T}; kwargs...) where T
+    fidx = setdiff(Set(atoms(substruct; kwargs...).fragment_idx), Set([nothing]))
+    ft = FragmentTable{T}(parent(substruct), collect(Int, fidx))
+    secondary_structures(ft)
 end
 
 @inline function fragments(substruct::Substructure; kwargs...)
     fidx = Set(atoms(substruct; kwargs...).fragment_idx)
-    filter(row -> row.idx in fidx, fragments(substruct.parent))
+    filter(row -> row.idx in fidx, fragments(parent(substruct)))
 end
 
-@inline function natoms(substruct::Substructure; kwargs...)
-    length(atoms(substruct; kwargs...))
+@inline function residues(substruct::Substructure; kwargs...)
+    fidx = Set(atoms(substruct; kwargs...).fragment_idx)
+    filter(row -> row.idx in fidx, residues(parent(substruct)))
 end
 
-@inline function nbonds(substruct::Substructure; kwargs...)
-    length(bonds(substruct; kwargs...))
+@inline function nucleotides(substruct::Substructure; kwargs...)
+    fidx = Set(atoms(substruct; kwargs...).fragment_idx)
+    filter(row -> row.idx in fidx, nucleotides(parent(substruct)))
 end
 
-@inline function nfragments(substruct::Substructure; kwargs...)
-    length(fragments(substruct; kwargs...))
+# natoms, nbonds, ...
+for comp in (
+    :atoms, :bonds, :molecules, :proteins, :chains,
+    :secondary_structures, :fragments, :residues, :nucleotides
+)
+    @eval begin
+        @inline function $(Symbol("n", comp))(substruct::Substructure; kwargs...)
+            length($(comp)(substruct; kwargs...))
+        end
+    end
 end
 
 @inline Base.parent(substruct::Substructure) = parent(substruct.parent)

--- a/src/substructures/substructure.jl
+++ b/src/substructures/substructure.jl
@@ -37,7 +37,7 @@ function filter_atoms(fn, mol::AbstractAtomContainer; name::AbstractString="", a
     bond_view = filter(row ->
         adjacent_bonds ? row.a1 ∈ idxset || row.a2 ∈ idxset
                         : row.a1 ∈ idxset && row.a2 ∈ idxset,
-        bonds(mol)
+        bonds(parent(mol))
     )
     Substructure(name, mol, atom_view, bond_view)
 end

--- a/test/substructures/test_substructure.jl
+++ b/test/substructures/test_substructure.jl
@@ -1,42 +1,107 @@
 @testitem "Substructure" begin
-    # read a simple molecule
-    mol = molecules(load_pubchem_json(ball_data_path("../test/data/aspirin_pug.json")))[1]
+    for T in [Float32, Float64]
+        # read a simple molecule
+        sys = load_pubchem_json(ball_data_path("../test/data/aspirin_pug.json"), T)
+        filter_fn = atom -> atom.element == Elements.C
 
-    filter_fn = atom -> atom.element == Elements.C
+        mol = first(molecules(load_pubchem_json(ball_data_path("../test/data/aspirin_pug.json"), T)))
 
-    # and create a substructure
-    filtered_atoms = filter(filter_fn, atoms(mol))
-    idxset = Set(filtered_atoms.idx)
-    filtered_bonds = filter(bond ->
-        bond.a1 ∈ idxset && bond.a2 ∈ idxset,
-        bonds(mol)
-    )
+        # create a substructure
+        filtered_atoms = filter(filter_fn, atoms(mol))
+        idxset = Set(filtered_atoms.idx)
+        filtered_bonds = filter(bond ->
+            bond.a1 ∈ idxset && bond.a2 ∈ idxset,
+            bonds(mol)
+        )
 
-    s = Substructure(
-        "aspirin substructure",
-        mol,
-        filtered_atoms,
-        filtered_bonds
-    )
+        s = Substructure(
+            "aspirin substructure",
+            mol,
+            filtered_atoms,
+            filtered_bonds
+        )
 
-    @test s isa Substructure
-    @test s.name == "aspirin substructure"
-    @test natoms(s) == 9
-    @test nbonds(s) == 8
-    @test length(s.properties) == 3
+        @test s isa Substructure{T}
+        @test s.name == "aspirin substructure"
+        @test natoms(s) == 9
+        @test nbonds(s) == 8
+        @test length(s.properties) == 3
 
-    # generate the same substructure by filtering
-    s2 = filter_atoms(
-        filter_fn,
-        mol;
-        name="aspirin substructure",
-        adjacent_bonds=false
-    )
+        # generate the same substructure by filtering
+        s2 = filter_atoms(
+            filter_fn,
+            mol;
+            name="aspirin substructure",
+            adjacent_bonds=false
+        )
 
-    @test s2 == s
+        @test s2 == s
 
-    # empty substructure (filter matches nothing)
-    s_empty = filter_atoms(a -> false, mol; name="empty", adjacent_bonds=false)
-    @test natoms(s_empty) == 0
-    @test nbonds(s_empty) == 0
+        sys = copy(s)
+        @test sys.name == "aspirin substructure"
+        @test length(sys.properties) == 3
+        @test natoms(sys) == natoms(s)
+        @test nbonds(sys) == nbonds(s)
+        @test nmolecules(sys) == nmolecules(s)
+        @test nproteins(sys) == nproteins(s)
+        @test nchains(sys) == nchains(s)
+        @test nfragments(sys) == nfragments(s)
+        @test nresidues(sys) == nresidues(s)
+        @test nnucleotides(sys) == nnucleotides(s)
+        @test nsecondary_structures(sys) == nsecondary_structures(s)
+
+        # empty substructure (filter matches nothing)
+        s_empty = filter_atoms(a -> false, mol; name="empty", adjacent_bonds=false)
+        @test natoms(s_empty) == 0
+        @test nbonds(s_empty) == 0
+
+        sys_empty = copy(s_empty)
+        @test sys_empty isa System{T}
+        @test natoms(sys_empty) == 0
+        @test nbonds(sys_empty) == 0
+        @test nmolecules(sys_empty) == 0
+
+        # check substruct interface for all atom containers
+        sys = load_pdb(ball_data_path("../test/data/AlaAla.pdb"), T)
+        fdb = FragmentDB{T}()
+        infer_topology!(sys, fdb)
+
+        for ac in (sys, first(molecules(sys)), first(chains(sys)), first(fragments(sys)), first(bonds(sys)))
+            filtered_atoms = filter(a -> true, atoms(ac))
+            idxset = Set(filtered_atoms.idx)
+            filtered_bonds = filter(bond ->
+                bond.a1 ∈ idxset && bond.a2 ∈ idxset,
+                bonds(parent(ac))
+            )
+
+            s = Substructure(
+                "AlaAla",
+                ac,
+                filtered_atoms,
+                filtered_bonds
+            )
+
+            @test s isa Substructure{T}
+            @test s.name == "AlaAla"
+            @test natoms(s) > 0
+            @test nbonds(s) > 0
+            @test nmolecules(s) > 0
+            @test nproteins(s) == 0
+            @test nchains(s) > 0
+            @test nfragments(s) > 0
+            @test nresidues(s) > 0
+            @test nnucleotides(s) == 0
+            @test nsecondary_structures(s) > 0
+
+            # generate the same substructure by filtering
+            s2 = filter_atoms(
+                a -> true,
+                ac;
+                name="AlaAla",
+                adjacent_bonds=false
+            )
+
+            @test s2 == s
+        end
+    end
 end


### PR DESCRIPTION
- [x] [Substruct: fix `_current_idx` in copied system](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/commit/5a9697f8a31bfe5b418e4bba4cf5873c6f4e87fb)
- [x] [System: add `atoms(::Bond)`](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/commit/46285f767aa1d93cbba0ec79e3b84ce02aa51674)
- [x] [Substruct: fix `filter_atoms` when used with bonds](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/commit/493edd3461aa604e3c96f695387f734495ad05bf)
- [x] [System: fix `Fragment` docstring](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/commit/18891bbfa0d6c8e6f5dc292d9fc25cb2d54eea93)
- [x] [Substruct: fix component accessors](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/commit/d4a36f77619659d428103de8fcb6da2953fcfdf8)
- [x] [Substruct: add more tests](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/commit/58d46d757d72e88d85966ecbf2d2627d85e3d651)
- [x] [PDB: hotfix bond assignment in multi-model structures](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/commit/3e9ab9277f0f5414036cacadde07dfa172c91f99)
- [x] [PDB: fix strands per sheet computation in writer](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/commit/495a502ae5e499a89ac73fc2336e2db9bfe821be)