### PR TITLE
System: allow switching between models

### DIFF
--- a/docs/src/public/system.md
+++ b/docs/src/public/system.md
@@ -25,11 +25,16 @@ AbstractSystemComponent
 AbstractSystemComponentTable
 SystemComponentTable
 SystemComponentTableCol
+copy_frame!
+frame_ids
 full_table
 get_property
 has_flag
 has_property
+nframes
 revalidate_indices!
+select_frame!
+selected_frame
 set_flag!
 set_property!
 unset_flag!

--- a/src/core/atom.jl
+++ b/src/core/atom.jl
@@ -53,7 +53,7 @@ Atom(
     radius::T = zero(T),
     properties::Properties = Properties(),
     flags::Flags = Flags(),
-    frame_id::Int = 1
+    frame_id::Int = selected_frame(ac),
     molecule_idx::MaybeInt = nothing,
     chain_idx::MaybeInt = nothing,
     fragment_idx::MaybeInt = nothing
@@ -76,7 +76,7 @@ const Atom{T} = SystemComponent{T, :Atom}
     sys::System{T},
     number::Int,
     element::ElementType;
-    frame_id::Int = 1,
+    frame_id::Int = selected_frame(sys),
     molecule_idx::MaybeInt = nothing,
     chain_idx::MaybeInt = nothing,
     fragment_idx::MaybeInt = nothing,
@@ -190,13 +190,13 @@ Returns the first `Atom{T}` associated with the given `name` in `ac`. Returns no
 atom exists.
 
 # Supported keyword arguments
- - `frame_id::MaybeInt = 1`: \
+ - `frame_id::MaybeInt = selected_frame(ac)`: \
 Any value other than `nothing` limits the result to atoms matching this frame ID.
 """
 @inline function atom_by_name(
     ac::AbstractAtomContainer{T},
     name::AbstractString;
-    frame_id::MaybeInt = 1
+    frame_id::MaybeInt = selected_frame(parent(ac))
 ) where T
     idx = filter(atom -> atom.name == name, atoms(ac; frame_id = frame_id)).idx
     isempty(idx) ? nothing : atom_by_idx(parent(ac), first(idx))
@@ -207,16 +207,16 @@ end
 end
 
 """
-    atoms(::Bond)
-    atoms(::Chain)
-    atoms(::Fragment)
-    atoms(::Molecule)
-    atoms(::System = default_system())
+    atoms(ac::Bond)
+    atoms(ac::Chain)
+    atoms(ac::Fragment)
+    atoms(ac::Molecule)
+    atoms(ac::System = default_system())
 
 Returns an `AtomTable{T}` containing all atoms of the given atom container.
 
 # Supported keyword arguments
- - `frame_id::MaybeInt = 1`
+ - `frame_id::MaybeInt = selected_frame(ac)`
  - `molecule_idx::Union{MaybeInt, Some{Nothing}} = nothing`
  - `chain_idx::Union{MaybeInt, Some{Nothing}} = nothing`
  - `fragment_idx::Union{MaybeInt, Some{Nothing}} = nothing`
@@ -224,7 +224,7 @@ All keyword arguments limit the results to atoms matching the given IDs. Keyword
 `nothing` are ignored. You can use `Some(nothing)` to explicitly filter for ID values of `nothing`.
 """
 @inline function atoms(sys::System{T} = default_system();
-    frame_id::MaybeInt = 1,
+    frame_id::MaybeInt = selected_frame(sys),
     molecule_idx::Union{MaybeInt, Some{Nothing}} = nothing,
     chain_idx::Union{MaybeInt, Some{Nothing}} = nothing,
     fragment_idx::Union{MaybeInt, Some{Nothing}} = nothing
@@ -348,11 +348,16 @@ assigned a new `idx`.
 See [`atoms`](@ref)
 """
 @inline function Base.push!(sys::System{T}, atom::Atom{T};
-    frame_id::Int = 1,
+    frame_id::Int = selected_frame(sys),
     molecule_idx::MaybeInt = nothing,
     chain_idx::MaybeInt = nothing,
     fragment_idx::MaybeInt = nothing
 ) where T
+    _copy!(atom; sys, frame_id, molecule_idx, chain_idx, fragment_idx)
+    sys
+end
+
+@inline function _copy!(atom::Atom{T}; sys::System{T} = parent(atom), kwargs...) where T
     Atom(sys, atom.number, atom.element;
         name = atom.name,
         atom_type = atom.atom_type,
@@ -364,12 +369,12 @@ See [`atoms`](@ref)
         radius = atom.radius,
         properties = atom.properties,
         flags = atom.flags,
-        frame_id = frame_id,
-        molecule_idx = molecule_idx,
-        chain_idx = chain_idx,
-        fragment_idx = fragment_idx
+        frame_id = atom.frame_id,
+        molecule_idx = atom.molecule_idx,
+        chain_idx = atom.chain_idx,
+        fragment_idx = atom.fragment_idx,
+        kwargs...
     )
-    sys
 end
 
 @enumx FullNameType begin

--- a/src/core/system.jl
+++ b/src/core/system.jl
@@ -117,7 +117,7 @@ Creates a new and empty `System{T}`.
     _chains::_ChainTable
     _secondary_structures::_SecondaryStructureTable
     _fragments::_FragmentTable
-    _curr_idx::Int
+    _current_idx::Int
 
     function System{T}(
         name::AbstractString = "",
@@ -167,7 +167,7 @@ end
 Returns the next available `idx` for the given system.
 """
 @inline function _next_idx!(sys::System{T}) where T
-    sys._curr_idx += 1
+    sys._current_idx += 1
 end
 
 @inline function _offset_atom_indices!(sys::System, by::Int)
@@ -224,7 +224,7 @@ function _offset_indices!(sys::System, by::Int)
     _offset_chain_indices!(sys, by)
     _offset_secondary_structure_indices!(sys, by)
     _offset_fragment_indices!(sys, by)
-    sys._curr_idx += by
+    sys._current_idx += by
     sys
 end
 
@@ -239,15 +239,15 @@ Copies all system components from `others` to `sys`.
 """
 function Base.append!(sys::System{T}, others::System{T}...) where T
     for other in others
-        offset = other._curr_idx
-        other = _offset_indices!(deepcopy(other), sys._curr_idx)
+        offset = other._current_idx
+        other = _offset_indices!(deepcopy(other), sys._current_idx)
         append!(sys._atoms, other._atoms)
         append!(sys._bonds, other._bonds)
         append!(sys._molecules, other._molecules)
         append!(sys._chains, other._chains)
         append!(sys._secondary_structures, other._secondary_structures)
         append!(sys._fragments, other._fragments)
-        sys._curr_idx += offset
+        sys._current_idx += offset
     end
     sys
 end

--- a/src/core/system.jl
+++ b/src/core/system.jl
@@ -4,6 +4,7 @@ export
     AtomContainer,
     System,
     SystemComponent,
+    copy_frame!,
     default_system,
     frame_ids,
     get_property,
@@ -11,6 +12,8 @@ export
     has_property,
     nframes,
     parent_system,
+    select_frame!,
+    selected_frame,
     set_flag!,
     set_property!,
     sort_atoms!,
@@ -84,9 +87,6 @@ Abstract base type for all atom containers.
 """
 abstract type AbstractAtomContainer{T} <: AbstractSystemComponent{T} end
 
-@inline frame_ids(ac::AbstractAtomContainer) = unique(atoms(ac; frame_id = nothing).frame_id)
-@inline nframes(ac::AbstractAtomContainer) = length(frame_ids(ac))
-
 """
     $(TYPEDEF)
 
@@ -117,7 +117,9 @@ Creates a new and empty `System{T}`.
     _chains::_ChainTable
     _secondary_structures::_SecondaryStructureTable
     _fragments::_FragmentTable
+
     _current_idx::Int
+    _current_frame::Int
 
     function System{T}(
         name::AbstractString = "",
@@ -134,7 +136,8 @@ Creates a new and empty `System{T}`.
             _ChainTable(),
             _SecondaryStructureTable(),
             _FragmentTable(),
-            0
+            0,
+            1
         )
     end
 end
@@ -226,6 +229,68 @@ function _offset_indices!(sys::System, by::Int)
     _offset_fragment_indices!(sys, by)
     sys._current_idx += by
     sys
+end
+
+"""
+    frame_ids(::AbstractAtomContainer = default_system())
+
+Returns a vector of all unique `frame_id`s present in the given container.
+"""
+@inline function frame_ids(ac::AbstractAtomContainer = default_system())
+    unique(atoms(ac; frame_id = nothing).frame_id)
+end
+
+"""
+    nframes(::AbstractAtomContainer = default_system())
+
+Returns the number of unique `frame_id`s present in the given container.
+"""
+@inline function nframes(ac::AbstractAtomContainer = default_system())
+    length(frame_ids(ac))
+end
+
+"""
+    selected_frame(::System = default_system())
+
+Returns the system's currently selected `frame_id`.
+"""
+@inline function selected_frame(sys::System = default_system())
+    sys._current_frame
+end
+
+"""
+    select_frame!(::System = default_system(), frame_id::Int)
+
+Sets the system's currently selected `frame_id` to the given value.
+"""
+@inline function select_frame!(sys::System, frame_id::Int)
+    sys._current_frame = frame_id
+    sys
+end
+
+@inline function select_frame!(frame_id::Int)
+    select_frame!(default_system(), frame_id)
+end
+
+"""
+    copy_frame!(::System = default_system(), target_frame::Int)
+
+Appends a copy of the currently selected frame to the given target frame ID.
+"""
+function copy_frame!(sys::System, target_frame::Int)
+    idxmap = Dict(a.idx => _copy!(a; frame_id = target_frame) for a in atoms(sys))
+    aidx   = keys(idxmap)
+    for b in filter(b -> b.atom1_idx in aidx && b.atom2_idx in aidx, bonds(sys))
+        Bond(idxmap[b.atom1_idx], idxmap[b.atom2_idx], b.order;
+            properties = b.properties,
+            flags = b.flags
+        )
+    end
+    sys
+end
+
+@inline function copy_frame!(target_frame::Int)
+    copy_frame!(default_system(), target_frame)
 end
 
 """

--- a/src/substructures/substructure.jl
+++ b/src/substructures/substructure.jl
@@ -45,6 +45,7 @@ end
 function Base.copy(substruct::Substructure{T}) where T
     sys = System{T}(substruct.name)
     sys._current_idx = parent(substruct)._current_idx
+    sys._current_frame = parent(substruct)._current_frame
 
     sys.properties = copy(substruct.properties)
     sys.flags      = copy(substruct.parent.flags)
@@ -68,7 +69,7 @@ Returns an `AtomTable` for all of the given system's atoms matching the given cr
 private atom fields.
 """
 @inline function atoms(substruct::Substructure{T};
-    frame_id::MaybeInt = 1,
+    frame_id::MaybeInt = selected_frame(parent(substruct)),
     molecule_idx::Union{MaybeInt, Some{Nothing}} = nothing,
     chain_idx::Union{MaybeInt, Some{Nothing}} = nothing,
     fragment_idx::Union{MaybeInt, Some{Nothing}} = nothing

--- a/src/substructures/substructure.jl
+++ b/src/substructures/substructure.jl
@@ -44,7 +44,7 @@ end
 
 function Base.copy(substruct::Substructure{T}) where T
     sys = System{T}(substruct.name)
-    sys._curr_idx = parent(substruct)._curr_idx
+    sys._current_idx = parent(substruct)._current_idx
 
     sys.properties = copy(substruct.properties)
     sys.flags      = copy(substruct.parent.flags)

--- a/test/core/test_system.jl
+++ b/test/core/test_system.jl
@@ -525,5 +525,37 @@ end
         sys2 = System{T}()
         @test nframes(sys2) == 0
         @test isempty(frame_ids(sys2))
+
+        # multi-model system
+        sys = load_pdb(ball_data_path("../test/data/1X0I.pdb"), T)
+        @test nframes(sys) == 2
+        @test frame_ids(sys) == [1, 2]
+        @test natoms(sys) == 1824
+        @test natoms(sys; frame_id = 1) == 1824
+        @test natoms(sys; frame_id = 2) == 1824
+        @test nbonds(sys) == 129
+        @test nbonds(sys; frame_id = 1) == 129
+        @test nbonds(sys; frame_id = 2) == 0   # https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/issues/343
+
+        select_frame!(sys, 2)
+        fdb = FragmentDB{T}()
+        infer_topology!(sys, fdb)
+        @test natoms(sys) == 3603
+        @test natoms(sys; frame_id = 1) == 1824
+        @test natoms(sys; frame_id = 2) == 3603
+        @test nbonds(sys) == 3490
+        @test nbonds(sys; frame_id = 1) == 129
+        @test nbonds(sys; frame_id = 2) == 3490
+
+        select_frame!(sys, 1)
+        copy_frame!(sys, 3)
+        @test natoms(sys) == 1824
+        @test natoms(sys; frame_id = 1) == 1824
+        @test natoms(sys; frame_id = 2) == 3603
+        @test natoms(sys; frame_id = 3) == 1824
+        @test nbonds(sys) == 129
+        @test nbonds(sys; frame_id = 1) == 129
+        @test nbonds(sys; frame_id = 2) == 3490
+        @test nbonds(sys; frame_id = 3) == 129
     end
 end

--- a/test/data/1X0I.pdb
+++ b/test/data/1X0I.pdb
@@ -1,0 +1,4282 @@
+HEADER    PROTON TRANSPORT                        23-MAR-05   1X0I              
+TITLE     CRYSTAL STRUCTURE OF THE ACID BLUE FORM OF BACTERIORHODOPSIN          
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: BACTERIORHODOPSIN;                                         
+COMPND   3 CHAIN: 1;                                                            
+COMPND   4 SYNONYM: BR                                                          
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: HALOBACTERIUM SALINARUM;                        
+SOURCE   3 ORGANISM_TAXID: 2242;                                                
+SOURCE   4 STRAIN: JW3                                                          
+KEYWDS    7 TRANSMEMBRANE HELICES, MEMBRANE PROTEIN, PROTON TRANSPORT           
+EXPDTA    X-RAY DIFFRACTION                                                     
+NUMMDL    2                                                                     
+AUTHOR    H.OKUMURA,M.MURAKAMI,T.KOUYAMA                                        
+REVDAT   5   30-OCT-24 1X0I    1       REMARK                                   
+REVDAT   4   25-OCT-23 1X0I    1       REMARK LINK                              
+REVDAT   3   09-SEP-15 1X0I    1       NUMMDL VERSN                             
+REVDAT   2   24-FEB-09 1X0I    1       VERSN                                    
+REVDAT   1   02-AUG-05 1X0I    0                                                
+JRNL        AUTH   H.OKUMURA,M.MURAKAMI,T.KOUYAMA                               
+JRNL        TITL   CRYSTAL STRUCTURES OF ACID BLUE AND ALKALINE PURPLE FORMS OF 
+JRNL        TITL 2 BACTERIORHODOPSIN                                            
+JRNL        REF    J.MOL.BIOL.                   V. 351   481 2005              
+JRNL        REFN                   ISSN 0022-2836                               
+JRNL        PMID   16023672                                                     
+JRNL        DOI    10.1016/J.JMB.2005.06.026                                    
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    2.30 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : CNS 1.1                                              
+REMARK   3   AUTHORS     : BRUNGER,ADAMS,CLORE,DELANO,GROS,GROSSE-              
+REMARK   3               : KUNSTLEVE,JIANG,KUSZEWSKI,NILGES,PANNU,              
+REMARK   3               : READ,RICE,SIMONSON,WARREN                            
+REMARK   3                                                                      
+REMARK   3  REFINEMENT TARGET : ENGH & HUBER                                    
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 2.30                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 14.91                          
+REMARK   3   DATA CUTOFF            (SIGMA(F)) : 0.000                          
+REMARK   3   DATA CUTOFF HIGH         (ABS(F)) : NULL                           
+REMARK   3   DATA CUTOFF LOW          (ABS(F)) : NULL                           
+REMARK   3   COMPLETENESS (WORKING+TEST)   (%) : 99.5                           
+REMARK   3   NUMBER OF REFLECTIONS             : 15506                          
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT.                                     
+REMARK   3   CROSS-VALIDATION METHOD          : THROUGHOUT                      
+REMARK   3   FREE R VALUE TEST SET SELECTION  : RANDOM                          
+REMARK   3   R VALUE            (WORKING SET) : 0.238                           
+REMARK   3   FREE R VALUE                     : 0.282                           
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : 4.900                           
+REMARK   3   FREE R VALUE TEST SET COUNT      : 767                             
+REMARK   3   ESTIMATED ERROR OF FREE R VALUE  : 0.010                           
+REMARK   3                                                                      
+REMARK   3  FIT IN THE HIGHEST RESOLUTION BIN.                                  
+REMARK   3   TOTAL NUMBER OF BINS USED           : 5                            
+REMARK   3   BIN RESOLUTION RANGE HIGH       (A) : 2.30                         
+REMARK   3   BIN RESOLUTION RANGE LOW        (A) : 2.48                         
+REMARK   3   BIN COMPLETENESS (WORKING+TEST) (%) : 99.60                        
+REMARK   3   REFLECTIONS IN BIN    (WORKING SET) : 2893                         
+REMARK   3   BIN R VALUE           (WORKING SET) : 0.2360                       
+REMARK   3   BIN FREE R VALUE                    : 0.2730                       
+REMARK   3   BIN FREE R VALUE TEST SET SIZE  (%) : 4.60                         
+REMARK   3   BIN FREE R VALUE TEST SET COUNT     : 138                          
+REMARK   3   ESTIMATED ERROR OF BIN FREE R VALUE : 0.023                        
+REMARK   3                                                                      
+REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
+REMARK   3   PROTEIN ATOMS            : 1666                                    
+REMARK   3   NUCLEIC ACID ATOMS       : 0                                       
+REMARK   3   HETEROGEN ATOMS          : 133                                     
+REMARK   3   SOLVENT ATOMS            : 25                                      
+REMARK   3                                                                      
+REMARK   3  B VALUES.                                                           
+REMARK   3   FROM WILSON PLOT           (A**2) : 45.00                          
+REMARK   3   MEAN B VALUE      (OVERALL, A**2) : 43.54                          
+REMARK   3   OVERALL ANISOTROPIC B VALUE.                                       
+REMARK   3    B11 (A**2) : -1.35000                                             
+REMARK   3    B22 (A**2) : 3.27000                                              
+REMARK   3    B33 (A**2) : -1.92000                                             
+REMARK   3    B12 (A**2) : 1.36000                                              
+REMARK   3    B13 (A**2) : 0.00000                                              
+REMARK   3    B23 (A**2) : 0.00000                                              
+REMARK   3                                                                      
+REMARK   3  ESTIMATED COORDINATE ERROR.                                         
+REMARK   3   ESD FROM LUZZATI PLOT        (A) : 0.24                            
+REMARK   3   ESD FROM SIGMAA              (A) : 0.11                            
+REMARK   3   LOW RESOLUTION CUTOFF        (A) : 5.00                            
+REMARK   3                                                                      
+REMARK   3  CROSS-VALIDATED ESTIMATED COORDINATE ERROR.                         
+REMARK   3   ESD FROM C-V LUZZATI PLOT    (A) : 0.30                            
+REMARK   3   ESD FROM C-V SIGMAA          (A) : 0.11                            
+REMARK   3                                                                      
+REMARK   3  RMS DEVIATIONS FROM IDEAL VALUES.                                   
+REMARK   3   BOND LENGTHS                 (A) : 0.010                           
+REMARK   3   BOND ANGLES            (DEGREES) : 1.100                           
+REMARK   3   DIHEDRAL ANGLES        (DEGREES) : NULL                            
+REMARK   3   IMPROPER ANGLES        (DEGREES) : NULL                            
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL MODEL : OVERALL                                   
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL FACTOR RESTRAINTS.    RMS    SIGMA                
+REMARK   3   MAIN-CHAIN BOND              (A**2) : NULL  ; NULL                 
+REMARK   3   MAIN-CHAIN ANGLE             (A**2) : NULL  ; NULL                 
+REMARK   3   SIDE-CHAIN BOND              (A**2) : NULL  ; NULL                 
+REMARK   3   SIDE-CHAIN ANGLE             (A**2) : NULL  ; NULL                 
+REMARK   3                                                                      
+REMARK   3  BULK SOLVENT MODELING.                                              
+REMARK   3   METHOD USED : CNS BULK SOLVENT MODEL USED                          
+REMARK   3   KSOL        : 0.41                                                 
+REMARK   3   BSOL        : 84.27                                                
+REMARK   3                                                                      
+REMARK   3  NCS MODEL : NULL                                                    
+REMARK   3                                                                      
+REMARK   3  NCS RESTRAINTS.                         RMS   SIGMA/WEIGHT          
+REMARK   3   GROUP  1  POSITIONAL            (A) : NULL  ; NULL                 
+REMARK   3   GROUP  1  B-FACTOR           (A**2) : NULL  ; NULL                 
+REMARK   3                                                                      
+REMARK   3  PARAMETER FILE  1  : NULL                                           
+REMARK   3  TOPOLOGY FILE  1   : NULL                                           
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: NULL                                      
+REMARK   4                                                                      
+REMARK   4 1X0I COMPLIES WITH FORMAT V. 3.15, 01-DEC-08                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY PDBJ ON 24-MAR-05.                  
+REMARK 100 THE DEPOSITION ID IS D_1000024225.                                   
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : 28-NOV-04                          
+REMARK 200  TEMPERATURE           (KELVIN) : 100                                
+REMARK 200  PH                             : 2.00                               
+REMARK 200  NUMBER OF CRYSTALS USED        : 1                                  
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : Y                                  
+REMARK 200  RADIATION SOURCE               : SPRING-8                           
+REMARK 200  BEAMLINE                       : BL38B1                             
+REMARK 200  X-RAY GENERATOR MODEL          : NULL                               
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : M                                  
+REMARK 200  WAVELENGTH OR RANGE        (A) : 1.0                                
+REMARK 200  MONOCHROMATOR                  : DOUBLE-CRYSTAL                     
+REMARK 200  OPTICS                         : MIRRORS                            
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : CCD                                
+REMARK 200  DETECTOR MANUFACTURER          : RIGAKU JUPITER 210                 
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : MOSFLM                             
+REMARK 200  DATA SCALING SOFTWARE          : CCP4 (SCALA)                       
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : 15527                              
+REMARK 200  RESOLUTION RANGE HIGH      (A) : 2.300                              
+REMARK 200  RESOLUTION RANGE LOW       (A) : 54.520                             
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : 0.000                              
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : 99.7                               
+REMARK 200  DATA REDUNDANCY                : 6.600                              
+REMARK 200  R MERGE                    (I) : 0.07400                            
+REMARK 200  R SYM                      (I) : 0.07400                            
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : 6.3000                             
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : 2.30                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : 2.42                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : 100.0                              
+REMARK 200  DATA REDUNDANCY IN SHELL       : 6.10                               
+REMARK 200  R MERGE FOR SHELL          (I) : 0.50000                            
+REMARK 200  R SYM FOR SHELL            (I) : 0.50000                            
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : 1.600                              
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: SINGLE WAVELENGTH                              
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: MOLECULAR REPLACEMENT        
+REMARK 200 SOFTWARE USED: XTALVIEW                                              
+REMARK 200 STARTING MODEL: 1IW6                                                 
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 40.00                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 3.09                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: AMMONIUM SULFATE, PH 2.00, VAPOR         
+REMARK 280  DIFFUSION, SITTING DROP, TEMPERATURE 277K                           
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: P 6 2 2                          
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -Y,X-Y,Z                                                
+REMARK 290       3555   -X+Y,-X,Z                                               
+REMARK 290       4555   -X,-Y,Z                                                 
+REMARK 290       5555   Y,-X+Y,Z                                                
+REMARK 290       6555   X-Y,X,Z                                                 
+REMARK 290       7555   Y,X,-Z                                                  
+REMARK 290       8555   X-Y,-Y,-Z                                               
+REMARK 290       9555   -X,-X+Y,-Z                                              
+REMARK 290      10555   -Y,-X,-Z                                                
+REMARK 290      11555   -X+Y,Y,-Z                                               
+REMARK 290      12555   X,X-Y,-Z                                                
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -0.500000 -0.866025  0.000000        0.00000            
+REMARK 290   SMTRY2   2  0.866025 -0.500000  0.000000        0.00000            
+REMARK 290   SMTRY3   2  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   3 -0.500000  0.866025  0.000000        0.00000            
+REMARK 290   SMTRY2   3 -0.866025 -0.500000  0.000000        0.00000            
+REMARK 290   SMTRY3   3  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   4 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   4  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   4  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   5  0.500000  0.866025  0.000000        0.00000            
+REMARK 290   SMTRY2   5 -0.866025  0.500000  0.000000        0.00000            
+REMARK 290   SMTRY3   5  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   6  0.500000 -0.866025  0.000000        0.00000            
+REMARK 290   SMTRY2   6  0.866025  0.500000  0.000000        0.00000            
+REMARK 290   SMTRY3   6  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   7 -0.500000  0.866025  0.000000        0.00000            
+REMARK 290   SMTRY2   7  0.866025  0.500000  0.000000        0.00000            
+REMARK 290   SMTRY3   7  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY1   8  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   8  0.000000 -1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   8  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY1   9 -0.500000 -0.866025  0.000000        0.00000            
+REMARK 290   SMTRY2   9 -0.866025  0.500000  0.000000        0.00000            
+REMARK 290   SMTRY3   9  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY1  10  0.500000 -0.866025  0.000000        0.00000            
+REMARK 290   SMTRY2  10 -0.866025 -0.500000  0.000000        0.00000            
+REMARK 290   SMTRY3  10  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY1  11 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2  11  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3  11  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290   SMTRY1  12  0.500000  0.866025  0.000000        0.00000            
+REMARK 290   SMTRY2  12  0.866025 -0.500000  0.000000        0.00000            
+REMARK 290   SMTRY3  12  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1                                                       
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: TRIMERIC                          
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: 1                                     
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 350   BIOMT1   2 -0.500000 -0.866025  0.000000      102.64000            
+REMARK 350   BIOMT2   2  0.866025 -0.500000  0.000000        0.00000            
+REMARK 350   BIOMT3   2  0.000000  0.000000  1.000000        0.00000            
+REMARK 350   BIOMT1   3 -0.500000  0.866025  0.000000       51.32000            
+REMARK 350   BIOMT2   3 -0.866025 -0.500000  0.000000       88.88885            
+REMARK 350   BIOMT3   3  0.000000  0.000000  1.000000        0.00000            
+REMARK 465                                                                      
+REMARK 465 MISSING RESIDUES                                                     
+REMARK 465 THE FOLLOWING RESIDUES WERE NOT LOCATED IN THE                       
+REMARK 465 EXPERIMENT. (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 465 IDENTIFIER; SSSEQ=SEQUENCE NUMBER; I=INSERTION CODE.)                
+REMARK 465                                                                      
+REMARK 465   M RES C SSSEQI                                                     
+REMARK 465   1 GLN 1     1                                                      
+REMARK 465   1 ALA 1     2                                                      
+REMARK 465   1 GLN 1     3                                                      
+REMARK 465   1 ILE 1     4                                                      
+REMARK 465   1 THR 1     5                                                      
+REMARK 465   1 GLY 1     6                                                      
+REMARK 465   1 ARG 1     7                                                      
+REMARK 465   1 LEU 1    66                                                      
+REMARK 465   1 THR 1    67                                                      
+REMARK 465   1 MET 1    68                                                      
+REMARK 465   1 VAL 1    69                                                      
+REMARK 465   1 PRO 1    70                                                      
+REMARK 465   1 PHE 1    71                                                      
+REMARK 465   1 GLY 1    72                                                      
+REMARK 465   1 GLY 1    73                                                      
+REMARK 465   1 GLU 1    74                                                      
+REMARK 465   1 GLN 1    75                                                      
+REMARK 465   1 ASN 1    76                                                      
+REMARK 465   1 GLU 1   234                                                      
+REMARK 465   1 ALA 1   235                                                      
+REMARK 465   1 PRO 1   236                                                      
+REMARK 465   1 GLU 1   237                                                      
+REMARK 465   1 PRO 1   238                                                      
+REMARK 465   1 SER 1   239                                                      
+REMARK 465   1 ALA 1   240                                                      
+REMARK 465   1 GLY 1   241                                                      
+REMARK 465   1 ASP 1   242                                                      
+REMARK 465   1 GLY 1   243                                                      
+REMARK 465   1 ALA 1   244                                                      
+REMARK 465   1 ALA 1   245                                                      
+REMARK 465   1 ALA 1   246                                                      
+REMARK 465   1 THR 1   247                                                      
+REMARK 465   1 SER 1   248                                                      
+REMARK 465   2 GLN 1     1                                                      
+REMARK 465   2 ALA 1     2                                                      
+REMARK 465   2 GLN 1     3                                                      
+REMARK 465   2 ILE 1     4                                                      
+REMARK 465   2 THR 1     5                                                      
+REMARK 465   2 GLY 1     6                                                      
+REMARK 465   2 ARG 1     7                                                      
+REMARK 465   2 LEU 1    66                                                      
+REMARK 465   2 THR 1    67                                                      
+REMARK 465   2 MET 1    68                                                      
+REMARK 465   2 VAL 1    69                                                      
+REMARK 465   2 PRO 1    70                                                      
+REMARK 465   2 PHE 1    71                                                      
+REMARK 465   2 GLY 1    72                                                      
+REMARK 465   2 GLY 1    73                                                      
+REMARK 465   2 GLU 1    74                                                      
+REMARK 465   2 GLN 1    75                                                      
+REMARK 465   2 ASN 1    76                                                      
+REMARK 465   2 GLU 1   234                                                      
+REMARK 465   2 ALA 1   235                                                      
+REMARK 465   2 PRO 1   236                                                      
+REMARK 465   2 GLU 1   237                                                      
+REMARK 465   2 PRO 1   238                                                      
+REMARK 465   2 SER 1   239                                                      
+REMARK 465   2 ALA 1   240                                                      
+REMARK 465   2 GLY 1   241                                                      
+REMARK 465   2 ASP 1   242                                                      
+REMARK 465   2 GLY 1   243                                                      
+REMARK 465   2 ALA 1   244                                                      
+REMARK 465   2 ALA 1   245                                                      
+REMARK 465   2 ALA 1   246                                                      
+REMARK 465   2 THR 1   247                                                      
+REMARK 465   2 SER 1   248                                                      
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: COVALENT BOND ANGLES                                       
+REMARK 500                                                                      
+REMARK 500 THE STEREOCHEMICAL PARAMETERS OF THE FOLLOWING RESIDUES              
+REMARK 500 HAVE VALUES WHICH DEVIATE FROM EXPECTED VALUES BY MORE               
+REMARK 500 THAN 6*RMSD (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 500 IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                 
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT: (10X,I3,1X,A3,1X,A1,I4,A1,3(1X,A4,2X),12X,F5.1)              
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES PROTEIN: ENGH AND HUBER, 1999                        
+REMARK 500 EXPECTED VALUES NUCLEIC ACID: CLOWNEY ET AL 1996                     
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI ATM1   ATM2   ATM3                                     
+REMARK 500  1 PRO 1  50   C   -  N   -  CA  ANGL. DEV. = -10.3 DEGREES          
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500  1 ILE 1  78      126.09     67.46                                   
+REMARK 500  1 PHE 1 154      -70.97    -95.86                                   
+REMARK 500  1 GLU 1 232      -91.61   -106.19                                   
+REMARK 500  2 ILE 1  78      118.80     66.03                                   
+REMARK 500  2 SER 1 193       14.44    -63.35                                   
+REMARK 500  2 LYS 1 216      -65.83   -108.38                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 610                                                                      
+REMARK 610 MISSING HETEROATOM                                                   
+REMARK 610 THE FOLLOWING RESIDUES HAVE MISSING ATOMS (M=MODEL NUMBER;           
+REMARK 610 RES=RESIDUE NAME; C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER;          
+REMARK 610 I=INSERTION CODE):                                                   
+REMARK 610   M RES C SSEQI                                                      
+REMARK 610   1 L3P 1  260                                                       
+REMARK 610   1 L2P 1  270                                                       
+REMARK 610   1 L3P 1  280                                                       
+REMARK 610   1 L3P 1  290                                                       
+REMARK 610   2 L3P 1  260                                                       
+REMARK 610   2 L2P 1  270                                                       
+REMARK 610   2 L3P 1  280                                                       
+REMARK 610   2 L3P 1  290                                                       
+REMARK 800                                                                      
+REMARK 800 SITE                                                                 
+REMARK 800 SITE_IDENTIFIER: AC1                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE SO4 1 700                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC2                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE RET 1 250                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC3                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE L3P 1 260                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC4                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE L2P 1 270                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC5                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE L3P 1 280                 
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC6                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE L3P 1 290                 
+DBREF  1X0I 1    1   248  UNP    P02945   BACR_HALSA      14    261             
+SEQRES   1 1  248  GLN ALA GLN ILE THR GLY ARG PRO GLU TRP ILE TRP LEU          
+SEQRES   2 1  248  ALA LEU GLY THR ALA LEU MET GLY LEU GLY THR LEU TYR          
+SEQRES   3 1  248  PHE LEU VAL LYS GLY MET GLY VAL SER ASP PRO ASP ALA          
+SEQRES   4 1  248  LYS LYS PHE TYR ALA ILE THR THR LEU VAL PRO ALA ILE          
+SEQRES   5 1  248  ALA PHE THR MET TYR LEU SER MET LEU LEU GLY TYR GLY          
+SEQRES   6 1  248  LEU THR MET VAL PRO PHE GLY GLY GLU GLN ASN PRO ILE          
+SEQRES   7 1  248  TYR TRP ALA ARG TYR ALA ASP TRP LEU PHE THR THR PRO          
+SEQRES   8 1  248  LEU LEU LEU LEU ASP LEU ALA LEU LEU VAL ASP ALA ASP          
+SEQRES   9 1  248  GLN GLY THR ILE LEU ALA LEU VAL GLY ALA ASP GLY ILE          
+SEQRES  10 1  248  MET ILE GLY THR GLY LEU VAL GLY ALA LEU THR LYS VAL          
+SEQRES  11 1  248  TYR SER TYR ARG PHE VAL TRP TRP ALA ILE SER THR ALA          
+SEQRES  12 1  248  ALA MET LEU TYR ILE LEU TYR VAL LEU PHE PHE GLY PHE          
+SEQRES  13 1  248  THR SER LYS ALA GLU SER MET ARG PRO GLU VAL ALA SER          
+SEQRES  14 1  248  THR PHE LYS VAL LEU ARG ASN VAL THR VAL VAL LEU TRP          
+SEQRES  15 1  248  SER ALA TYR PRO VAL VAL TRP LEU ILE GLY SER GLU GLY          
+SEQRES  16 1  248  ALA GLY ILE VAL PRO LEU ASN ILE GLU THR LEU LEU PHE          
+SEQRES  17 1  248  MET VAL LEU ASP VAL SER ALA LYS VAL GLY PHE GLY LEU          
+SEQRES  18 1  248  ILE LEU LEU ARG SER ARG ALA ILE PHE GLY GLU ALA GLU          
+SEQRES  19 1  248  ALA PRO GLU PRO SER ALA GLY ASP GLY ALA ALA ALA THR          
+SEQRES  20 1  248  SER                                                          
+HET    SO4  1 700       5                                                       
+HET    RET  1 250      20                                                       
+HET    L3P  1 260      40                                                       
+HET    L2P  1 270      28                                                       
+HET    L3P  1 280      20                                                       
+HET    L3P  1 290      20                                                       
+HETNAM     SO4 SULFATE ION                                                      
+HETNAM     RET RETINAL                                                          
+HETNAM     L3P 2,3-DI-O-PHYTANLY-3-SN-GLYCERO-1-PHOSPHORYL-3'-SN-               
+HETNAM   2 L3P  GLYCEROL-1'-PHOSPHATE                                           
+HETNAM     L2P 2,3-DI-PHYTANYL-GLYCEROL                                         
+HETSYN     L2P 1,2-DI-1-(3,7,11,15-TETRAMETHYL-HEXADECANE)-SN-GLYCEROL          
+FORMUL   2  SO4    O4 S 2-                                                      
+FORMUL   3  RET    C20 H28 O                                                    
+FORMUL   4  L3P    3(C46 H94 O11 P2 2-)                                         
+FORMUL   5  L2P    C43 H88 O3                                                   
+FORMUL   8  HOH   *25(H2 O)                                                     
+HELIX    1   1 GLU 1    9  MET 1   32  1                                  24    
+HELIX    2   2 ASP 1   36  GLY 1   63  1                                  28    
+HELIX    3   3 TYR 1   79  VAL 1  101  1                                  23    
+HELIX    4   4 ASP 1  104  LEU 1  127  1                                  24    
+HELIX    5   5 VAL 1  130  PHE 1  154  1                                  25    
+HELIX    6   6 PHE 1  154  GLU 1  161  1                                   8    
+HELIX    7   7 ARG 1  164  GLY 1  192  1                                  29    
+HELIX    8   8 PRO 1  200  SER 1  226  1                                  27    
+LINK         NZ  LYS 1 216                 C15 RET 1 250     1555   1555  1.36  
+SITE     1 AC1 10 PRO 1  77  ARG 1  82  SER 1 193  GLU 1 194                    
+SITE     2 AC1 10 LEU 1 201  GLU 1 204  HOH 1 607  HOH 1 608                    
+SITE     3 AC1 10 HOH 1 609  HOH 1 612                                          
+SITE     1 AC2  9 TRP 1  86  TRP 1 138  SER 1 141  THR 1 142                    
+SITE     2 AC2  9 TRP 1 182  TYR 1 185  PRO 1 186  ASP 1 212                    
+SITE     3 AC2  9 LYS 1 216                                                     
+SITE     1 AC3  8 LEU 1  25  LYS 1  40  ALA 1  44  PHE 1  54                    
+SITE     2 AC3  8 THR 1 107  ILE 1 117  TYR 1 147  HOH 1 635                    
+SITE     1 AC4  7 THR 1  55  MET 1  56  PHE 1  88  THR 1 121                    
+SITE     2 AC4  7 LEU 1 123  VAL 1 124  LEU 1 127                               
+SITE     1 AC5  3 VAL 1 136  ALA 1 139  ILE 1 140                               
+SITE     1 AC6  1 LEU 1  15                                                     
+CRYST1  102.640  102.640  109.040  90.00  90.00 120.00 P 6 2 2      12          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.009743  0.005625  0.000000        0.00000                         
+SCALE2      0.000000  0.011250  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.009171        0.00000                         
+MODEL        1                                                                  
+ATOM      1  N   PRO 1   8      22.387  24.982   7.210  0.50 61.97           N  
+ATOM      2  CA  PRO 1   8      23.387  26.071   7.141  0.50 61.37           C  
+ATOM      3  C   PRO 1   8      24.098  26.240   8.481  0.50 59.70           C  
+ATOM      4  O   PRO 1   8      23.461  26.304   9.531  0.50 59.46           O  
+ATOM      5  CB  PRO 1   8      22.634  27.337   6.754  0.50 62.76           C  
+ATOM      6  CG  PRO 1   8      21.240  27.030   7.298  0.50 62.53           C  
+ATOM      7  CD  PRO 1   8      21.036  25.534   7.002  0.50 62.33           C  
+ATOM      8  N   GLU 1   9      25.425  26.310   8.432  0.50 58.45           N  
+ATOM      9  CA  GLU 1   9      26.235  26.456   9.633  0.50 57.81           C  
+ATOM     10  C   GLU 1   9      26.180  27.828  10.281  0.50 56.18           C  
+ATOM     11  O   GLU 1   9      26.275  27.948  11.503  0.50 55.76           O  
+ATOM     12  CB  GLU 1   9      27.690  26.123   9.324  0.50 58.73           C  
+ATOM     13  CG  GLU 1   9      27.935  24.667   9.037  0.50 61.40           C  
+ATOM     14  CD  GLU 1   9      29.406  24.341   9.009  0.50 63.43           C  
+ATOM     15  OE1 GLU 1   9      29.748  23.165   8.758  0.50 65.17           O  
+ATOM     16  OE2 GLU 1   9      30.219  25.262   9.242  0.50 63.29           O  
+ATOM     17  N   TRP 1  10      26.030  28.864   9.466  0.50 55.20           N  
+ATOM     18  CA  TRP 1  10      26.000  30.221   9.990  0.50 54.14           C  
+ATOM     19  C   TRP 1  10      25.033  30.408  11.156  0.50 52.43           C  
+ATOM     20  O   TRP 1  10      25.360  31.101  12.118  0.50 52.79           O  
+ATOM     21  CB  TRP 1  10      25.666  31.228   8.885  0.50 54.02           C  
+ATOM     22  CG  TRP 1  10      24.208  31.391   8.632  0.50 56.06           C  
+ATOM     23  CD1 TRP 1  10      23.433  30.665   7.775  0.50 57.27           C  
+ATOM     24  CD2 TRP 1  10      23.331  32.319   9.282  0.50 57.14           C  
+ATOM     25  NE1 TRP 1  10      22.125  31.083   7.850  0.50 58.09           N  
+ATOM     26  CE2 TRP 1  10      22.034  32.096   8.768  0.50 57.88           C  
+ATOM     27  CE3 TRP 1  10      23.515  33.316  10.252  0.50 56.93           C  
+ATOM     28  CZ2 TRP 1  10      20.923  32.838   9.194  0.50 57.84           C  
+ATOM     29  CZ3 TRP 1  10      22.411  34.052  10.676  0.50 56.94           C  
+ATOM     30  CH2 TRP 1  10      21.131  33.807  10.146  0.50 57.58           C  
+ATOM     31  N   ILE 1  11      23.857  29.787  11.088  0.50 50.69           N  
+ATOM     32  CA  ILE 1  11      22.879  29.948  12.159  0.50 50.31           C  
+ATOM     33  C   ILE 1  11      23.227  29.151  13.410  0.50 49.13           C  
+ATOM     34  O   ILE 1  11      22.732  29.447  14.500  0.50 49.15           O  
+ATOM     35  CB  ILE 1  11      21.441  29.587  11.692  0.50 51.12           C  
+ATOM     36  CG1 ILE 1  11      20.423  30.145  12.694  0.50 52.35           C  
+ATOM     37  CG2 ILE 1  11      21.279  28.084  11.574  0.50 51.09           C  
+ATOM     38  CD1 ILE 1  11      18.989  30.116  12.202  0.50 54.26           C  
+ATOM     39  N   TRP 1  12      24.070  28.135  13.251  0.50 47.27           N  
+ATOM     40  CA  TRP 1  12      24.508  27.337  14.388  0.50 46.00           C  
+ATOM     41  C   TRP 1  12      25.657  28.127  15.002  0.50 44.01           C  
+ATOM     42  O   TRP 1  12      25.781  28.217  16.222  0.50 42.88           O  
+ATOM     43  CB  TRP 1  12      25.005  25.966  13.932  0.50 47.16           C  
+ATOM     44  CG  TRP 1  12      23.998  25.192  13.130  0.50 48.66           C  
+ATOM     45  CD1 TRP 1  12      24.247  24.443  12.016  0.50 47.68           C  
+ATOM     46  CD2 TRP 1  12      22.587  25.081  13.382  0.50 48.54           C  
+ATOM     47  NE1 TRP 1  12      23.085  23.876  11.557  0.50 48.61           N  
+ATOM     48  CE2 TRP 1  12      22.053  24.247  12.374  0.50 49.03           C  
+ATOM     49  CE3 TRP 1  12      21.729  25.602  14.360  0.50 48.98           C  
+ATOM     50  CZ2 TRP 1  12      20.689  23.923  12.316  0.50 49.19           C  
+ATOM     51  CZ3 TRP 1  12      20.368  25.276  14.299  0.50 50.40           C  
+ATOM     52  CH2 TRP 1  12      19.867  24.444  13.283  0.50 49.21           C  
+ATOM     53  N   LEU 1  13      26.488  28.707  14.140  0.50 41.93           N  
+ATOM     54  CA  LEU 1  13      27.612  29.513  14.595  0.50 41.13           C  
+ATOM     55  C   LEU 1  13      27.122  30.856  15.142  0.50 41.03           C  
+ATOM     56  O   LEU 1  13      27.790  31.463  15.982  0.50 40.79           O  
+ATOM     57  CB  LEU 1  13      28.608  29.742  13.452  0.50 40.53           C  
+ATOM     58  CG  LEU 1  13      29.273  28.485  12.871  0.50 40.05           C  
+ATOM     59  CD1 LEU 1  13      30.115  28.859  11.653  0.50 40.46           C  
+ATOM     60  CD2 LEU 1  13      30.132  27.817  13.935  0.50 38.83           C  
+ATOM     61  N   ALA 1  14      25.956  31.313  14.672  0.50 40.78           N  
+ATOM     62  CA  ALA 1  14      25.381  32.587  15.130  0.50 40.69           C  
+ATOM     63  C   ALA 1  14      24.850  32.432  16.548  0.50 39.49           C  
+ATOM     64  O   ALA 1  14      25.088  33.278  17.409  0.50 40.45           O  
+ATOM     65  CB  ALA 1  14      24.250  33.040  14.193  0.50 42.12           C  
+ATOM     66  N   LEU 1  15      24.140  31.337  16.784  0.50 38.26           N  
+ATOM     67  CA  LEU 1  15      23.582  31.054  18.098  0.50 38.37           C  
+ATOM     68  C   LEU 1  15      24.705  30.847  19.120  0.50 38.27           C  
+ATOM     69  O   LEU 1  15      24.664  31.396  20.220  0.50 38.91           O  
+ATOM     70  CB  LEU 1  15      22.707  29.799  18.028  0.50 37.86           C  
+ATOM     71  CG  LEU 1  15      21.749  29.532  19.193  0.50 38.09           C  
+ATOM     72  CD1 LEU 1  15      20.684  30.621  19.226  0.50 38.62           C  
+ATOM     73  CD2 LEU 1  15      21.091  28.160  19.030  0.50 39.43           C  
+ATOM     74  N   GLY 1  16      25.705  30.048  18.749  0.50 38.32           N  
+ATOM     75  CA  GLY 1  16      26.818  29.790  19.649  0.50 37.75           C  
+ATOM     76  C   GLY 1  16      27.443  31.094  20.102  0.50 37.19           C  
+ATOM     77  O   GLY 1  16      27.700  31.313  21.284  0.50 37.51           O  
+ATOM     78  N   THR 1  17      27.688  31.971  19.144  0.50 36.80           N  
+ATOM     79  CA  THR 1  17      28.256  33.268  19.443  0.50 37.45           C  
+ATOM     80  C   THR 1  17      27.365  33.986  20.452  0.50 37.52           C  
+ATOM     81  O   THR 1  17      27.849  34.632  21.385  0.50 37.85           O  
+ATOM     82  CB  THR 1  17      28.342  34.116  18.171  0.50 37.17           C  
+ATOM     83  OG1 THR 1  17      29.099  33.406  17.183  0.50 39.09           O  
+ATOM     84  CG2 THR 1  17      29.005  35.454  18.460  0.50 37.66           C  
+ATOM     85  N   ALA 1  18      26.055  33.852  20.268  0.50 37.42           N  
+ATOM     86  CA  ALA 1  18      25.087  34.512  21.133  0.50 36.17           C  
+ATOM     87  C   ALA 1  18      25.049  33.954  22.541  0.50 36.30           C  
+ATOM     88  O   ALA 1  18      25.141  34.699  23.517  0.50 36.55           O  
+ATOM     89  CB  ALA 1  18      23.689  34.439  20.503  0.50 36.25           C  
+ATOM     90  N   LEU 1  19      24.920  32.642  22.657  0.50 36.32           N  
+ATOM     91  CA  LEU 1  19      24.856  32.033  23.974  0.50 35.82           C  
+ATOM     92  C   LEU 1  19      26.156  32.217  24.755  0.50 36.55           C  
+ATOM     93  O   LEU 1  19      26.129  32.470  25.960  0.50 36.08           O  
+ATOM     94  CB  LEU 1  19      24.474  30.556  23.840  0.50 35.42           C  
+ATOM     95  CG  LEU 1  19      23.056  30.362  23.257  0.50 37.28           C  
+ATOM     96  CD1 LEU 1  19      22.720  28.882  23.075  0.50 34.65           C  
+ATOM     97  CD2 LEU 1  19      22.046  31.011  24.197  0.50 35.60           C  
+ATOM     98  N   MET 1  20      27.298  32.100  24.082  0.50 36.15           N  
+ATOM     99  CA  MET 1  20      28.556  32.290  24.783  0.50 35.96           C  
+ATOM    100  C   MET 1  20      28.597  33.741  25.237  0.50 35.87           C  
+ATOM    101  O   MET 1  20      28.910  34.013  26.385  0.50 37.79           O  
+ATOM    102  CB  MET 1  20      29.760  31.972  23.882  0.50 35.87           C  
+ATOM    103  CG  MET 1  20      29.909  30.483  23.516  0.50 33.68           C  
+ATOM    104  SD  MET 1  20      30.167  29.356  24.927  0.50 33.73           S  
+ATOM    105  CE  MET 1  20      30.332  27.725  24.017  0.50 34.74           C  
+ATOM    106  N   GLY 1  21      28.250  34.672  24.352  0.50 37.47           N  
+ATOM    107  CA  GLY 1  21      28.253  36.080  24.727  0.50 38.36           C  
+ATOM    108  C   GLY 1  21      27.299  36.396  25.872  0.50 40.11           C  
+ATOM    109  O   GLY 1  21      27.631  37.170  26.767  0.50 41.39           O  
+ATOM    110  N   LEU 1  22      26.112  35.799  25.853  0.50 39.90           N  
+ATOM    111  CA  LEU 1  22      25.128  36.039  26.905  0.50 40.47           C  
+ATOM    112  C   LEU 1  22      25.591  35.448  28.231  0.50 40.36           C  
+ATOM    113  O   LEU 1  22      25.433  36.051  29.298  0.50 40.41           O  
+ATOM    114  CB  LEU 1  22      23.784  35.415  26.522  0.50 41.20           C  
+ATOM    115  CG  LEU 1  22      23.124  35.961  25.259  0.50 44.08           C  
+ATOM    116  CD1 LEU 1  22      21.857  35.158  24.985  0.50 44.68           C  
+ATOM    117  CD2 LEU 1  22      22.802  37.452  25.427  0.50 44.92           C  
+ATOM    118  N   GLY 1  23      26.157  34.249  28.153  0.50 39.16           N  
+ATOM    119  CA  GLY 1  23      26.642  33.594  29.347  0.50 36.61           C  
+ATOM    120  C   GLY 1  23      27.748  34.402  29.993  0.50 35.95           C  
+ATOM    121  O   GLY 1  23      27.740  34.605  31.207  0.50 36.41           O  
+ATOM    122  N   THR 1  24      28.705  34.880  29.203  0.50 36.15           N  
+ATOM    123  CA  THR 1  24      29.784  35.665  29.799  0.50 38.19           C  
+ATOM    124  C   THR 1  24      29.223  36.960  30.391  0.50 38.22           C  
+ATOM    125  O   THR 1  24      29.651  37.397  31.460  0.50 38.82           O  
+ATOM    126  CB  THR 1  24      30.954  35.926  28.768  0.50 37.30           C  
+ATOM    127  OG1 THR 1  24      31.652  37.137  29.097  0.50 35.87           O  
+ATOM    128  CG2 THR 1  24      30.430  35.978  27.369  0.50 36.63           C  
+ATOM    129  N   LEU 1  25      28.246  37.560  29.719  0.50 40.05           N  
+ATOM    130  CA  LEU 1  25      27.634  38.782  30.245  0.50 41.84           C  
+ATOM    131  C   LEU 1  25      26.958  38.485  31.584  0.50 40.81           C  
+ATOM    132  O   LEU 1  25      27.176  39.183  32.574  0.50 40.79           O  
+ATOM    133  CB  LEU 1  25      26.596  39.333  29.261  0.50 42.95           C  
+ATOM    134  CG  LEU 1  25      27.132  39.786  27.898  0.50 45.53           C  
+ATOM    135  CD1 LEU 1  25      26.017  40.424  27.084  0.50 46.93           C  
+ATOM    136  CD2 LEU 1  25      28.266  40.784  28.100  0.50 46.97           C  
+ATOM    137  N   TYR 1  26      26.129  37.448  31.610  0.50 41.37           N  
+ATOM    138  CA  TYR 1  26      25.442  37.072  32.838  0.50 41.47           C  
+ATOM    139  C   TYR 1  26      26.464  36.771  33.943  0.50 41.25           C  
+ATOM    140  O   TYR 1  26      26.346  37.265  35.070  0.50 41.47           O  
+ATOM    141  CB  TYR 1  26      24.547  35.855  32.584  0.50 41.30           C  
+ATOM    142  CG  TYR 1  26      23.946  35.257  33.838  0.50 43.49           C  
+ATOM    143  CD1 TYR 1  26      22.993  35.958  34.591  0.50 43.10           C  
+ATOM    144  CD2 TYR 1  26      24.347  33.994  34.288  0.50 43.02           C  
+ATOM    145  CE1 TYR 1  26      22.455  35.413  35.770  0.50 42.93           C  
+ATOM    146  CE2 TYR 1  26      23.823  33.440  35.456  0.50 43.23           C  
+ATOM    147  CZ  TYR 1  26      22.879  34.151  36.194  0.50 44.16           C  
+ATOM    148  OH  TYR 1  26      22.377  33.591  37.353  0.50 44.66           O  
+ATOM    149  N   PHE 1  27      27.474  35.968  33.626  0.50 40.34           N  
+ATOM    150  CA  PHE 1  27      28.491  35.638  34.625  0.50 40.25           C  
+ATOM    151  C   PHE 1  27      29.120  36.915  35.172  0.50 39.33           C  
+ATOM    152  O   PHE 1  27      29.392  37.038  36.371  0.50 39.98           O  
+ATOM    153  CB  PHE 1  27      29.587  34.737  34.015  0.50 39.10           C  
+ATOM    154  CG  PHE 1  27      29.113  33.347  33.661  0.50 39.57           C  
+ATOM    155  CD1 PHE 1  27      27.814  32.941  33.961  0.50 41.22           C  
+ATOM    156  CD2 PHE 1  27      29.959  32.447  33.026  0.50 39.16           C  
+ATOM    157  CE1 PHE 1  27      27.370  31.658  33.635  0.50 41.75           C  
+ATOM    158  CE2 PHE 1  27      29.521  31.167  32.701  0.50 40.98           C  
+ATOM    159  CZ  PHE 1  27      28.224  30.774  33.003  0.50 40.93           C  
+ATOM    160  N   LEU 1  28      29.337  37.873  34.286  0.50 39.09           N  
+ATOM    161  CA  LEU 1  28      29.942  39.129  34.680  0.50 40.99           C  
+ATOM    162  C   LEU 1  28      29.057  39.908  35.655  0.50 40.49           C  
+ATOM    163  O   LEU 1  28      29.543  40.528  36.604  0.50 40.51           O  
+ATOM    164  CB  LEU 1  28      30.219  39.974  33.436  0.50 42.60           C  
+ATOM    165  CG  LEU 1  28      31.607  40.610  33.365  0.50 46.11           C  
+ATOM    166  CD1 LEU 1  28      31.835  41.472  34.602  0.50 47.08           C  
+ATOM    167  CD2 LEU 1  28      32.671  39.530  33.284  0.50 46.76           C  
+ATOM    168  N   VAL 1  29      27.756  39.878  35.416  0.50 39.31           N  
+ATOM    169  CA  VAL 1  29      26.820  40.592  36.268  0.50 40.60           C  
+ATOM    170  C   VAL 1  29      26.760  39.989  37.673  0.50 41.34           C  
+ATOM    171  O   VAL 1  29      26.900  40.690  38.682  0.50 41.64           O  
+ATOM    172  CB  VAL 1  29      25.399  40.584  35.628  0.50 40.77           C  
+ATOM    173  CG1 VAL 1  29      24.383  41.223  36.566  0.50 40.46           C  
+ATOM    174  CG2 VAL 1  29      25.437  41.320  34.293  0.50 39.75           C  
+ATOM    175  N   LYS 1  30      26.562  38.677  37.728  0.50 42.15           N  
+ATOM    176  CA  LYS 1  30      26.468  37.957  38.991  0.50 42.06           C  
+ATOM    177  C   LYS 1  30      27.734  38.075  39.845  0.50 42.45           C  
+ATOM    178  O   LYS 1  30      27.666  38.038  41.072  0.50 42.75           O  
+ATOM    179  CB  LYS 1  30      26.140  36.488  38.704  0.50 43.50           C  
+ATOM    180  CG  LYS 1  30      25.885  35.641  39.934  0.50 46.91           C  
+ATOM    181  CD  LYS 1  30      25.132  34.356  39.585  0.50 47.73           C  
+ATOM    182  CE  LYS 1  30      25.065  33.419  40.786  0.50 49.25           C  
+ATOM    183  NZ  LYS 1  30      24.540  34.084  42.017  0.50 50.30           N  
+ATOM    184  N   GLY 1  31      28.887  38.232  39.201  0.50 43.09           N  
+ATOM    185  CA  GLY 1  31      30.128  38.344  39.944  0.50 44.45           C  
+ATOM    186  C   GLY 1  31      30.511  39.755  40.361  0.50 44.68           C  
+ATOM    187  O   GLY 1  31      31.399  39.943  41.186  0.50 43.51           O  
+ATOM    188  N   MET 1  32      29.841  40.755  39.800  0.50 46.44           N  
+ATOM    189  CA  MET 1  32      30.145  42.146  40.127  0.50 47.84           C  
+ATOM    190  C   MET 1  32      30.357  42.438  41.611  0.50 47.29           C  
+ATOM    191  O   MET 1  32      31.346  43.069  41.987  0.50 46.96           O  
+ATOM    192  CB  MET 1  32      29.047  43.069  39.605  0.50 49.68           C  
+ATOM    193  CG  MET 1  32      28.821  42.993  38.117  0.50 52.61           C  
+ATOM    194  SD  MET 1  32      28.002  44.476  37.527  0.50 57.62           S  
+ATOM    195  CE  MET 1  32      26.493  44.431  38.508  0.50 55.47           C  
+ATOM    196  N   GLY 1  33      29.434  41.989  42.455  0.50 47.83           N  
+ATOM    197  CA  GLY 1  33      29.570  42.260  43.879  0.50 49.71           C  
+ATOM    198  C   GLY 1  33      30.103  41.130  44.743  0.50 49.88           C  
+ATOM    199  O   GLY 1  33      29.504  40.811  45.774  0.50 50.87           O  
+ATOM    200  N   VAL 1  34      31.234  40.545  44.353  0.50 49.27           N  
+ATOM    201  CA  VAL 1  34      31.816  39.435  45.109  0.50 49.71           C  
+ATOM    202  C   VAL 1  34      33.128  39.774  45.822  0.50 50.11           C  
+ATOM    203  O   VAL 1  34      34.129  40.093  45.185  0.50 48.76           O  
+ATOM    204  CB  VAL 1  34      32.048  38.219  44.189  0.50 48.98           C  
+ATOM    205  CG1 VAL 1  34      32.752  37.112  44.956  0.50 50.12           C  
+ATOM    206  CG2 VAL 1  34      30.717  37.732  43.636  0.50 48.85           C  
+ATOM    207  N   SER 1  35      33.120  39.675  47.148  0.50 52.00           N  
+ATOM    208  CA  SER 1  35      34.304  39.989  47.944  0.50 53.43           C  
+ATOM    209  C   SER 1  35      35.092  38.752  48.366  0.50 53.68           C  
+ATOM    210  O   SER 1  35      36.320  38.784  48.446  0.50 53.89           O  
+ATOM    211  CB  SER 1  35      33.898  40.774  49.193  0.50 53.80           C  
+ATOM    212  OG  SER 1  35      33.065  39.990  50.032  0.50 54.98           O  
+ATOM    213  N   ASP 1  36      34.388  37.666  48.652  0.50 54.21           N  
+ATOM    214  CA  ASP 1  36      35.062  36.447  49.070  0.50 54.08           C  
+ATOM    215  C   ASP 1  36      36.071  36.048  48.006  0.50 53.67           C  
+ATOM    216  O   ASP 1  36      35.706  35.715  46.884  0.50 53.55           O  
+ATOM    217  CB  ASP 1  36      34.044  35.326  49.286  0.50 55.50           C  
+ATOM    218  CG  ASP 1  36      34.699  34.002  49.625  0.50 56.69           C  
+ATOM    219  OD1 ASP 1  36      35.530  33.963  50.561  0.50 56.44           O  
+ATOM    220  OD2 ASP 1  36      34.374  33.000  48.954  0.50 57.54           O  
+ATOM    221  N   PRO 1  37      37.367  36.099  48.343  0.50 53.98           N  
+ATOM    222  CA  PRO 1  37      38.402  35.733  47.376  0.50 53.24           C  
+ATOM    223  C   PRO 1  37      38.251  34.336  46.770  0.50 53.45           C  
+ATOM    224  O   PRO 1  37      38.665  34.099  45.636  0.50 53.80           O  
+ATOM    225  CB  PRO 1  37      39.701  35.907  48.172  0.50 52.98           C  
+ATOM    226  CG  PRO 1  37      39.275  35.800  49.610  0.50 52.83           C  
+ATOM    227  CD  PRO 1  37      37.967  36.539  49.615  0.50 53.21           C  
+ATOM    228  N   ASP 1  38      37.660  33.409  47.513  0.50 53.31           N  
+ATOM    229  CA  ASP 1  38      37.477  32.065  46.982  0.50 52.56           C  
+ATOM    230  C   ASP 1  38      36.536  32.172  45.790  0.50 51.67           C  
+ATOM    231  O   ASP 1  38      36.811  31.655  44.705  0.50 50.76           O  
+ATOM    232  CB  ASP 1  38      36.869  31.150  48.047  0.50 54.17           C  
+ATOM    233  CG  ASP 1  38      37.614  29.835  48.182  0.50 56.34           C  
+ATOM    234  OD1 ASP 1  38      38.848  29.882  48.364  0.50 56.44           O  
+ATOM    235  OD2 ASP 1  38      36.970  28.762  48.121  0.50 55.78           O  
+ATOM    236  N   ALA 1  39      35.425  32.865  46.007  0.50 49.95           N  
+ATOM    237  CA  ALA 1  39      34.420  33.049  44.974  0.50 48.25           C  
+ATOM    238  C   ALA 1  39      34.966  33.848  43.797  0.50 47.61           C  
+ATOM    239  O   ALA 1  39      34.612  33.589  42.642  0.50 47.93           O  
+ATOM    240  CB  ALA 1  39      33.195  33.739  45.562  0.50 47.26           C  
+ATOM    241  N   LYS 1  40      35.837  34.809  44.088  0.50 46.92           N  
+ATOM    242  CA  LYS 1  40      36.430  35.638  43.046  0.50 45.97           C  
+ATOM    243  C   LYS 1  40      37.193  34.793  42.039  0.50 44.76           C  
+ATOM    244  O   LYS 1  40      37.098  35.016  40.827  0.50 44.62           O  
+ATOM    245  CB  LYS 1  40      37.356  36.689  43.669  0.50 47.53           C  
+ATOM    246  CG  LYS 1  40      36.631  37.688  44.571  0.50 49.19           C  
+ATOM    247  CD  LYS 1  40      36.918  39.130  44.161  0.50 51.92           C  
+ATOM    248  CE  LYS 1  40      38.346  39.536  44.474  0.50 52.80           C  
+ATOM    249  NZ  LYS 1  40      38.596  39.601  45.941  0.50 55.59           N  
+ATOM    250  N   LYS 1  41      37.946  33.814  42.533  0.50 43.96           N  
+ATOM    251  CA  LYS 1  41      38.707  32.938  41.643  0.50 42.69           C  
+ATOM    252  C   LYS 1  41      37.753  32.147  40.761  0.50 40.86           C  
+ATOM    253  O   LYS 1  41      37.912  32.088  39.540  0.50 40.10           O  
+ATOM    254  CB  LYS 1  41      39.573  31.971  42.454  0.50 43.59           C  
+ATOM    255  CG  LYS 1  41      40.949  32.492  42.765  0.50 43.42           C  
+ATOM    256  CD  LYS 1  41      41.730  31.522  43.640  0.50 45.73           C  
+ATOM    257  CE  LYS 1  41      41.289  31.599  45.090  0.50 46.51           C  
+ATOM    258  NZ  LYS 1  41      42.298  30.992  46.001  0.50 48.15           N  
+ATOM    259  N   PHE 1  42      36.755  31.536  41.380  0.50 40.50           N  
+ATOM    260  CA  PHE 1  42      35.798  30.764  40.607  0.50 41.26           C  
+ATOM    261  C   PHE 1  42      35.114  31.626  39.554  0.50 40.84           C  
+ATOM    262  O   PHE 1  42      34.958  31.198  38.409  0.50 40.10           O  
+ATOM    263  CB  PHE 1  42      34.763  30.125  41.532  0.50 40.98           C  
+ATOM    264  CG  PHE 1  42      35.306  28.983  42.342  0.50 42.67           C  
+ATOM    265  CD1 PHE 1  42      35.770  27.825  41.710  0.50 43.67           C  
+ATOM    266  CD2 PHE 1  42      35.361  29.062  43.735  0.50 43.14           C  
+ATOM    267  CE1 PHE 1  42      36.282  26.755  42.453  0.50 44.98           C  
+ATOM    268  CE2 PHE 1  42      35.871  28.003  44.500  0.50 43.71           C  
+ATOM    269  CZ  PHE 1  42      36.336  26.840  43.858  0.50 44.44           C  
+ATOM    270  N   TYR 1  43      34.714  32.842  39.927  0.50 40.10           N  
+ATOM    271  CA  TYR 1  43      34.058  33.725  38.961  0.50 40.82           C  
+ATOM    272  C   TYR 1  43      35.007  34.095  37.842  0.50 40.00           C  
+ATOM    273  O   TYR 1  43      34.638  34.048  36.671  0.50 39.91           O  
+ATOM    274  CB  TYR 1  43      33.532  35.016  39.614  0.50 41.10           C  
+ATOM    275  CG  TYR 1  43      32.139  34.895  40.200  0.50 40.22           C  
+ATOM    276  CD1 TYR 1  43      31.946  34.779  41.576  0.50 41.15           C  
+ATOM    277  CD2 TYR 1  43      31.016  34.847  39.372  0.50 41.69           C  
+ATOM    278  CE1 TYR 1  43      30.663  34.615  42.119  0.50 41.51           C  
+ATOM    279  CE2 TYR 1  43      29.728  34.681  39.900  0.50 42.31           C  
+ATOM    280  CZ  TYR 1  43      29.560  34.562  41.274  0.50 43.10           C  
+ATOM    281  OH  TYR 1  43      28.294  34.373  41.798  0.50 44.34           O  
+ATOM    282  N   ALA 1  44      36.228  34.476  38.205  0.50 39.78           N  
+ATOM    283  CA  ALA 1  44      37.214  34.847  37.209  0.50 40.31           C  
+ATOM    284  C   ALA 1  44      37.487  33.679  36.266  0.50 40.31           C  
+ATOM    285  O   ALA 1  44      37.402  33.821  35.047  0.50 40.35           O  
+ATOM    286  CB  ALA 1  44      38.516  35.292  37.890  0.50 39.13           C  
+ATOM    287  N   ILE 1  45      37.811  32.522  36.834  0.50 40.56           N  
+ATOM    288  CA  ILE 1  45      38.100  31.351  36.018  0.50 41.26           C  
+ATOM    289  C   ILE 1  45      36.950  31.001  35.118  0.50 40.77           C  
+ATOM    290  O   ILE 1  45      37.110  30.863  33.904  0.50 41.64           O  
+ATOM    291  CB  ILE 1  45      38.346  30.101  36.858  0.50 42.41           C  
+ATOM    292  CG1 ILE 1  45      39.597  30.279  37.712  0.50 42.66           C  
+ATOM    293  CG2 ILE 1  45      38.491  28.874  35.931  0.50 43.00           C  
+ATOM    294  CD1 ILE 1  45      39.767  29.181  38.732  0.50 42.68           C  
+ATOM    295  N   THR 1  46      35.786  30.845  35.733  0.50 40.68           N  
+ATOM    296  CA  THR 1  46      34.586  30.447  35.019  0.50 40.32           C  
+ATOM    297  C   THR 1  46      34.097  31.429  33.978  0.50 40.81           C  
+ATOM    298  O   THR 1  46      33.542  31.020  32.964  0.50 41.47           O  
+ATOM    299  CB  THR 1  46      33.449  30.182  36.003  0.50 40.57           C  
+ATOM    300  OG1 THR 1  46      33.915  29.306  37.036  0.50 39.92           O  
+ATOM    301  CG2 THR 1  46      32.270  29.543  35.290  0.50 39.57           C  
+ATOM    302  N   THR 1  47      34.284  32.723  34.224  0.50 40.01           N  
+ATOM    303  CA  THR 1  47      33.834  33.738  33.274  0.50 39.61           C  
+ATOM    304  C   THR 1  47      34.761  33.829  32.064  0.50 39.38           C  
+ATOM    305  O   THR 1  47      34.319  34.127  30.950  0.50 39.68           O  
+ATOM    306  CB  THR 1  47      33.748  35.117  33.955  0.50 40.41           C  
+ATOM    307  OG1 THR 1  47      32.890  35.021  35.100  0.50 40.67           O  
+ATOM    308  CG2 THR 1  47      33.202  36.173  32.988  0.50 39.75           C  
+ATOM    309  N   LEU 1  48      36.046  33.562  32.271  0.50 38.83           N  
+ATOM    310  CA  LEU 1  48      37.006  33.624  31.165  0.50 38.21           C  
+ATOM    311  C   LEU 1  48      36.730  32.550  30.125  0.50 36.74           C  
+ATOM    312  O   LEU 1  48      36.882  32.786  28.927  0.50 36.39           O  
+ATOM    313  CB  LEU 1  48      38.436  33.428  31.668  0.50 37.34           C  
+ATOM    314  CG  LEU 1  48      39.492  34.404  31.143  0.50 38.04           C  
+ATOM    315  CD1 LEU 1  48      40.864  33.886  31.547  0.50 35.08           C  
+ATOM    316  CD2 LEU 1  48      39.404  34.548  29.635  0.50 36.42           C  
+ATOM    317  N   VAL 1  49      36.333  31.368  30.589  0.50 35.60           N  
+ATOM    318  CA  VAL 1  49      36.082  30.250  29.690  0.50 36.08           C  
+ATOM    319  C   VAL 1  49      35.059  30.698  28.686  0.50 37.05           C  
+ATOM    320  O   VAL 1  49      35.355  30.867  27.488  0.50 35.01           O  
+ATOM    321  CB  VAL 1  49      35.564  29.019  30.468  0.50 36.16           C  
+ATOM    322  CG1 VAL 1  49      34.843  28.034  29.531  0.50 34.26           C  
+ATOM    323  CG2 VAL 1  49      36.721  28.348  31.150  0.50 33.79           C  
+ATOM    324  N   PRO 1  50      33.813  30.885  29.147  0.50 39.45           N  
+ATOM    325  CA  PRO 1  50      32.960  31.327  28.045  0.50 41.53           C  
+ATOM    326  C   PRO 1  50      33.420  32.701  27.394  0.50 39.76           C  
+ATOM    327  O   PRO 1  50      33.141  32.890  26.208  0.50 43.43           O  
+ATOM    328  CB  PRO 1  50      31.542  31.340  28.674  0.50 39.52           C  
+ATOM    329  CG  PRO 1  50      31.795  31.710  30.088  0.50 41.70           C  
+ATOM    330  CD  PRO 1  50      33.089  30.921  30.436  0.50 40.37           C  
+ATOM    331  N   ALA 1  51      34.130  33.608  28.055  0.50 34.20           N  
+ATOM    332  CA  ALA 1  51      34.507  34.842  27.314  0.50 34.99           C  
+ATOM    333  C   ALA 1  51      35.383  34.530  26.101  0.50 34.38           C  
+ATOM    334  O   ALA 1  51      35.308  35.203  25.074  0.50 34.24           O  
+ATOM    335  CB  ALA 1  51      35.252  35.888  28.212  0.50 32.28           C  
+ATOM    336  N   ILE 1  52      36.229  33.515  26.224  0.50 34.06           N  
+ATOM    337  CA  ILE 1  52      37.126  33.119  25.135  0.50 34.73           C  
+ATOM    338  C   ILE 1  52      36.378  32.422  24.007  0.50 35.23           C  
+ATOM    339  O   ILE 1  52      36.575  32.737  22.831  0.50 35.55           O  
+ATOM    340  CB  ILE 1  52      38.252  32.189  25.667  0.50 34.41           C  
+ATOM    341  CG1 ILE 1  52      39.215  33.023  26.522  0.50 36.21           C  
+ATOM    342  CG2 ILE 1  52      39.001  31.509  24.507  0.50 34.29           C  
+ATOM    343  CD1 ILE 1  52      40.260  32.200  27.271  0.50 37.60           C  
+ATOM    344  N   ALA 1  53      35.504  31.485  24.359  0.50 35.89           N  
+ATOM    345  CA  ALA 1  53      34.758  30.771  23.336  0.50 36.17           C  
+ATOM    346  C   ALA 1  53      33.971  31.784  22.528  0.50 36.73           C  
+ATOM    347  O   ALA 1  53      33.809  31.636  21.314  0.50 37.22           O  
+ATOM    348  CB  ALA 1  53      33.834  29.765  23.971  0.50 35.88           C  
+ATOM    349  N   PHE 1  54      33.486  32.822  23.209  0.50 36.17           N  
+ATOM    350  CA  PHE 1  54      32.744  33.884  22.542  0.50 35.47           C  
+ATOM    351  C   PHE 1  54      33.518  34.429  21.358  0.50 35.13           C  
+ATOM    352  O   PHE 1  54      33.012  34.435  20.241  0.50 34.44           O  
+ATOM    353  CB  PHE 1  54      32.463  35.058  23.482  0.50 37.50           C  
+ATOM    354  CG  PHE 1  54      32.057  36.323  22.755  0.50 38.72           C  
+ATOM    355  CD1 PHE 1  54      30.821  36.415  22.115  0.50 39.17           C  
+ATOM    356  CD2 PHE 1  54      32.928  37.401  22.669  0.50 38.02           C  
+ATOM    357  CE1 PHE 1  54      30.462  37.571  21.395  0.50 40.26           C  
+ATOM    358  CE2 PHE 1  54      32.580  38.559  21.953  0.50 40.11           C  
+ATOM    359  CZ  PHE 1  54      31.344  38.642  21.315  0.50 39.46           C  
+ATOM    360  N   THR 1  55      34.739  34.910  21.602  0.50 35.48           N  
+ATOM    361  CA  THR 1  55      35.528  35.477  20.516  0.50 36.62           C  
+ATOM    362  C   THR 1  55      35.822  34.431  19.456  0.50 37.53           C  
+ATOM    363  O   THR 1  55      35.879  34.749  18.268  0.50 37.32           O  
+ATOM    364  CB  THR 1  55      36.869  36.087  21.012  0.50 36.85           C  
+ATOM    365  OG1 THR 1  55      37.706  35.053  21.538  0.50 38.62           O  
+ATOM    366  CG2 THR 1  55      36.619  37.132  22.097  0.50 36.52           C  
+ATOM    367  N   MET 1  56      35.983  33.179  19.879  0.50 37.78           N  
+ATOM    368  CA  MET 1  56      36.266  32.105  18.933  0.50 39.01           C  
+ATOM    369  C   MET 1  56      35.089  31.834  18.003  0.50 39.82           C  
+ATOM    370  O   MET 1  56      35.272  31.671  16.789  0.50 40.14           O  
+ATOM    371  CB  MET 1  56      36.646  30.813  19.666  0.50 40.67           C  
+ATOM    372  CG  MET 1  56      38.011  30.858  20.350  0.50 42.62           C  
+ATOM    373  SD  MET 1  56      39.390  31.144  19.190  0.50 46.53           S  
+ATOM    374  CE  MET 1  56      40.716  31.551  20.362  0.50 46.64           C  
+ATOM    375  N   TYR 1  57      33.883  31.764  18.561  0.50 39.12           N  
+ATOM    376  CA  TYR 1  57      32.711  31.527  17.724  0.50 39.85           C  
+ATOM    377  C   TYR 1  57      32.470  32.719  16.811  0.50 39.79           C  
+ATOM    378  O   TYR 1  57      32.086  32.556  15.651  0.50 38.45           O  
+ATOM    379  CB  TYR 1  57      31.457  31.238  18.565  0.50 39.89           C  
+ATOM    380  CG  TYR 1  57      31.213  29.760  18.735  0.50 40.94           C  
+ATOM    381  CD1 TYR 1  57      31.963  29.007  19.645  0.50 40.61           C  
+ATOM    382  CD2 TYR 1  57      30.320  29.089  17.902  0.50 40.83           C  
+ATOM    383  CE1 TYR 1  57      31.839  27.619  19.712  0.50 41.06           C  
+ATOM    384  CE2 TYR 1  57      30.187  27.701  17.956  0.50 41.32           C  
+ATOM    385  CZ  TYR 1  57      30.954  26.972  18.860  0.50 42.18           C  
+ATOM    386  OH  TYR 1  57      30.865  25.595  18.889  0.50 44.01           O  
+ATOM    387  N   LEU 1  58      32.705  33.923  17.320  0.50 40.07           N  
+ATOM    388  CA  LEU 1  58      32.514  35.097  16.480  0.50 41.50           C  
+ATOM    389  C   LEU 1  58      33.421  35.009  15.248  0.50 42.52           C  
+ATOM    390  O   LEU 1  58      32.985  35.322  14.139  0.50 42.34           O  
+ATOM    391  CB  LEU 1  58      32.796  36.390  17.255  0.50 40.13           C  
+ATOM    392  CG  LEU 1  58      32.580  37.709  16.495  0.50 40.71           C  
+ATOM    393  CD1 LEU 1  58      31.110  37.925  16.165  0.50 39.34           C  
+ATOM    394  CD2 LEU 1  58      33.069  38.852  17.362  0.50 40.55           C  
+ATOM    395  N   SER 1  59      34.672  34.567  15.420  0.50 43.78           N  
+ATOM    396  CA  SER 1  59      35.573  34.467  14.265  0.50 44.56           C  
+ATOM    397  C   SER 1  59      35.063  33.413  13.288  0.50 44.58           C  
+ATOM    398  O   SER 1  59      35.221  33.552  12.075  0.50 43.52           O  
+ATOM    399  CB  SER 1  59      37.015  34.139  14.688  0.50 45.15           C  
+ATOM    400  OG  SER 1  59      37.170  32.786  15.081  0.50 47.45           O  
+ATOM    401  N   MET 1  60      34.456  32.352  13.808  0.50 45.90           N  
+ATOM    402  CA  MET 1  60      33.918  31.328  12.920  0.50 47.63           C  
+ATOM    403  C   MET 1  60      32.728  31.916  12.158  0.50 48.11           C  
+ATOM    404  O   MET 1  60      32.592  31.707  10.955  0.50 48.69           O  
+ATOM    405  CB  MET 1  60      33.488  30.084  13.706  0.50 48.28           C  
+ATOM    406  CG  MET 1  60      34.636  29.166  14.115  0.50 49.41           C  
+ATOM    407  SD  MET 1  60      34.080  27.704  15.057  0.50 50.98           S  
+ATOM    408  CE  MET 1  60      34.469  28.189  16.725  0.50 47.88           C  
+ATOM    409  N   LEU 1  61      31.878  32.667  12.853  0.50 48.85           N  
+ATOM    410  CA  LEU 1  61      30.723  33.287  12.209  0.50 49.35           C  
+ATOM    411  C   LEU 1  61      31.159  34.269  11.123  0.50 51.05           C  
+ATOM    412  O   LEU 1  61      30.656  34.226  10.004  0.50 50.79           O  
+ATOM    413  CB  LEU 1  61      29.863  34.027  13.237  0.50 48.22           C  
+ATOM    414  CG  LEU 1  61      28.653  34.801  12.689  0.50 48.86           C  
+ATOM    415  CD1 LEU 1  61      27.669  33.834  12.033  0.50 48.32           C  
+ATOM    416  CD2 LEU 1  61      27.969  35.567  13.809  0.50 48.09           C  
+ATOM    417  N   LEU 1  62      32.086  35.161  11.453  0.50 52.99           N  
+ATOM    418  CA  LEU 1  62      32.557  36.140  10.480  0.50 55.34           C  
+ATOM    419  C   LEU 1  62      33.484  35.474   9.481  0.50 57.57           C  
+ATOM    420  O   LEU 1  62      33.833  36.061   8.458  0.50 57.73           O  
+ATOM    421  CB  LEU 1  62      33.295  37.284  11.177  0.50 54.39           C  
+ATOM    422  CG  LEU 1  62      32.503  38.071  12.223  0.50 54.97           C  
+ATOM    423  CD1 LEU 1  62      33.367  39.211  12.758  0.50 54.84           C  
+ATOM    424  CD2 LEU 1  62      31.220  38.614  11.600  0.50 54.10           C  
+ATOM    425  N   GLY 1  63      33.872  34.240   9.783  0.50 60.07           N  
+ATOM    426  CA  GLY 1  63      34.767  33.506   8.907  0.50 63.28           C  
+ATOM    427  C   GLY 1  63      34.213  33.256   7.518  0.50 65.47           C  
+ATOM    428  O   GLY 1  63      34.968  33.035   6.575  0.50 66.16           O  
+ATOM    429  N   TYR 1  64      32.890  33.292   7.390  0.50 67.56           N  
+ATOM    430  CA  TYR 1  64      32.229  33.059   6.108  0.50 69.16           C  
+ATOM    431  C   TYR 1  64      32.163  34.298   5.219  0.50 69.16           C  
+ATOM    432  O   TYR 1  64      31.501  35.284   5.551  0.50 68.69           O  
+ATOM    433  CB  TYR 1  64      30.818  32.515   6.344  0.50 70.99           C  
+ATOM    434  CG  TYR 1  64      30.778  31.023   6.598  0.50 72.96           C  
+ATOM    435  CD1 TYR 1  64      30.866  30.119   5.540  0.50 73.37           C  
+ATOM    436  CD2 TYR 1  64      30.664  30.514   7.894  0.50 72.86           C  
+ATOM    437  CE1 TYR 1  64      30.847  28.744   5.762  0.50 73.74           C  
+ATOM    438  CE2 TYR 1  64      30.640  29.142   8.127  0.50 73.85           C  
+ATOM    439  CZ  TYR 1  64      30.731  28.264   7.056  0.50 74.24           C  
+ATOM    440  OH  TYR 1  64      30.700  26.907   7.278  0.50 74.49           O  
+ATOM    441  N   GLY 1  65      32.852  34.232   4.084  0.50 69.63           N  
+ATOM    442  CA  GLY 1  65      32.869  35.348   3.156  0.50 69.95           C  
+ATOM    443  C   GLY 1  65      34.230  35.513   2.508  0.50 69.79           C  
+ATOM    444  O   GLY 1  65      34.899  34.527   2.196  0.50 70.42           O  
+ATOM    445  N   PRO 1  77      37.050  20.938   5.051  0.50 69.72           N  
+ATOM    446  CA  PRO 1  77      36.546  21.723   6.183  0.50 69.57           C  
+ATOM    447  C   PRO 1  77      37.677  22.307   7.028  0.50 69.21           C  
+ATOM    448  O   PRO 1  77      38.360  23.245   6.609  0.50 69.66           O  
+ATOM    449  CB  PRO 1  77      35.709  20.706   6.952  0.50 69.72           C  
+ATOM    450  CG  PRO 1  77      35.159  19.849   5.856  0.50 70.17           C  
+ATOM    451  CD  PRO 1  77      36.370  19.633   4.975  0.50 69.81           C  
+ATOM    452  N   ILE 1  78      37.863  21.749   8.220  0.50 68.28           N  
+ATOM    453  CA  ILE 1  78      38.915  22.192   9.128  0.50 67.50           C  
+ATOM    454  C   ILE 1  78      38.668  23.604   9.661  0.50 66.48           C  
+ATOM    455  O   ILE 1  78      38.469  24.546   8.891  0.50 66.51           O  
+ATOM    456  CB  ILE 1  78      40.298  22.156   8.428  0.50 67.33           C  
+ATOM    457  CG1 ILE 1  78      40.522  20.786   7.775  0.50 67.21           C  
+ATOM    458  CG2 ILE 1  78      41.398  22.442   9.438  0.50 67.39           C  
+ATOM    459  CD1 ILE 1  78      41.761  20.709   6.891  0.50 66.03           C  
+ATOM    460  N   TYR 1  79      38.680  23.739  10.986  0.50 64.46           N  
+ATOM    461  CA  TYR 1  79      38.470  25.029  11.636  0.50 62.10           C  
+ATOM    462  C   TYR 1  79      39.396  25.191  12.832  0.50 60.23           C  
+ATOM    463  O   TYR 1  79      39.169  24.608  13.892  0.50 60.41           O  
+ATOM    464  CB  TYR 1  79      37.025  25.164  12.109  0.50 63.18           C  
+ATOM    465  CG  TYR 1  79      36.279  26.324  11.492  0.50 64.07           C  
+ATOM    466  CD1 TYR 1  79      36.849  27.596  11.430  0.50 64.37           C  
+ATOM    467  CD2 TYR 1  79      34.990  26.154  10.993  0.50 63.82           C  
+ATOM    468  CE1 TYR 1  79      36.149  28.672  10.886  0.50 64.29           C  
+ATOM    469  CE2 TYR 1  79      34.281  27.220  10.450  0.50 64.24           C  
+ATOM    470  CZ  TYR 1  79      34.864  28.477  10.399  0.50 64.80           C  
+ATOM    471  OH  TYR 1  79      34.152  29.533   9.874  0.50 64.99           O  
+ATOM    472  N   TRP 1  80      40.438  25.992  12.660  0.50 57.76           N  
+ATOM    473  CA  TRP 1  80      41.390  26.223  13.729  0.50 55.05           C  
+ATOM    474  C   TRP 1  80      40.737  26.877  14.945  0.50 51.94           C  
+ATOM    475  O   TRP 1  80      41.080  26.566  16.081  0.50 52.82           O  
+ATOM    476  CB  TRP 1  80      42.541  27.092  13.220  0.50 56.86           C  
+ATOM    477  CG  TRP 1  80      43.335  26.438  12.138  0.50 57.94           C  
+ATOM    478  CD1 TRP 1  80      42.910  26.134  10.874  0.50 59.62           C  
+ATOM    479  CD2 TRP 1  80      44.683  25.976  12.228  0.50 58.73           C  
+ATOM    480  NE1 TRP 1  80      43.911  25.507  10.174  0.50 59.33           N  
+ATOM    481  CE2 TRP 1  80      45.018  25.395  10.985  0.50 59.25           C  
+ATOM    482  CE3 TRP 1  80      45.651  25.988  13.245  0.50 58.39           C  
+ATOM    483  CZ2 TRP 1  80      46.270  24.837  10.721  0.50 59.80           C  
+ATOM    484  CZ3 TRP 1  80      46.900  25.433  12.987  0.50 59.39           C  
+ATOM    485  CH2 TRP 1  80      47.197  24.863  11.734  0.50 59.60           C  
+ATOM    486  N   ALA 1  81      39.796  27.780  14.705  0.50 48.25           N  
+ATOM    487  CA  ALA 1  81      39.112  28.464  15.794  0.50 46.56           C  
+ATOM    488  C   ALA 1  81      38.461  27.458  16.743  0.50 44.75           C  
+ATOM    489  O   ALA 1  81      38.416  27.660  17.962  0.50 44.08           O  
+ATOM    490  CB  ALA 1  81      38.053  29.419  15.232  0.50 46.06           C  
+ATOM    491  N   ARG 1  82      37.965  26.365  16.182  0.50 43.58           N  
+ATOM    492  CA  ARG 1  82      37.317  25.342  16.984  0.50 44.09           C  
+ATOM    493  C   ARG 1  82      38.282  24.665  17.952  0.50 42.95           C  
+ATOM    494  O   ARG 1  82      37.926  24.380  19.097  0.50 43.31           O  
+ATOM    495  CB  ARG 1  82      36.673  24.300  16.068  0.50 44.88           C  
+ATOM    496  CG  ARG 1  82      36.053  23.121  16.788  0.50 46.57           C  
+ATOM    497  CD  ARG 1  82      35.545  22.099  15.777  0.50 48.27           C  
+ATOM    498  NE  ARG 1  82      34.439  22.608  14.965  0.50 48.13           N  
+ATOM    499  CZ  ARG 1  82      33.992  22.027  13.854  0.50 49.40           C  
+ATOM    500  NH1 ARG 1  82      32.978  22.563  13.187  0.50 49.14           N  
+ATOM    501  NH2 ARG 1  82      34.563  20.916  13.400  0.50 49.12           N  
+ATOM    502  N   TYR 1  83      39.504  24.415  17.498  0.50 43.10           N  
+ATOM    503  CA  TYR 1  83      40.504  23.748  18.328  0.50 43.08           C  
+ATOM    504  C   TYR 1  83      41.219  24.682  19.282  0.50 43.11           C  
+ATOM    505  O   TYR 1  83      41.609  24.276  20.390  0.50 42.84           O  
+ATOM    506  CB  TYR 1  83      41.509  23.008  17.440  0.50 44.98           C  
+ATOM    507  CG  TYR 1  83      40.911  21.770  16.803  0.50 48.45           C  
+ATOM    508  CD1 TYR 1  83      39.949  21.876  15.796  0.50 49.14           C  
+ATOM    509  CD2 TYR 1  83      41.263  20.492  17.248  0.50 48.82           C  
+ATOM    510  CE1 TYR 1  83      39.346  20.741  15.246  0.50 50.01           C  
+ATOM    511  CE2 TYR 1  83      40.666  19.347  16.706  0.50 50.47           C  
+ATOM    512  CZ  TYR 1  83      39.708  19.479  15.706  0.50 51.19           C  
+ATOM    513  OH  TYR 1  83      39.103  18.352  15.182  0.50 51.90           O  
+ATOM    514  N   ALA 1  84      41.395  25.929  18.857  0.50 41.14           N  
+ATOM    515  CA  ALA 1  84      42.030  26.933  19.706  0.50 40.94           C  
+ATOM    516  C   ALA 1  84      41.090  27.196  20.887  0.50 40.19           C  
+ATOM    517  O   ALA 1  84      41.527  27.324  22.034  0.50 40.38           O  
+ATOM    518  CB  ALA 1  84      42.264  28.218  18.910  0.50 41.08           C  
+ATOM    519  N   ASP 1  85      39.793  27.268  20.603  0.50 39.75           N  
+ATOM    520  CA  ASP 1  85      38.817  27.490  21.660  0.50 39.39           C  
+ATOM    521  C   ASP 1  85      39.022  26.396  22.698  0.50 39.04           C  
+ATOM    522  O   ASP 1  85      39.259  26.667  23.870  0.50 40.05           O  
+ATOM    523  CB  ASP 1  85      37.389  27.395  21.110  0.50 39.60           C  
+ATOM    524  CG  ASP 1  85      36.330  27.558  22.197  0.50 41.66           C  
+ATOM    525  OD1 ASP 1  85      35.255  26.925  22.102  0.50 42.29           O  
+ATOM    526  OD2 ASP 1  85      36.567  28.330  23.151  0.50 43.19           O  
+ATOM    527  N   TRP 1  86      38.947  25.149  22.253  0.50 39.27           N  
+ATOM    528  CA  TRP 1  86      39.113  24.017  23.153  0.50 39.27           C  
+ATOM    529  C   TRP 1  86      40.446  24.051  23.876  0.50 39.31           C  
+ATOM    530  O   TRP 1  86      40.521  23.801  25.080  0.50 39.63           O  
+ATOM    531  CB  TRP 1  86      38.995  22.706  22.374  0.50 40.58           C  
+ATOM    532  CG  TRP 1  86      37.662  22.514  21.702  0.50 40.88           C  
+ATOM    533  CD1 TRP 1  86      36.507  23.182  21.976  0.50 41.04           C  
+ATOM    534  CD2 TRP 1  86      37.335  21.543  20.701  0.50 41.09           C  
+ATOM    535  NE1 TRP 1  86      35.479  22.687  21.214  0.50 41.69           N  
+ATOM    536  CE2 TRP 1  86      35.959  21.678  20.422  0.50 42.22           C  
+ATOM    537  CE3 TRP 1  86      38.071  20.569  20.015  0.50 41.44           C  
+ATOM    538  CZ2 TRP 1  86      35.296  20.872  19.480  0.50 43.31           C  
+ATOM    539  CZ3 TRP 1  86      37.413  19.767  19.078  0.50 42.84           C  
+ATOM    540  CH2 TRP 1  86      36.040  19.925  18.822  0.50 42.83           C  
+ATOM    541  N   LEU 1  87      41.503  24.355  23.132  0.50 39.31           N  
+ATOM    542  CA  LEU 1  87      42.838  24.407  23.704  0.50 39.87           C  
+ATOM    543  C   LEU 1  87      42.946  25.399  24.859  0.50 39.51           C  
+ATOM    544  O   LEU 1  87      43.510  25.092  25.909  0.50 39.19           O  
+ATOM    545  CB  LEU 1  87      43.868  24.774  22.625  0.50 40.35           C  
+ATOM    546  CG  LEU 1  87      45.325  24.914  23.100  0.50 42.07           C  
+ATOM    547  CD1 LEU 1  87      45.831  23.586  23.644  0.50 40.41           C  
+ATOM    548  CD2 LEU 1  87      46.205  25.377  21.935  0.50 41.40           C  
+ATOM    549  N   PHE 1  88      42.394  26.590  24.684  0.50 39.52           N  
+ATOM    550  CA  PHE 1  88      42.508  27.582  25.739  0.50 39.16           C  
+ATOM    551  C   PHE 1  88      41.501  27.451  26.883  0.50 38.62           C  
+ATOM    552  O   PHE 1  88      41.790  27.821  28.023  0.50 38.96           O  
+ATOM    553  CB  PHE 1  88      42.422  28.987  25.139  0.50 41.35           C  
+ATOM    554  CG  PHE 1  88      43.397  29.234  24.018  0.50 42.40           C  
+ATOM    555  CD1 PHE 1  88      44.700  28.752  24.087  0.50 43.27           C  
+ATOM    556  CD2 PHE 1  88      43.010  29.965  22.900  0.50 43.55           C  
+ATOM    557  CE1 PHE 1  88      45.608  28.993  23.055  0.50 44.45           C  
+ATOM    558  CE2 PHE 1  88      43.907  30.215  21.860  0.50 44.56           C  
+ATOM    559  CZ  PHE 1  88      45.209  29.727  21.938  0.50 44.32           C  
+ATOM    560  N   THR 1  89      40.335  26.900  26.592  0.50 37.59           N  
+ATOM    561  CA  THR 1  89      39.291  26.775  27.594  0.50 38.53           C  
+ATOM    562  C   THR 1  89      39.246  25.507  28.457  0.50 38.65           C  
+ATOM    563  O   THR 1  89      38.856  25.568  29.624  0.50 38.91           O  
+ATOM    564  CB  THR 1  89      37.934  26.965  26.929  0.50 39.31           C  
+ATOM    565  OG1 THR 1  89      37.745  28.359  26.643  0.50 36.86           O  
+ATOM    566  CG2 THR 1  89      36.842  26.474  27.825  0.50 42.04           C  
+ATOM    567  N   THR 1  90      39.626  24.363  27.900  0.50 38.69           N  
+ATOM    568  CA  THR 1  90      39.596  23.128  28.676  0.50 38.74           C  
+ATOM    569  C   THR 1  90      40.464  23.198  29.935  0.50 38.40           C  
+ATOM    570  O   THR 1  90      40.075  22.707  30.994  0.50 40.03           O  
+ATOM    571  CB  THR 1  90      40.005  21.892  27.806  0.50 39.05           C  
+ATOM    572  OG1 THR 1  90      41.232  22.154  27.116  0.50 38.97           O  
+ATOM    573  CG2 THR 1  90      38.919  21.573  26.791  0.50 38.26           C  
+ATOM    574  N   PRO 1  91      41.644  23.835  29.851  0.50 39.27           N  
+ATOM    575  CA  PRO 1  91      42.502  23.919  31.045  0.50 38.40           C  
+ATOM    576  C   PRO 1  91      41.827  24.641  32.209  0.50 38.99           C  
+ATOM    577  O   PRO 1  91      41.907  24.204  33.359  0.50 40.13           O  
+ATOM    578  CB  PRO 1  91      43.737  24.665  30.533  0.50 37.82           C  
+ATOM    579  CG  PRO 1  91      43.782  24.291  29.077  0.50 38.18           C  
+ATOM    580  CD  PRO 1  91      42.327  24.399  28.672  0.50 38.27           C  
+ATOM    581  N   LEU 1  92      41.162  25.753  31.905  0.50 39.07           N  
+ATOM    582  CA  LEU 1  92      40.458  26.538  32.919  0.50 38.11           C  
+ATOM    583  C   LEU 1  92      39.345  25.715  33.534  0.50 37.51           C  
+ATOM    584  O   LEU 1  92      39.116  25.760  34.747  0.50 37.96           O  
+ATOM    585  CB  LEU 1  92      39.863  27.801  32.287  0.50 39.88           C  
+ATOM    586  CG  LEU 1  92      40.902  28.753  31.680  0.50 41.00           C  
+ATOM    587  CD1 LEU 1  92      40.206  29.884  30.912  0.50 41.50           C  
+ATOM    588  CD2 LEU 1  92      41.771  29.311  32.804  0.50 39.98           C  
+ATOM    589  N   LEU 1  93      38.644  24.966  32.688  0.50 37.06           N  
+ATOM    590  CA  LEU 1  93      37.549  24.122  33.159  0.50 36.85           C  
+ATOM    591  C   LEU 1  93      38.090  23.153  34.211  0.50 35.84           C  
+ATOM    592  O   LEU 1  93      37.515  23.011  35.284  0.50 36.67           O  
+ATOM    593  CB  LEU 1  93      36.919  23.362  31.980  0.50 34.04           C  
+ATOM    594  CG  LEU 1  93      35.624  23.826  31.279  0.50 34.74           C  
+ATOM    595  CD1 LEU 1  93      35.402  25.308  31.430  0.50 30.45           C  
+ATOM    596  CD2 LEU 1  93      35.672  23.416  29.799  0.50 29.52           C  
+ATOM    597  N   LEU 1  94      39.204  22.491  33.923  0.50 36.81           N  
+ATOM    598  CA  LEU 1  94      39.747  21.570  34.913  0.50 36.50           C  
+ATOM    599  C   LEU 1  94      40.214  22.335  36.154  0.50 37.28           C  
+ATOM    600  O   LEU 1  94      40.093  21.843  37.278  0.50 38.01           O  
+ATOM    601  CB  LEU 1  94      40.910  20.758  34.336  0.50 36.21           C  
+ATOM    602  CG  LEU 1  94      40.744  19.598  33.327  0.50 36.49           C  
+ATOM    603  CD1 LEU 1  94      39.486  18.784  33.603  0.50 33.69           C  
+ATOM    604  CD2 LEU 1  94      40.742  20.136  31.929  0.50 34.21           C  
+ATOM    605  N   LEU 1  95      40.749  23.536  35.965  0.50 37.46           N  
+ATOM    606  CA  LEU 1  95      41.200  24.327  37.111  0.50 38.17           C  
+ATOM    607  C   LEU 1  95      40.028  24.526  38.080  0.50 38.01           C  
+ATOM    608  O   LEU 1  95      40.183  24.387  39.299  0.50 37.94           O  
+ATOM    609  CB  LEU 1  95      41.757  25.679  36.640  0.50 38.52           C  
+ATOM    610  CG  LEU 1  95      42.416  26.585  37.686  0.50 39.20           C  
+ATOM    611  CD1 LEU 1  95      43.583  25.870  38.363  0.50 35.43           C  
+ATOM    612  CD2 LEU 1  95      42.904  27.858  36.998  0.50 38.75           C  
+ATOM    613  N   ASP 1  96      38.853  24.835  37.534  0.50 38.45           N  
+ATOM    614  CA  ASP 1  96      37.657  25.016  38.360  0.50 38.84           C  
+ATOM    615  C   ASP 1  96      37.442  23.808  39.271  0.50 39.74           C  
+ATOM    616  O   ASP 1  96      37.279  23.937  40.488  0.50 40.50           O  
+ATOM    617  CB  ASP 1  96      36.406  25.174  37.486  0.50 39.10           C  
+ATOM    618  CG  ASP 1  96      35.979  26.616  37.319  0.50 39.56           C  
+ATOM    619  OD1 ASP 1  96      36.284  27.445  38.207  0.50 38.22           O  
+ATOM    620  OD2 ASP 1  96      35.318  26.915  36.300  0.50 39.88           O  
+ATOM    621  N   LEU 1  97      37.420  22.632  38.658  0.50 40.07           N  
+ATOM    622  CA  LEU 1  97      37.217  21.390  39.391  0.50 40.50           C  
+ATOM    623  C   LEU 1  97      38.354  21.175  40.389  0.50 42.08           C  
+ATOM    624  O   LEU 1  97      38.130  20.785  41.541  0.50 42.36           O  
+ATOM    625  CB  LEU 1  97      37.130  20.219  38.394  0.50 39.76           C  
+ATOM    626  CG  LEU 1  97      35.769  19.755  37.833  0.50 42.08           C  
+ATOM    627  CD1 LEU 1  97      34.654  20.706  38.241  0.50 39.39           C  
+ATOM    628  CD2 LEU 1  97      35.839  19.622  36.315  0.50 40.65           C  
+ATOM    629  N   ALA 1  98      39.577  21.445  39.946  0.50 43.17           N  
+ATOM    630  CA  ALA 1  98      40.746  21.274  40.800  0.50 44.68           C  
+ATOM    631  C   ALA 1  98      40.649  22.123  42.064  0.50 45.44           C  
+ATOM    632  O   ALA 1  98      40.805  21.621  43.179  0.50 46.43           O  
+ATOM    633  CB  ALA 1  98      42.020  21.630  40.028  0.50 44.39           C  
+ATOM    634  N   LEU 1  99      40.389  23.414  41.889  0.50 47.04           N  
+ATOM    635  CA  LEU 1  99      40.282  24.316  43.026  0.50 47.36           C  
+ATOM    636  C   LEU 1  99      39.103  23.935  43.918  0.50 47.23           C  
+ATOM    637  O   LEU 1  99      39.203  23.974  45.143  0.50 47.62           O  
+ATOM    638  CB  LEU 1  99      40.140  25.769  42.547  0.50 49.51           C  
+ATOM    639  CG  LEU 1  99      41.303  26.364  41.728  0.50 51.60           C  
+ATOM    640  CD1 LEU 1  99      41.112  27.876  41.607  0.50 51.86           C  
+ATOM    641  CD2 LEU 1  99      42.647  26.063  42.389  0.50 51.68           C  
+ATOM    642  N   LEU 1 100      37.989  23.555  43.307  0.50 47.13           N  
+ATOM    643  CA  LEU 1 100      36.814  23.165  44.081  0.50 47.85           C  
+ATOM    644  C   LEU 1 100      37.125  22.041  45.063  0.50 47.43           C  
+ATOM    645  O   LEU 1 100      36.581  21.993  46.161  0.50 48.18           O  
+ATOM    646  CB  LEU 1 100      35.685  22.705  43.156  0.50 47.22           C  
+ATOM    647  CG  LEU 1 100      34.361  22.364  43.853  0.50 48.28           C  
+ATOM    648  CD1 LEU 1 100      33.804  23.603  44.565  0.50 47.21           C  
+ATOM    649  CD2 LEU 1 100      33.360  21.854  42.820  0.50 47.98           C  
+ATOM    650  N   VAL 1 101      38.014  21.142  44.668  0.50 48.14           N  
+ATOM    651  CA  VAL 1 101      38.351  20.006  45.506  0.50 49.08           C  
+ATOM    652  C   VAL 1 101      39.720  20.169  46.173  0.50 49.24           C  
+ATOM    653  O   VAL 1 101      40.244  19.231  46.773  0.50 48.61           O  
+ATOM    654  CB  VAL 1 101      38.316  18.706  44.655  0.50 49.94           C  
+ATOM    655  CG1 VAL 1 101      39.606  18.560  43.837  0.50 50.21           C  
+ATOM    656  CG2 VAL 1 101      38.120  17.516  45.540  0.50 51.99           C  
+ATOM    657  N   ASP 1 102      40.296  21.363  46.058  0.50 50.34           N  
+ATOM    658  CA  ASP 1 102      41.608  21.660  46.639  0.50 51.48           C  
+ATOM    659  C   ASP 1 102      42.666  20.651  46.199  0.50 51.36           C  
+ATOM    660  O   ASP 1 102      43.501  20.224  46.993  0.50 52.01           O  
+ATOM    661  CB  ASP 1 102      41.508  21.703  48.172  0.50 53.86           C  
+ATOM    662  CG  ASP 1 102      42.804  22.159  48.840  0.50 57.34           C  
+ATOM    663  OD1 ASP 1 102      43.530  22.994  48.250  0.50 58.90           O  
+ATOM    664  OD2 ASP 1 102      43.091  21.693  49.966  0.50 58.86           O  
+ATOM    665  N   ALA 1 103      42.629  20.290  44.917  0.50 50.12           N  
+ATOM    666  CA  ALA 1 103      43.563  19.329  44.332  0.50 48.89           C  
+ATOM    667  C   ALA 1 103      45.019  19.763  44.465  0.50 48.71           C  
+ATOM    668  O   ALA 1 103      45.314  20.951  44.508  0.50 48.61           O  
+ATOM    669  CB  ALA 1 103      43.225  19.118  42.854  0.50 48.77           C  
+ATOM    670  N   ASP 1 104      45.924  18.787  44.500  0.50 48.53           N  
+ATOM    671  CA  ASP 1 104      47.359  19.047  44.621  0.50 48.77           C  
+ATOM    672  C   ASP 1 104      47.916  19.708  43.355  0.50 47.49           C  
+ATOM    673  O   ASP 1 104      47.391  19.513  42.260  0.50 47.43           O  
+ATOM    674  CB  ASP 1 104      48.107  17.726  44.881  0.50 50.04           C  
+ATOM    675  CG  ASP 1 104      47.675  17.038  46.183  0.50 52.01           C  
+ATOM    676  OD1 ASP 1 104      46.694  17.491  46.813  0.50 49.96           O  
+ATOM    677  OD2 ASP 1 104      48.322  16.037  46.576  0.50 53.43           O  
+ATOM    678  N   GLN 1 105      48.982  20.485  43.504  0.50 46.43           N  
+ATOM    679  CA  GLN 1 105      49.599  21.160  42.364  0.50 46.01           C  
+ATOM    680  C   GLN 1 105      50.086  20.186  41.307  0.50 45.29           C  
+ATOM    681  O   GLN 1 105      49.943  20.421  40.107  0.50 45.38           O  
+ATOM    682  CB  GLN 1 105      50.789  21.991  42.819  0.50 45.81           C  
+ATOM    683  CG  GLN 1 105      50.419  23.182  43.654  0.50 47.11           C  
+ATOM    684  CD  GLN 1 105      51.637  23.950  44.125  0.50 47.15           C  
+ATOM    685  OE1 GLN 1 105      51.517  24.926  44.864  0.50 48.88           O  
+ATOM    686  NE2 GLN 1 105      52.818  23.510  43.701  0.50 47.11           N  
+ATOM    687  N   GLY 1 106      50.687  19.096  41.760  0.50 44.33           N  
+ATOM    688  CA  GLY 1 106      51.195  18.118  40.825  0.50 42.99           C  
+ATOM    689  C   GLY 1 106      50.082  17.550  39.978  0.50 42.25           C  
+ATOM    690  O   GLY 1 106      50.199  17.469  38.757  0.50 41.23           O  
+ATOM    691  N   THR 1 107      48.983  17.173  40.621  0.50 42.60           N  
+ATOM    692  CA  THR 1 107      47.871  16.597  39.893  0.50 42.20           C  
+ATOM    693  C   THR 1 107      47.214  17.631  38.994  0.50 41.98           C  
+ATOM    694  O   THR 1 107      46.687  17.290  37.941  0.50 41.39           O  
+ATOM    695  CB  THR 1 107      46.861  15.950  40.858  0.50 41.30           C  
+ATOM    696  OG1 THR 1 107      45.542  16.047  40.313  0.50 45.44           O  
+ATOM    697  CG2 THR 1 107      46.921  16.603  42.192  0.50 43.17           C  
+ATOM    698  N   ILE 1 108      47.282  18.901  39.390  0.50 42.43           N  
+ATOM    699  CA  ILE 1 108      46.719  19.963  38.568  0.50 42.58           C  
+ATOM    700  C   ILE 1 108      47.599  20.091  37.343  0.50 42.51           C  
+ATOM    701  O   ILE 1 108      47.110  20.151  36.211  0.50 43.12           O  
+ATOM    702  CB  ILE 1 108      46.710  21.320  39.294  0.50 43.77           C  
+ATOM    703  CG1 ILE 1 108      45.726  21.274  40.465  0.50 43.07           C  
+ATOM    704  CG2 ILE 1 108      46.301  22.439  38.324  0.50 43.34           C  
+ATOM    705  CD1 ILE 1 108      45.609  22.595  41.212  0.50 43.46           C  
+ATOM    706  N   LEU 1 109      48.908  20.124  37.569  0.50 43.30           N  
+ATOM    707  CA  LEU 1 109      49.840  20.238  36.459  0.50 43.89           C  
+ATOM    708  C   LEU 1 109      49.713  19.055  35.510  0.50 42.95           C  
+ATOM    709  O   LEU 1 109      49.873  19.207  34.299  0.50 40.97           O  
+ATOM    710  CB  LEU 1 109      51.284  20.334  36.963  0.50 45.65           C  
+ATOM    711  CG  LEU 1 109      52.302  20.588  35.843  0.50 48.38           C  
+ATOM    712  CD1 LEU 1 109      51.926  21.845  35.052  0.50 49.08           C  
+ATOM    713  CD2 LEU 1 109      53.681  20.743  36.447  0.50 50.20           C  
+ATOM    714  N   ALA 1 110      49.429  17.874  36.059  0.50 42.10           N  
+ATOM    715  CA  ALA 1 110      49.278  16.672  35.236  0.50 42.19           C  
+ATOM    716  C   ALA 1 110      47.993  16.740  34.399  0.50 41.26           C  
+ATOM    717  O   ALA 1 110      47.962  16.275  33.259  0.50 41.36           O  
+ATOM    718  CB  ALA 1 110      49.271  15.411  36.133  0.50 41.74           C  
+ATOM    719  N   LEU 1 111      46.933  17.314  34.962  0.50 40.36           N  
+ATOM    720  CA  LEU 1 111      45.663  17.445  34.237  0.50 40.92           C  
+ATOM    721  C   LEU 1 111      45.809  18.365  33.019  0.50 41.35           C  
+ATOM    722  O   LEU 1 111      45.410  18.013  31.905  0.50 41.38           O  
+ATOM    723  CB  LEU 1 111      44.569  18.008  35.157  0.50 40.01           C  
+ATOM    724  CG  LEU 1 111      43.500  17.125  35.822  0.50 39.94           C  
+ATOM    725  CD1 LEU 1 111      43.504  15.714  35.243  0.50 35.87           C  
+ATOM    726  CD2 LEU 1 111      43.730  17.123  37.314  0.50 39.70           C  
+ATOM    727  N   VAL 1 112      46.377  19.549  33.239  0.50 42.22           N  
+ATOM    728  CA  VAL 1 112      46.572  20.523  32.165  0.50 43.03           C  
+ATOM    729  C   VAL 1 112      47.501  20.006  31.076  0.50 42.37           C  
+ATOM    730  O   VAL 1 112      47.262  20.233  29.892  0.50 42.12           O  
+ATOM    731  CB  VAL 1 112      47.148  21.855  32.708  0.50 44.93           C  
+ATOM    732  CG1 VAL 1 112      47.406  22.842  31.559  0.50 45.91           C  
+ATOM    733  CG2 VAL 1 112      46.179  22.456  33.695  0.50 45.59           C  
+ATOM    734  N   GLY 1 113      48.578  19.338  31.474  0.50 42.09           N  
+ATOM    735  CA  GLY 1 113      49.488  18.789  30.486  0.50 41.40           C  
+ATOM    736  C   GLY 1 113      48.766  17.732  29.663  0.50 40.85           C  
+ATOM    737  O   GLY 1 113      48.816  17.734  28.436  0.50 41.06           O  
+ATOM    738  N   ALA 1 114      48.086  16.815  30.337  0.50 40.34           N  
+ATOM    739  CA  ALA 1 114      47.349  15.776  29.627  0.50 40.33           C  
+ATOM    740  C   ALA 1 114      46.354  16.452  28.690  0.50 39.61           C  
+ATOM    741  O   ALA 1 114      46.178  16.046  27.543  0.50 40.90           O  
+ATOM    742  CB  ALA 1 114      46.602  14.884  30.627  0.50 39.64           C  
+ATOM    743  N   ASP 1 115      45.705  17.497  29.187  0.50 39.44           N  
+ATOM    744  CA  ASP 1 115      44.717  18.232  28.401  0.50 39.34           C  
+ATOM    745  C   ASP 1 115      45.355  18.875  27.185  0.50 38.18           C  
+ATOM    746  O   ASP 1 115      44.861  18.741  26.066  0.50 38.02           O  
+ATOM    747  CB  ASP 1 115      44.050  19.302  29.273  0.50 39.79           C  
+ATOM    748  CG  ASP 1 115      43.057  20.159  28.502  0.50 41.44           C  
+ATOM    749  OD1 ASP 1 115      43.444  21.230  27.983  0.50 41.20           O  
+ATOM    750  OD2 ASP 1 115      41.879  19.755  28.415  0.50 42.57           O  
+ATOM    751  N   GLY 1 116      46.453  19.588  27.400  0.50 39.13           N  
+ATOM    752  CA  GLY 1 116      47.124  20.219  26.275  0.50 39.60           C  
+ATOM    753  C   GLY 1 116      47.439  19.165  25.229  0.50 40.78           C  
+ATOM    754  O   GLY 1 116      47.329  19.407  24.030  0.50 42.42           O  
+ATOM    755  N   ILE 1 117      47.817  17.976  25.685  0.50 40.39           N  
+ATOM    756  CA  ILE 1 117      48.152  16.894  24.766  0.50 41.08           C  
+ATOM    757  C   ILE 1 117      46.927  16.385  24.030  0.50 40.38           C  
+ATOM    758  O   ILE 1 117      46.982  16.087  22.832  0.50 40.46           O  
+ATOM    759  CB  ILE 1 117      48.822  15.718  25.518  0.50 41.55           C  
+ATOM    760  CG1 ILE 1 117      50.257  16.100  25.873  0.50 41.38           C  
+ATOM    761  CG2 ILE 1 117      48.769  14.441  24.677  0.50 41.91           C  
+ATOM    762  CD1 ILE 1 117      51.045  14.992  26.552  0.50 41.41           C  
+ATOM    763  N   MET 1 118      45.821  16.287  24.753  0.50 39.83           N  
+ATOM    764  CA  MET 1 118      44.573  15.815  24.172  0.50 40.50           C  
+ATOM    765  C   MET 1 118      44.117  16.682  23.003  0.50 40.95           C  
+ATOM    766  O   MET 1 118      43.720  16.174  21.952  0.50 40.28           O  
+ATOM    767  CB  MET 1 118      43.487  15.789  25.244  0.50 40.36           C  
+ATOM    768  CG  MET 1 118      42.085  15.478  24.739  0.50 40.65           C  
+ATOM    769  SD  MET 1 118      40.981  15.455  26.171  0.50 41.69           S  
+ATOM    770  CE  MET 1 118      40.644  17.221  26.325  0.50 40.92           C  
+ATOM    771  N   ILE 1 119      44.173  17.997  23.186  0.50 41.69           N  
+ATOM    772  CA  ILE 1 119      43.742  18.911  22.137  0.50 40.60           C  
+ATOM    773  C   ILE 1 119      44.731  19.025  20.989  0.50 40.77           C  
+ATOM    774  O   ILE 1 119      44.344  18.934  19.820  0.50 40.43           O  
+ATOM    775  CB  ILE 1 119      43.466  20.318  22.706  0.50 41.19           C  
+ATOM    776  CG1 ILE 1 119      42.328  20.239  23.724  0.50 39.93           C  
+ATOM    777  CG2 ILE 1 119      43.097  21.280  21.579  0.50 39.80           C  
+ATOM    778  CD1 ILE 1 119      41.046  19.612  23.163  0.50 41.21           C  
+ATOM    779  N   GLY 1 120      46.005  19.217  21.317  0.50 40.67           N  
+ATOM    780  CA  GLY 1 120      47.011  19.347  20.276  0.50 40.86           C  
+ATOM    781  C   GLY 1 120      47.014  18.113  19.396  0.50 41.85           C  
+ATOM    782  O   GLY 1 120      46.985  18.175  18.164  0.50 42.45           O  
+ATOM    783  N   THR 1 121      47.051  16.970  20.054  0.50 40.89           N  
+ATOM    784  CA  THR 1 121      47.049  15.694  19.371  0.50 41.64           C  
+ATOM    785  C   THR 1 121      45.803  15.528  18.485  0.50 42.25           C  
+ATOM    786  O   THR 1 121      45.875  14.963  17.389  0.50 42.07           O  
+ATOM    787  CB  THR 1 121      47.167  14.576  20.436  0.50 40.46           C  
+ATOM    788  OG1 THR 1 121      48.510  14.067  20.440  0.50 40.79           O  
+ATOM    789  CG2 THR 1 121      46.187  13.493  20.206  0.50 36.25           C  
+ATOM    790  N   GLY 1 122      44.665  16.035  18.946  0.50 42.38           N  
+ATOM    791  CA  GLY 1 122      43.454  15.916  18.151  0.50 43.41           C  
+ATOM    792  C   GLY 1 122      43.483  16.806  16.920  0.50 44.91           C  
+ATOM    793  O   GLY 1 122      42.863  16.495  15.902  0.50 45.57           O  
+ATOM    794  N   LEU 1 123      44.195  17.925  17.010  0.50 45.49           N  
+ATOM    795  CA  LEU 1 123      44.299  18.847  15.882  0.50 46.25           C  
+ATOM    796  C   LEU 1 123      45.177  18.244  14.794  0.50 45.85           C  
+ATOM    797  O   LEU 1 123      44.922  18.419  13.607  0.50 45.07           O  
+ATOM    798  CB  LEU 1 123      44.895  20.192  16.327  0.50 46.62           C  
+ATOM    799  CG  LEU 1 123      45.297  21.150  15.190  0.50 48.28           C  
+ATOM    800  CD1 LEU 1 123      44.065  21.518  14.364  0.50 48.08           C  
+ATOM    801  CD2 LEU 1 123      45.950  22.409  15.759  0.50 48.00           C  
+ATOM    802  N   VAL 1 124      46.227  17.544  15.199  0.50 46.57           N  
+ATOM    803  CA  VAL 1 124      47.113  16.916  14.229  0.50 46.88           C  
+ATOM    804  C   VAL 1 124      46.320  15.854  13.466  0.50 47.30           C  
+ATOM    805  O   VAL 1 124      46.459  15.708  12.252  0.50 46.80           O  
+ATOM    806  CB  VAL 1 124      48.312  16.262  14.931  0.50 46.85           C  
+ATOM    807  CG1 VAL 1 124      49.130  15.456  13.932  0.50 48.66           C  
+ATOM    808  CG2 VAL 1 124      49.175  17.336  15.568  0.50 46.53           C  
+ATOM    809  N   GLY 1 125      45.483  15.117  14.186  0.50 47.30           N  
+ATOM    810  CA  GLY 1 125      44.684  14.095  13.543  0.50 47.89           C  
+ATOM    811  C   GLY 1 125      43.776  14.724  12.509  0.50 49.24           C  
+ATOM    812  O   GLY 1 125      43.693  14.265  11.370  0.50 48.51           O  
+ATOM    813  N   ALA 1 126      43.101  15.795  12.907  0.50 49.81           N  
+ATOM    814  CA  ALA 1 126      42.199  16.484  12.005  0.50 50.60           C  
+ATOM    815  C   ALA 1 126      42.944  16.958  10.764  0.50 51.78           C  
+ATOM    816  O   ALA 1 126      42.410  16.927   9.655  0.50 52.60           O  
+ATOM    817  CB  ALA 1 126      41.561  17.661  12.713  0.50 50.31           C  
+ATOM    818  N   LEU 1 127      44.186  17.387  10.951  0.50 53.05           N  
+ATOM    819  CA  LEU 1 127      44.993  17.878   9.842  0.50 54.15           C  
+ATOM    820  C   LEU 1 127      45.701  16.777   9.064  0.50 55.76           C  
+ATOM    821  O   LEU 1 127      46.504  17.059   8.177  0.50 56.17           O  
+ATOM    822  CB  LEU 1 127      46.018  18.884  10.360  0.50 53.27           C  
+ATOM    823  CG  LEU 1 127      45.679  20.369  10.209  0.50 54.19           C  
+ATOM    824  CD1 LEU 1 127      44.218  20.640  10.512  0.50 54.34           C  
+ATOM    825  CD2 LEU 1 127      46.579  21.158  11.130  0.50 54.48           C  
+ATOM    826  N   THR 1 128      45.406  15.525   9.395  0.50 57.20           N  
+ATOM    827  CA  THR 1 128      46.026  14.403   8.707  0.50 58.54           C  
+ATOM    828  C   THR 1 128      45.045  13.776   7.724  0.50 59.70           C  
+ATOM    829  O   THR 1 128      43.838  13.697   7.981  0.50 59.19           O  
+ATOM    830  CB  THR 1 128      46.526  13.336   9.709  0.50 59.25           C  
+ATOM    831  OG1 THR 1 128      47.589  13.887  10.498  0.50 59.22           O  
+ATOM    832  CG2 THR 1 128      47.039  12.104   8.978  0.50 59.68           C  
+ATOM    833  N   LYS 1 129      45.586  13.332   6.595  0.50 61.15           N  
+ATOM    834  CA  LYS 1 129      44.804  12.733   5.522  0.50 61.60           C  
+ATOM    835  C   LYS 1 129      44.651  11.217   5.626  0.50 62.10           C  
+ATOM    836  O   LYS 1 129      43.544  10.690   5.497  0.50 62.93           O  
+ATOM    837  CB  LYS 1 129      45.436  13.127   4.187  0.50 62.16           C  
+ATOM    838  CG  LYS 1 129      46.952  13.276   4.265  0.50 63.34           C  
+ATOM    839  CD  LYS 1 129      47.518  14.082   3.100  0.50 63.15           C  
+ATOM    840  CE  LYS 1 129      47.265  15.578   3.255  0.50 63.84           C  
+ATOM    841  NZ  LYS 1 129      45.821  15.932   3.292  0.50 63.20           N  
+ATOM    842  N   VAL 1 130      45.756  10.517   5.864  0.50 61.93           N  
+ATOM    843  CA  VAL 1 130      45.726   9.062   5.992  0.50 61.14           C  
+ATOM    844  C   VAL 1 130      44.929   8.652   7.228  0.50 60.53           C  
+ATOM    845  O   VAL 1 130      45.343   8.918   8.353  0.50 59.79           O  
+ATOM    846  CB  VAL 1 130      47.154   8.482   6.123  0.50 61.45           C  
+ATOM    847  CG1 VAL 1 130      47.095   6.963   6.239  0.50 61.76           C  
+ATOM    848  CG2 VAL 1 130      47.993   8.893   4.927  0.50 61.83           C  
+ATOM    849  N   TYR 1 131      43.791   7.999   7.016  0.50 60.15           N  
+ATOM    850  CA  TYR 1 131      42.951   7.563   8.126  0.50 59.88           C  
+ATOM    851  C   TYR 1 131      43.764   6.797   9.166  0.50 58.26           C  
+ATOM    852  O   TYR 1 131      43.546   6.932  10.371  0.50 58.16           O  
+ATOM    853  CB  TYR 1 131      41.810   6.673   7.620  0.50 61.81           C  
+ATOM    854  CG  TYR 1 131      40.816   7.365   6.708  0.50 64.00           C  
+ATOM    855  CD1 TYR 1 131      41.108   7.589   5.363  0.50 65.27           C  
+ATOM    856  CD2 TYR 1 131      39.572   7.773   7.187  0.50 64.76           C  
+ATOM    857  CE1 TYR 1 131      40.183   8.198   4.514  0.50 65.84           C  
+ATOM    858  CE2 TYR 1 131      38.639   8.386   6.347  0.50 65.85           C  
+ATOM    859  CZ  TYR 1 131      38.951   8.593   5.011  0.50 66.70           C  
+ATOM    860  OH  TYR 1 131      38.033   9.193   4.175  0.50 66.45           O  
+ATOM    861  N   SER 1 132      44.701   5.991   8.684  0.50 55.87           N  
+ATOM    862  CA  SER 1 132      45.557   5.189   9.546  0.50 53.19           C  
+ATOM    863  C   SER 1 132      46.306   6.080  10.537  0.50 51.81           C  
+ATOM    864  O   SER 1 132      46.307   5.831  11.742  0.50 51.30           O  
+ATOM    865  CB  SER 1 132      46.551   4.405   8.686  0.50 52.63           C  
+ATOM    866  OG  SER 1 132      47.278   3.473   9.462  0.50 52.84           O  
+ATOM    867  N   TYR 1 133      46.955   7.113  10.015  0.50 50.83           N  
+ATOM    868  CA  TYR 1 133      47.698   8.050  10.843  0.50 50.14           C  
+ATOM    869  C   TYR 1 133      46.734   8.757  11.782  0.50 49.14           C  
+ATOM    870  O   TYR 1 133      46.943   8.809  12.996  0.50 49.60           O  
+ATOM    871  CB  TYR 1 133      48.403   9.073   9.954  0.50 50.63           C  
+ATOM    872  CG  TYR 1 133      49.636   8.538   9.256  0.50 50.73           C  
+ATOM    873  CD1 TYR 1 133      49.773   7.179   8.972  0.50 51.04           C  
+ATOM    874  CD2 TYR 1 133      50.660   9.396   8.867  0.50 51.04           C  
+ATOM    875  CE1 TYR 1 133      50.900   6.689   8.321  0.50 51.24           C  
+ATOM    876  CE2 TYR 1 133      51.792   8.919   8.212  0.50 51.88           C  
+ATOM    877  CZ  TYR 1 133      51.905   7.565   7.942  0.50 52.17           C  
+ATOM    878  OH  TYR 1 133      53.019   7.088   7.288  0.50 53.30           O  
+ATOM    879  N   ARG 1 134      45.669   9.292  11.204  0.50 47.82           N  
+ATOM    880  CA  ARG 1 134      44.653   9.993  11.965  0.50 47.65           C  
+ATOM    881  C   ARG 1 134      44.182   9.098  13.108  0.50 47.28           C  
+ATOM    882  O   ARG 1 134      43.901   9.573  14.210  0.50 47.44           O  
+ATOM    883  CB  ARG 1 134      43.483  10.338  11.050  0.50 47.65           C  
+ATOM    884  CG  ARG 1 134      42.476  11.298  11.638  0.50 50.18           C  
+ATOM    885  CD  ARG 1 134      41.275  11.416  10.721  0.50 50.86           C  
+ATOM    886  NE  ARG 1 134      41.681  11.726   9.355  0.50 51.83           N  
+ATOM    887  CZ  ARG 1 134      40.907  11.570   8.286  0.50 52.75           C  
+ATOM    888  NH1 ARG 1 134      39.674  11.102   8.413  0.50 53.08           N  
+ATOM    889  NH2 ARG 1 134      41.370  11.884   7.085  0.50 52.97           N  
+ATOM    890  N   PHE 1 135      44.103   7.796  12.841  0.50 46.89           N  
+ATOM    891  CA  PHE 1 135      43.673   6.836  13.853  0.50 46.28           C  
+ATOM    892  C   PHE 1 135      44.612   6.859  15.058  0.50 44.36           C  
+ATOM    893  O   PHE 1 135      44.167   6.840  16.202  0.50 44.48           O  
+ATOM    894  CB  PHE 1 135      43.625   5.413  13.272  0.50 46.45           C  
+ATOM    895  CG  PHE 1 135      43.615   4.331  14.324  0.50 47.56           C  
+ATOM    896  CD1 PHE 1 135      42.534   4.189  15.190  0.50 47.91           C  
+ATOM    897  CD2 PHE 1 135      44.709   3.483  14.477  0.50 47.59           C  
+ATOM    898  CE1 PHE 1 135      42.543   3.220  16.198  0.50 49.45           C  
+ATOM    899  CE2 PHE 1 135      44.731   2.511  15.481  0.50 49.52           C  
+ATOM    900  CZ  PHE 1 135      43.644   2.379  16.344  0.50 49.00           C  
+ATOM    901  N   VAL 1 136      45.912   6.891  14.801  0.50 43.64           N  
+ATOM    902  CA  VAL 1 136      46.871   6.909  15.893  0.50 42.69           C  
+ATOM    903  C   VAL 1 136      46.712   8.172  16.732  0.50 42.43           C  
+ATOM    904  O   VAL 1 136      46.645   8.112  17.963  0.50 42.41           O  
+ATOM    905  CB  VAL 1 136      48.310   6.812  15.366  0.50 43.32           C  
+ATOM    906  CG1 VAL 1 136      49.297   6.950  16.522  0.50 42.82           C  
+ATOM    907  CG2 VAL 1 136      48.505   5.473  14.654  0.50 42.03           C  
+ATOM    908  N   TRP 1 137      46.642   9.319  16.071  0.50 41.26           N  
+ATOM    909  CA  TRP 1 137      46.472  10.567  16.800  0.50 41.60           C  
+ATOM    910  C   TRP 1 137      45.203  10.509  17.642  0.50 42.29           C  
+ATOM    911  O   TRP 1 137      45.207  10.893  18.813  0.50 42.25           O  
+ATOM    912  CB  TRP 1 137      46.434  11.743  15.818  0.50 40.48           C  
+ATOM    913  CG  TRP 1 137      47.756  11.912  15.146  0.50 39.20           C  
+ATOM    914  CD1 TRP 1 137      48.031  11.790  13.811  0.50 38.37           C  
+ATOM    915  CD2 TRP 1 137      49.008  12.175  15.793  0.50 38.48           C  
+ATOM    916  NE1 TRP 1 137      49.375  11.960  13.590  0.50 37.52           N  
+ATOM    917  CE2 TRP 1 137      50.000  12.199  14.787  0.50 37.75           C  
+ATOM    918  CE3 TRP 1 137      49.388  12.394  17.128  0.50 36.82           C  
+ATOM    919  CZ2 TRP 1 137      51.351  12.436  15.072  0.50 37.15           C  
+ATOM    920  CZ3 TRP 1 137      50.731  12.628  17.411  0.50 35.11           C  
+ATOM    921  CH2 TRP 1 137      51.695  12.647  16.388  0.50 36.68           C  
+ATOM    922  N   TRP 1 138      44.125  10.003  17.045  0.50 43.39           N  
+ATOM    923  CA  TRP 1 138      42.845   9.866  17.736  0.50 44.04           C  
+ATOM    924  C   TRP 1 138      43.003   9.037  19.003  0.50 44.25           C  
+ATOM    925  O   TRP 1 138      42.498   9.404  20.068  0.50 45.48           O  
+ATOM    926  CB  TRP 1 138      41.816   9.185  16.822  0.50 46.52           C  
+ATOM    927  CG  TRP 1 138      40.524   8.826  17.521  0.50 48.19           C  
+ATOM    928  CD1 TRP 1 138      39.435   9.631  17.706  0.50 49.31           C  
+ATOM    929  CD2 TRP 1 138      40.218   7.585  18.169  0.50 49.08           C  
+ATOM    930  NE1 TRP 1 138      38.470   8.966  18.432  0.50 49.44           N  
+ATOM    931  CE2 TRP 1 138      38.928   7.707  18.729  0.50 49.63           C  
+ATOM    932  CE3 TRP 1 138      40.913   6.376  18.334  0.50 50.33           C  
+ATOM    933  CZ2 TRP 1 138      38.314   6.668  19.446  0.50 50.21           C  
+ATOM    934  CZ3 TRP 1 138      40.304   5.342  19.047  0.50 50.18           C  
+ATOM    935  CH2 TRP 1 138      39.018   5.498  19.593  0.50 50.37           C  
+ATOM    936  N   ALA 1 139      43.705   7.914  18.886  0.50 43.63           N  
+ATOM    937  CA  ALA 1 139      43.921   7.018  20.023  0.50 42.06           C  
+ATOM    938  C   ALA 1 139      44.686   7.691  21.160  0.50 41.33           C  
+ATOM    939  O   ALA 1 139      44.311   7.572  22.333  0.50 41.64           O  
+ATOM    940  CB  ALA 1 139      44.663   5.762  19.557  0.50 43.48           C  
+ATOM    941  N   ILE 1 140      45.769   8.384  20.820  0.50 40.49           N  
+ATOM    942  CA  ILE 1 140      46.566   9.082  21.830  0.50 40.56           C  
+ATOM    943  C   ILE 1 140      45.708  10.154  22.515  0.50 39.87           C  
+ATOM    944  O   ILE 1 140      45.758  10.322  23.732  0.50 40.52           O  
+ATOM    945  CB  ILE 1 140      47.814   9.747  21.186  0.50 41.42           C  
+ATOM    946  CG1 ILE 1 140      48.733   8.668  20.612  0.50 41.03           C  
+ATOM    947  CG2 ILE 1 140      48.574  10.570  22.227  0.50 40.56           C  
+ATOM    948  CD1 ILE 1 140      49.734   9.195  19.579  0.50 41.48           C  
+ATOM    949  N   SER 1 141      44.912  10.867  21.728  0.50 39.52           N  
+ATOM    950  CA  SER 1 141      44.041  11.910  22.265  0.50 40.12           C  
+ATOM    951  C   SER 1 141      43.006  11.334  23.239  0.50 39.95           C  
+ATOM    952  O   SER 1 141      42.816  11.838  24.349  0.50 40.27           O  
+ATOM    953  CB  SER 1 141      43.332  12.626  21.109  0.50 40.41           C  
+ATOM    954  OG  SER 1 141      42.692  13.810  21.541  0.50 41.80           O  
+ATOM    955  N   THR 1 142      42.338  10.268  22.820  0.50 39.95           N  
+ATOM    956  CA  THR 1 142      41.326   9.634  23.651  0.50 38.65           C  
+ATOM    957  C   THR 1 142      41.960   9.044  24.916  0.50 39.11           C  
+ATOM    958  O   THR 1 142      41.358   9.033  26.000  0.50 38.87           O  
+ATOM    959  CB  THR 1 142      40.599   8.543  22.831  0.50 40.52           C  
+ATOM    960  OG1 THR 1 142      39.920   9.161  21.724  0.50 40.13           O  
+ATOM    961  CG2 THR 1 142      39.602   7.789  23.692  0.50 38.83           C  
+ATOM    962  N   ALA 1 143      43.186   8.556  24.787  0.50 38.93           N  
+ATOM    963  CA  ALA 1 143      43.865   8.004  25.947  0.50 39.13           C  
+ATOM    964  C   ALA 1 143      44.083   9.146  26.939  0.50 39.40           C  
+ATOM    965  O   ALA 1 143      43.914   8.980  28.149  0.50 39.33           O  
+ATOM    966  CB  ALA 1 143      45.207   7.385  25.529  0.50 38.68           C  
+ATOM    967  N   ALA 1 144      44.450  10.314  26.419  0.50 40.15           N  
+ATOM    968  CA  ALA 1 144      44.681  11.474  27.271  0.50 40.32           C  
+ATOM    969  C   ALA 1 144      43.382  11.894  27.951  0.50 40.84           C  
+ATOM    970  O   ALA 1 144      43.363  12.202  29.145  0.50 40.86           O  
+ATOM    971  CB  ALA 1 144      45.244  12.626  26.445  0.50 40.04           C  
+ATOM    972  N   MET 1 145      42.290  11.911  27.199  0.50 41.22           N  
+ATOM    973  CA  MET 1 145      41.014  12.289  27.797  0.50 41.93           C  
+ATOM    974  C   MET 1 145      40.604  11.284  28.880  0.50 42.68           C  
+ATOM    975  O   MET 1 145      40.182  11.664  29.975  0.50 42.67           O  
+ATOM    976  CB  MET 1 145      39.917  12.359  26.734  0.50 42.93           C  
+ATOM    977  CG  MET 1 145      38.582  12.813  27.296  0.50 43.81           C  
+ATOM    978  SD  MET 1 145      37.217  12.396  26.189  0.50 47.04           S  
+ATOM    979  CE  MET 1 145      37.138  10.597  26.393  0.50 43.90           C  
+ATOM    980  N   LEU 1 146      40.723   9.996  28.576  0.50 43.10           N  
+ATOM    981  CA  LEU 1 146      40.347   8.984  29.552  0.50 43.54           C  
+ATOM    982  C   LEU 1 146      41.156   9.149  30.834  0.50 44.03           C  
+ATOM    983  O   LEU 1 146      40.650   8.920  31.939  0.50 44.34           O  
+ATOM    984  CB  LEU 1 146      40.533   7.584  28.961  0.50 44.26           C  
+ATOM    985  CG  LEU 1 146      39.552   7.239  27.828  0.50 45.26           C  
+ATOM    986  CD1 LEU 1 146      39.877   5.846  27.284  0.50 45.33           C  
+ATOM    987  CD2 LEU 1 146      38.101   7.271  28.342  0.50 43.67           C  
+ATOM    988  N   TYR 1 147      42.416   9.546  30.687  0.50 43.88           N  
+ATOM    989  CA  TYR 1 147      43.278   9.778  31.841  0.50 43.94           C  
+ATOM    990  C   TYR 1 147      42.659  10.890  32.683  0.50 43.27           C  
+ATOM    991  O   TYR 1 147      42.463  10.747  33.892  0.50 43.88           O  
+ATOM    992  CB  TYR 1 147      44.675  10.236  31.394  0.50 45.47           C  
+ATOM    993  CG  TYR 1 147      45.546  10.653  32.560  0.50 46.06           C  
+ATOM    994  CD1 TYR 1 147      46.099   9.699  33.415  0.50 47.59           C  
+ATOM    995  CD2 TYR 1 147      45.749  12.003  32.859  0.50 46.13           C  
+ATOM    996  CE1 TYR 1 147      46.828  10.080  34.539  0.50 47.44           C  
+ATOM    997  CE2 TYR 1 147      46.475  12.396  33.982  0.50 45.88           C  
+ATOM    998  CZ  TYR 1 147      47.008  11.430  34.814  0.50 46.59           C  
+ATOM    999  OH  TYR 1 147      47.727  11.802  35.924  0.50 49.24           O  
+ATOM   1000  N   ILE 1 148      42.366  12.009  32.031  0.50 43.56           N  
+ATOM   1001  CA  ILE 1 148      41.767  13.161  32.706  0.50 42.86           C  
+ATOM   1002  C   ILE 1 148      40.465  12.771  33.407  0.50 42.32           C  
+ATOM   1003  O   ILE 1 148      40.277  13.042  34.596  0.50 42.92           O  
+ATOM   1004  CB  ILE 1 148      41.491  14.305  31.692  0.50 43.93           C  
+ATOM   1005  CG1 ILE 1 148      42.818  14.899  31.207  0.50 43.97           C  
+ATOM   1006  CG2 ILE 1 148      40.623  15.387  32.333  0.50 43.89           C  
+ATOM   1007  CD1 ILE 1 148      42.680  15.811  29.988  0.50 45.00           C  
+ATOM   1008  N   LEU 1 149      39.569  12.127  32.674  0.50 41.15           N  
+ATOM   1009  CA  LEU 1 149      38.301  11.709  33.253  0.50 42.10           C  
+ATOM   1010  C   LEU 1 149      38.531  10.767  34.426  0.50 42.31           C  
+ATOM   1011  O   LEU 1 149      37.914  10.915  35.479  0.50 42.61           O  
+ATOM   1012  CB  LEU 1 149      37.428  11.035  32.190  0.50 41.74           C  
+ATOM   1013  CG  LEU 1 149      37.191  11.879  30.930  0.50 42.25           C  
+ATOM   1014  CD1 LEU 1 149      36.042  11.286  30.113  0.50 41.18           C  
+ATOM   1015  CD2 LEU 1 149      36.864  13.328  31.337  0.50 42.33           C  
+ATOM   1016  N   TYR 1 150      39.433   9.806  34.251  0.50 43.47           N  
+ATOM   1017  CA  TYR 1 150      39.736   8.859  35.316  0.50 43.79           C  
+ATOM   1018  C   TYR 1 150      40.055   9.609  36.609  0.50 44.12           C  
+ATOM   1019  O   TYR 1 150      39.528   9.292  37.674  0.50 43.61           O  
+ATOM   1020  CB  TYR 1 150      40.941   7.990  34.933  0.50 44.99           C  
+ATOM   1021  CG  TYR 1 150      41.407   7.076  36.055  0.50 45.64           C  
+ATOM   1022  CD1 TYR 1 150      40.801   5.832  36.273  0.50 47.09           C  
+ATOM   1023  CD2 TYR 1 150      42.414   7.478  36.938  0.50 46.25           C  
+ATOM   1024  CE1 TYR 1 150      41.184   5.016  37.348  0.50 46.31           C  
+ATOM   1025  CE2 TYR 1 150      42.801   6.674  38.014  0.50 46.36           C  
+ATOM   1026  CZ  TYR 1 150      42.183   5.447  38.213  0.50 47.15           C  
+ATOM   1027  OH  TYR 1 150      42.555   4.666  39.285  0.50 46.87           O  
+ATOM   1028  N   VAL 1 151      40.939  10.598  36.511  0.50 45.04           N  
+ATOM   1029  CA  VAL 1 151      41.329  11.384  37.675  0.50 45.03           C  
+ATOM   1030  C   VAL 1 151      40.162  12.211  38.195  0.50 44.98           C  
+ATOM   1031  O   VAL 1 151      40.002  12.363  39.405  0.50 45.23           O  
+ATOM   1032  CB  VAL 1 151      42.516  12.336  37.351  0.50 46.13           C  
+ATOM   1033  CG1 VAL 1 151      42.850  13.197  38.567  0.50 43.80           C  
+ATOM   1034  CG2 VAL 1 151      43.742  11.522  36.942  0.50 45.20           C  
+ATOM   1035  N   LEU 1 152      39.344  12.742  37.293  0.50 44.98           N  
+ATOM   1036  CA  LEU 1 152      38.210  13.545  37.736  0.50 46.42           C  
+ATOM   1037  C   LEU 1 152      37.180  12.702  38.484  0.50 46.88           C  
+ATOM   1038  O   LEU 1 152      36.736  13.062  39.571  0.50 47.36           O  
+ATOM   1039  CB  LEU 1 152      37.524  14.246  36.553  0.50 44.93           C  
+ATOM   1040  CG  LEU 1 152      38.259  15.362  35.804  0.50 46.09           C  
+ATOM   1041  CD1 LEU 1 152      37.315  15.978  34.778  0.50 44.49           C  
+ATOM   1042  CD2 LEU 1 152      38.737  16.435  36.793  0.50 45.09           C  
+ATOM   1043  N   PHE 1 153      36.812  11.567  37.910  0.50 48.20           N  
+ATOM   1044  CA  PHE 1 153      35.809  10.721  38.529  0.50 48.52           C  
+ATOM   1045  C   PHE 1 153      36.231  10.090  39.850  0.50 48.97           C  
+ATOM   1046  O   PHE 1 153      35.458  10.053  40.803  0.50 50.12           O  
+ATOM   1047  CB  PHE 1 153      35.389   9.621  37.561  0.50 49.41           C  
+ATOM   1048  CG  PHE 1 153      34.064   9.009  37.885  0.50 49.10           C  
+ATOM   1049  CD1 PHE 1 153      32.888   9.585  37.417  0.50 49.33           C  
+ATOM   1050  CD2 PHE 1 153      33.983   7.909  38.730  0.50 48.49           C  
+ATOM   1051  CE1 PHE 1 153      31.648   9.051  37.765  0.50 49.36           C  
+ATOM   1052  CE2 PHE 1 153      32.749   7.368  39.085  0.50 47.52           C  
+ATOM   1053  CZ  PHE 1 153      31.580   7.949  38.614  0.50 47.87           C  
+ATOM   1054  N   PHE 1 154      37.462   9.612  39.921  0.50 49.68           N  
+ATOM   1055  CA  PHE 1 154      37.928   8.950  41.129  0.50 50.47           C  
+ATOM   1056  C   PHE 1 154      38.703   9.807  42.118  0.50 51.03           C  
+ATOM   1057  O   PHE 1 154      38.209  10.113  43.208  0.50 51.37           O  
+ATOM   1058  CB  PHE 1 154      38.763   7.737  40.734  0.50 51.11           C  
+ATOM   1059  CG  PHE 1 154      37.989   6.700  39.971  0.50 51.93           C  
+ATOM   1060  CD1 PHE 1 154      36.983   5.970  40.594  0.50 53.00           C  
+ATOM   1061  CD2 PHE 1 154      38.260   6.455  38.629  0.50 52.80           C  
+ATOM   1062  CE1 PHE 1 154      36.257   5.002  39.893  0.50 54.18           C  
+ATOM   1063  CE2 PHE 1 154      37.540   5.490  37.914  0.50 53.99           C  
+ATOM   1064  CZ  PHE 1 154      36.537   4.764  38.549  0.50 54.71           C  
+ATOM   1065  N   GLY 1 155      39.923  10.176  41.750  0.50 50.74           N  
+ATOM   1066  CA  GLY 1 155      40.737  10.991  42.630  0.50 50.89           C  
+ATOM   1067  C   GLY 1 155      40.025  12.220  43.177  0.50 51.63           C  
+ATOM   1068  O   GLY 1 155      40.000  12.445  44.386  0.50 52.96           O  
+ATOM   1069  N   PHE 1 156      39.437  13.022  42.300  0.50 51.24           N  
+ATOM   1070  CA  PHE 1 156      38.760  14.231  42.755  0.50 51.72           C  
+ATOM   1071  C   PHE 1 156      37.567  13.932  43.657  0.50 52.79           C  
+ATOM   1072  O   PHE 1 156      37.303  14.675  44.610  0.50 52.89           O  
+ATOM   1073  CB  PHE 1 156      38.318  15.080  41.558  0.50 50.60           C  
+ATOM   1074  CG  PHE 1 156      39.420  15.926  40.969  0.50 50.06           C  
+ATOM   1075  CD1 PHE 1 156      40.750  15.534  41.069  0.50 49.76           C  
+ATOM   1076  CD2 PHE 1 156      39.120  17.089  40.271  0.50 50.34           C  
+ATOM   1077  CE1 PHE 1 156      41.767  16.283  40.480  0.50 50.17           C  
+ATOM   1078  CE2 PHE 1 156      40.132  17.847  39.675  0.50 51.13           C  
+ATOM   1079  CZ  PHE 1 156      41.459  17.440  39.782  0.50 50.40           C  
+ATOM   1080  N   THR 1 157      36.846  12.849  43.368  0.50 52.83           N  
+ATOM   1081  CA  THR 1 157      35.700  12.489  44.195  0.50 53.01           C  
+ATOM   1082  C   THR 1 157      36.172  12.160  45.610  0.50 53.57           C  
+ATOM   1083  O   THR 1 157      35.569  12.603  46.585  0.50 54.38           O  
+ATOM   1084  CB  THR 1 157      34.924  11.286  43.621  0.50 53.15           C  
+ATOM   1085  OG1 THR 1 157      34.330  11.657  42.372  0.50 52.00           O  
+ATOM   1086  CG2 THR 1 157      33.821  10.859  44.581  0.50 51.97           C  
+ATOM   1087  N   SER 1 158      37.250  11.393  45.732  0.50 53.96           N  
+ATOM   1088  CA  SER 1 158      37.759  11.075  47.062  0.50 54.72           C  
+ATOM   1089  C   SER 1 158      38.136  12.377  47.765  0.50 54.90           C  
+ATOM   1090  O   SER 1 158      37.750  12.610  48.907  0.50 55.17           O  
+ATOM   1091  CB  SER 1 158      38.994  10.174  46.979  0.50 54.70           C  
+ATOM   1092  OG  SER 1 158      38.661   8.871  46.531  0.50 56.85           O  
+ATOM   1093  N   LYS 1 159      38.884  13.224  47.063  0.50 54.79           N  
+ATOM   1094  CA  LYS 1 159      39.328  14.503  47.601  0.50 54.27           C  
+ATOM   1095  C   LYS 1 159      38.114  15.351  47.988  0.50 54.63           C  
+ATOM   1096  O   LYS 1 159      38.121  16.045  49.007  0.50 54.42           O  
+ATOM   1097  CB  LYS 1 159      40.165  15.228  46.544  0.50 54.71           C  
+ATOM   1098  CG  LYS 1 159      41.016  16.376  47.055  0.50 57.00           C  
+ATOM   1099  CD  LYS 1 159      42.358  15.893  47.595  0.50 55.99           C  
+ATOM   1100  CE  LYS 1 159      43.231  17.065  48.033  0.50 56.62           C  
+ATOM   1101  NZ  LYS 1 159      44.567  16.620  48.528  0.50 56.44           N  
+ATOM   1102  N   ALA 1 160      37.067  15.283  47.168  0.50 54.18           N  
+ATOM   1103  CA  ALA 1 160      35.847  16.042  47.414  0.50 54.32           C  
+ATOM   1104  C   ALA 1 160      35.122  15.522  48.645  0.50 54.15           C  
+ATOM   1105  O   ALA 1 160      34.245  16.193  49.188  0.50 53.72           O  
+ATOM   1106  CB  ALA 1 160      34.924  15.959  46.200  0.50 54.32           C  
+ATOM   1107  N   GLU 1 161      35.498  14.329  49.086  0.50 54.37           N  
+ATOM   1108  CA  GLU 1 161      34.862  13.722  50.243  0.50 55.71           C  
+ATOM   1109  C   GLU 1 161      35.295  14.356  51.553  0.50 55.11           C  
+ATOM   1110  O   GLU 1 161      34.703  14.097  52.599  0.50 55.85           O  
+ATOM   1111  CB  GLU 1 161      35.142  12.216  50.272  0.50 57.38           C  
+ATOM   1112  CG  GLU 1 161      33.873  11.374  50.232  0.50 60.34           C  
+ATOM   1113  CD  GLU 1 161      33.037  11.616  48.984  0.50 61.13           C  
+ATOM   1114  OE1 GLU 1 161      33.209  10.866  47.996  0.50 61.48           O  
+ATOM   1115  OE2 GLU 1 161      32.213  12.559  48.993  0.50 60.42           O  
+ATOM   1116  N   SER 1 162      36.321  15.193  51.498  0.50 54.60           N  
+ATOM   1117  CA  SER 1 162      36.802  15.851  52.701  0.50 54.49           C  
+ATOM   1118  C   SER 1 162      36.232  17.267  52.835  0.50 53.65           C  
+ATOM   1119  O   SER 1 162      36.602  18.006  53.744  0.50 53.70           O  
+ATOM   1120  CB  SER 1 162      38.332  15.909  52.693  0.50 55.05           C  
+ATOM   1121  OG  SER 1 162      38.803  16.895  51.794  0.50 56.19           O  
+ATOM   1122  N   MET 1 163      35.323  17.634  51.936  0.50 52.34           N  
+ATOM   1123  CA  MET 1 163      34.712  18.959  51.951  0.50 51.29           C  
+ATOM   1124  C   MET 1 163      33.292  18.889  52.513  0.50 50.86           C  
+ATOM   1125  O   MET 1 163      32.701  17.809  52.586  0.50 50.43           O  
+ATOM   1126  CB  MET 1 163      34.672  19.523  50.526  0.50 51.80           C  
+ATOM   1127  CG  MET 1 163      36.039  19.652  49.857  0.50 52.25           C  
+ATOM   1128  SD  MET 1 163      37.008  21.011  50.532  0.50 53.70           S  
+ATOM   1129  CE  MET 1 163      36.532  22.339  49.429  0.50 53.63           C  
+ATOM   1130  N   ARG 1 164      32.745  20.038  52.909  0.50 49.52           N  
+ATOM   1131  CA  ARG 1 164      31.389  20.073  53.443  0.50 48.75           C  
+ATOM   1132  C   ARG 1 164      30.452  19.521  52.369  0.50 48.25           C  
+ATOM   1133  O   ARG 1 164      30.739  19.629  51.177  0.50 47.88           O  
+ATOM   1134  CB  ARG 1 164      30.980  21.511  53.821  0.50 48.54           C  
+ATOM   1135  CG  ARG 1 164      31.218  22.564  52.738  0.50 47.42           C  
+ATOM   1136  CD  ARG 1 164      30.333  23.807  52.916  0.50 48.10           C  
+ATOM   1137  NE  ARG 1 164      30.846  24.938  52.138  0.50 49.49           N  
+ATOM   1138  CZ  ARG 1 164      30.097  25.846  51.514  0.50 49.12           C  
+ATOM   1139  NH1 ARG 1 164      28.771  25.782  51.559  0.50 50.07           N  
+ATOM   1140  NH2 ARG 1 164      30.683  26.812  50.820  0.50 48.15           N  
+ATOM   1141  N   PRO 1 165      29.323  18.917  52.777  0.50 47.30           N  
+ATOM   1142  CA  PRO 1 165      28.376  18.357  51.803  0.50 46.68           C  
+ATOM   1143  C   PRO 1 165      28.012  19.268  50.623  0.50 46.88           C  
+ATOM   1144  O   PRO 1 165      27.874  18.791  49.496  0.50 46.88           O  
+ATOM   1145  CB  PRO 1 165      27.167  17.952  52.666  0.50 45.45           C  
+ATOM   1146  CG  PRO 1 165      27.368  18.679  53.986  0.50 46.20           C  
+ATOM   1147  CD  PRO 1 165      28.856  18.714  54.160  0.50 46.06           C  
+ATOM   1148  N   GLU 1 166      27.879  20.566  50.868  0.50 47.70           N  
+ATOM   1149  CA  GLU 1 166      27.543  21.511  49.800  0.50 48.71           C  
+ATOM   1150  C   GLU 1 166      28.543  21.468  48.643  0.50 48.63           C  
+ATOM   1151  O   GLU 1 166      28.152  21.485  47.474  0.50 49.27           O  
+ATOM   1152  CB  GLU 1 166      27.478  22.940  50.357  0.50 49.59           C  
+ATOM   1153  CG  GLU 1 166      27.405  24.034  49.294  0.50 50.68           C  
+ATOM   1154  CD  GLU 1 166      26.130  23.969  48.486  0.50 52.67           C  
+ATOM   1155  OE1 GLU 1 166      26.009  24.724  47.492  0.50 55.37           O  
+ATOM   1156  OE2 GLU 1 166      25.245  23.163  48.849  0.50 51.21           O  
+ATOM   1157  N   VAL 1 167      29.831  21.428  48.977  0.50 48.40           N  
+ATOM   1158  CA  VAL 1 167      30.888  21.379  47.974  0.50 47.25           C  
+ATOM   1159  C   VAL 1 167      30.971  19.983  47.365  0.50 47.76           C  
+ATOM   1160  O   VAL 1 167      31.211  19.829  46.161  0.50 49.17           O  
+ATOM   1161  CB  VAL 1 167      32.264  21.761  48.597  0.50 48.22           C  
+ATOM   1162  CG1 VAL 1 167      33.373  21.622  47.565  0.50 47.34           C  
+ATOM   1163  CG2 VAL 1 167      32.225  23.198  49.109  0.50 47.55           C  
+ATOM   1164  N   ALA 1 168      30.763  18.963  48.189  0.50 47.31           N  
+ATOM   1165  CA  ALA 1 168      30.832  17.588  47.704  0.50 47.58           C  
+ATOM   1166  C   ALA 1 168      29.777  17.329  46.641  0.50 47.44           C  
+ATOM   1167  O   ALA 1 168      30.070  16.767  45.586  0.50 47.18           O  
+ATOM   1168  CB  ALA 1 168      30.657  16.610  48.860  0.50 45.59           C  
+ATOM   1169  N   SER 1 169      28.545  17.749  46.916  0.50 48.05           N  
+ATOM   1170  CA  SER 1 169      27.463  17.539  45.965  0.50 48.82           C  
+ATOM   1171  C   SER 1 169      27.586  18.409  44.709  0.50 48.53           C  
+ATOM   1172  O   SER 1 169      27.241  17.969  43.618  0.50 48.75           O  
+ATOM   1173  CB  SER 1 169      26.110  17.763  46.645  0.50 48.78           C  
+ATOM   1174  OG  SER 1 169      26.101  18.999  47.327  0.50 54.54           O  
+ATOM   1175  N   THR 1 170      28.075  19.636  44.834  0.50 48.69           N  
+ATOM   1176  CA  THR 1 170      28.206  20.453  43.636  0.50 48.59           C  
+ATOM   1177  C   THR 1 170      29.272  19.817  42.750  0.50 48.40           C  
+ATOM   1178  O   THR 1 170      29.131  19.750  41.527  0.50 48.78           O  
+ATOM   1179  CB  THR 1 170      28.618  21.891  43.968  0.50 49.31           C  
+ATOM   1180  OG1 THR 1 170      27.671  22.450  44.884  0.50 49.53           O  
+ATOM   1181  CG2 THR 1 170      28.664  22.743  42.698  0.50 48.21           C  
+ATOM   1182  N   PHE 1 171      30.345  19.333  43.354  0.50 48.57           N  
+ATOM   1183  CA  PHE 1 171      31.364  18.713  42.532  0.50 48.46           C  
+ATOM   1184  C   PHE 1 171      30.809  17.508  41.779  0.50 48.01           C  
+ATOM   1185  O   PHE 1 171      31.066  17.348  40.584  0.50 48.54           O  
+ATOM   1186  CB  PHE 1 171      32.563  18.254  43.355  0.50 47.82           C  
+ATOM   1187  CG  PHE 1 171      33.522  17.427  42.560  0.50 47.90           C  
+ATOM   1188  CD1 PHE 1 171      34.340  18.016  41.597  0.50 47.92           C  
+ATOM   1189  CD2 PHE 1 171      33.525  16.040  42.688  0.50 48.12           C  
+ATOM   1190  CE1 PHE 1 171      35.141  17.230  40.769  0.50 48.75           C  
+ATOM   1191  CE2 PHE 1 171      34.320  15.248  41.867  0.50 47.83           C  
+ATOM   1192  CZ  PHE 1 171      35.130  15.842  40.904  0.50 47.53           C  
+ATOM   1193  N   LYS 1 172      30.056  16.657  42.474  0.50 48.37           N  
+ATOM   1194  CA  LYS 1 172      29.494  15.463  41.842  0.50 48.69           C  
+ATOM   1195  C   LYS 1 172      28.706  15.765  40.583  0.50 47.84           C  
+ATOM   1196  O   LYS 1 172      28.809  15.037  39.593  0.50 47.91           O  
+ATOM   1197  CB  LYS 1 172      28.607  14.684  42.818  0.50 50.55           C  
+ATOM   1198  CG  LYS 1 172      29.337  13.611  43.610  0.50 53.67           C  
+ATOM   1199  CD  LYS 1 172      28.345  12.631  44.246  0.50 55.71           C  
+ATOM   1200  CE  LYS 1 172      29.046  11.480  44.967  0.50 57.59           C  
+ATOM   1201  NZ  LYS 1 172      29.741  11.917  46.215  0.50 58.83           N  
+ATOM   1202  N   VAL 1 173      27.916  16.834  40.624  0.50 46.89           N  
+ATOM   1203  CA  VAL 1 173      27.121  17.242  39.473  0.50 46.27           C  
+ATOM   1204  C   VAL 1 173      28.035  17.689  38.336  0.50 45.66           C  
+ATOM   1205  O   VAL 1 173      27.863  17.263  37.196  0.50 44.90           O  
+ATOM   1206  CB  VAL 1 173      26.153  18.402  39.839  0.50 46.76           C  
+ATOM   1207  CG1 VAL 1 173      25.384  18.864  38.602  0.50 47.36           C  
+ATOM   1208  CG2 VAL 1 173      25.178  17.944  40.911  0.50 46.42           C  
+ATOM   1209  N   LEU 1 174      28.999  18.555  38.643  0.50 45.79           N  
+ATOM   1210  CA  LEU 1 174      29.942  19.041  37.631  0.50 45.44           C  
+ATOM   1211  C   LEU 1 174      30.751  17.875  37.076  0.50 45.24           C  
+ATOM   1212  O   LEU 1 174      31.046  17.811  35.884  0.50 44.31           O  
+ATOM   1213  CB  LEU 1 174      30.883  20.078  38.248  0.50 44.84           C  
+ATOM   1214  CG  LEU 1 174      30.197  21.384  38.662  0.50 45.53           C  
+ATOM   1215  CD1 LEU 1 174      31.162  22.238  39.470  0.50 45.84           C  
+ATOM   1216  CD2 LEU 1 174      29.726  22.138  37.416  0.50 44.96           C  
+ATOM   1217  N   ARG 1 175      31.112  16.953  37.958  0.50 45.38           N  
+ATOM   1218  CA  ARG 1 175      31.868  15.774  37.560  0.50 45.60           C  
+ATOM   1219  C   ARG 1 175      31.071  14.957  36.546  0.50 46.10           C  
+ATOM   1220  O   ARG 1 175      31.586  14.598  35.483  0.50 46.96           O  
+ATOM   1221  CB  ARG 1 175      32.168  14.910  38.780  0.50 45.89           C  
+ATOM   1222  CG  ARG 1 175      32.903  13.614  38.459  0.50 48.63           C  
+ATOM   1223  CD  ARG 1 175      32.751  12.610  39.598  0.50 48.58           C  
+ATOM   1224  NE  ARG 1 175      31.363  12.173  39.737  0.50 49.10           N  
+ATOM   1225  CZ  ARG 1 175      30.899  11.418  40.733  0.50 49.49           C  
+ATOM   1226  NH1 ARG 1 175      31.705  11.005  41.700  0.50 50.06           N  
+ATOM   1227  NH2 ARG 1 175      29.623  11.074  40.761  0.50 48.42           N  
+ATOM   1228  N   ASN 1 176      29.818  14.658  36.883  0.50 44.71           N  
+ATOM   1229  CA  ASN 1 176      28.960  13.881  35.993  0.50 44.69           C  
+ATOM   1230  C   ASN 1 176      28.781  14.567  34.650  0.50 43.13           C  
+ATOM   1231  O   ASN 1 176      28.991  13.956  33.602  0.50 43.77           O  
+ATOM   1232  CB  ASN 1 176      27.580  13.654  36.621  0.50 44.76           C  
+ATOM   1233  CG  ASN 1 176      27.631  12.758  37.844  0.50 46.96           C  
+ATOM   1234  OD1 ASN 1 176      28.668  12.165  38.158  0.50 47.42           O  
+ATOM   1235  ND2 ASN 1 176      26.501  12.646  38.540  0.50 46.45           N  
+ATOM   1236  N   VAL 1 177      28.368  15.831  34.688  0.50 41.52           N  
+ATOM   1237  CA  VAL 1 177      28.167  16.603  33.469  0.50 39.67           C  
+ATOM   1238  C   VAL 1 177      29.448  16.687  32.648  0.50 39.02           C  
+ATOM   1239  O   VAL 1 177      29.403  16.611  31.425  0.50 39.16           O  
+ATOM   1240  CB  VAL 1 177      27.684  18.057  33.783  0.50 41.36           C  
+ATOM   1241  CG1 VAL 1 177      27.802  18.943  32.527  0.50 39.93           C  
+ATOM   1242  CG2 VAL 1 177      26.231  18.032  34.270  0.50 39.44           C  
+ATOM   1243  N   THR 1 178      30.591  16.845  33.308  0.50 37.83           N  
+ATOM   1244  CA  THR 1 178      31.836  16.948  32.563  0.50 36.95           C  
+ATOM   1245  C   THR 1 178      32.246  15.630  31.913  0.50 36.65           C  
+ATOM   1246  O   THR 1 178      32.555  15.601  30.728  0.50 35.63           O  
+ATOM   1247  CB  THR 1 178      32.988  17.472  33.450  0.50 36.28           C  
+ATOM   1248  OG1 THR 1 178      32.993  16.768  34.697  0.50 40.95           O  
+ATOM   1249  CG2 THR 1 178      32.826  18.954  33.721  0.50 35.27           C  
+ATOM   1250  N   VAL 1 179      32.243  14.539  32.672  0.50 37.53           N  
+ATOM   1251  CA  VAL 1 179      32.626  13.238  32.116  0.50 38.51           C  
+ATOM   1252  C   VAL 1 179      31.733  12.839  30.945  0.50 39.34           C  
+ATOM   1253  O   VAL 1 179      32.195  12.263  29.959  0.50 40.47           O  
+ATOM   1254  CB  VAL 1 179      32.566  12.125  33.197  0.50 39.50           C  
+ATOM   1255  CG1 VAL 1 179      32.771  10.748  32.567  0.50 38.39           C  
+ATOM   1256  CG2 VAL 1 179      33.634  12.382  34.246  0.50 38.50           C  
+ATOM   1257  N   VAL 1 180      30.449  13.141  31.057  0.50 39.49           N  
+ATOM   1258  CA  VAL 1 180      29.506  12.814  30.001  0.50 39.42           C  
+ATOM   1259  C   VAL 1 180      29.713  13.707  28.781  0.50 39.10           C  
+ATOM   1260  O   VAL 1 180      29.924  13.213  27.679  0.50 40.00           O  
+ATOM   1261  CB  VAL 1 180      28.034  12.948  30.521  0.50 41.22           C  
+ATOM   1262  CG1 VAL 1 180      27.048  12.991  29.356  0.50 40.32           C  
+ATOM   1263  CG2 VAL 1 180      27.702  11.772  31.445  0.50 38.69           C  
+ATOM   1264  N   LEU 1 181      29.657  15.023  28.969  0.50 39.34           N  
+ATOM   1265  CA  LEU 1 181      29.822  15.932  27.841  0.50 39.70           C  
+ATOM   1266  C   LEU 1 181      31.151  15.772  27.124  0.50 40.28           C  
+ATOM   1267  O   LEU 1 181      31.199  15.747  25.893  0.50 39.96           O  
+ATOM   1268  CB  LEU 1 181      29.669  17.383  28.294  0.50 40.11           C  
+ATOM   1269  CG  LEU 1 181      28.282  17.798  28.796  0.50 40.00           C  
+ATOM   1270  CD1 LEU 1 181      28.300  19.287  29.109  0.50 38.26           C  
+ATOM   1271  CD2 LEU 1 181      27.219  17.482  27.744  0.50 38.30           C  
+ATOM   1272  N   TRP 1 182      32.234  15.662  27.886  0.50 39.56           N  
+ATOM   1273  CA  TRP 1 182      33.548  15.516  27.267  0.50 41.80           C  
+ATOM   1274  C   TRP 1 182      33.704  14.245  26.430  0.50 42.22           C  
+ATOM   1275  O   TRP 1 182      34.348  14.267  25.377  0.50 41.11           O  
+ATOM   1276  CB  TRP 1 182      34.655  15.602  28.332  0.50 41.69           C  
+ATOM   1277  CG  TRP 1 182      34.933  17.023  28.794  0.50 41.87           C  
+ATOM   1278  CD1 TRP 1 182      34.003  17.992  29.079  0.50 42.52           C  
+ATOM   1279  CD2 TRP 1 182      36.214  17.605  29.086  0.50 42.16           C  
+ATOM   1280  NE1 TRP 1 182      34.627  19.130  29.530  0.50 42.89           N  
+ATOM   1281  CE2 TRP 1 182      35.980  18.922  29.545  0.50 42.22           C  
+ATOM   1282  CE3 TRP 1 182      37.534  17.141  29.007  0.50 42.18           C  
+ATOM   1283  CZ2 TRP 1 182      37.020  19.779  29.924  0.50 42.52           C  
+ATOM   1284  CZ3 TRP 1 182      38.572  17.997  29.386  0.50 42.50           C  
+ATOM   1285  CH2 TRP 1 182      38.307  19.299  29.837  0.50 42.32           C  
+ATOM   1286  N   SER 1 183      33.106  13.145  26.884  0.50 42.74           N  
+ATOM   1287  CA  SER 1 183      33.192  11.882  26.150  0.50 43.73           C  
+ATOM   1288  C   SER 1 183      32.477  11.939  24.799  0.50 43.82           C  
+ATOM   1289  O   SER 1 183      32.824  11.206  23.876  0.50 43.97           O  
+ATOM   1290  CB  SER 1 183      32.594  10.741  26.976  0.50 42.90           C  
+ATOM   1291  OG  SER 1 183      33.326  10.531  28.167  0.50 43.66           O  
+ATOM   1292  N   ALA 1 184      31.480  12.806  24.685  0.50 43.46           N  
+ATOM   1293  CA  ALA 1 184      30.725  12.928  23.442  0.50 43.56           C  
+ATOM   1294  C   ALA 1 184      31.498  13.564  22.291  0.50 44.55           C  
+ATOM   1295  O   ALA 1 184      31.159  13.353  21.124  0.50 45.61           O  
+ATOM   1296  CB  ALA 1 184      29.448  13.709  23.692  0.50 43.17           C  
+ATOM   1297  N   TYR 1 185      32.536  14.340  22.604  0.50 44.46           N  
+ATOM   1298  CA  TYR 1 185      33.315  14.992  21.556  0.50 44.13           C  
+ATOM   1299  C   TYR 1 185      33.976  14.017  20.586  0.50 44.41           C  
+ATOM   1300  O   TYR 1 185      33.762  14.094  19.379  0.50 45.22           O  
+ATOM   1301  CB  TYR 1 185      34.370  15.927  22.170  0.50 44.97           C  
+ATOM   1302  CG  TYR 1 185      33.816  17.269  22.616  0.50 45.53           C  
+ATOM   1303  CD1 TYR 1 185      33.230  17.431  23.872  0.50 46.01           C  
+ATOM   1304  CD2 TYR 1 185      33.866  18.373  21.769  0.50 45.36           C  
+ATOM   1305  CE1 TYR 1 185      32.709  18.671  24.274  0.50 45.21           C  
+ATOM   1306  CE2 TYR 1 185      33.351  19.607  22.159  0.50 44.89           C  
+ATOM   1307  CZ  TYR 1 185      32.777  19.752  23.411  0.50 45.24           C  
+ATOM   1308  OH  TYR 1 185      32.305  20.991  23.802  0.50 44.96           O  
+ATOM   1309  N   PRO 1 186      34.811  13.099  21.091  0.50 44.74           N  
+ATOM   1310  CA  PRO 1 186      35.417  12.179  20.128  0.50 45.24           C  
+ATOM   1311  C   PRO 1 186      34.361  11.385  19.340  0.50 46.21           C  
+ATOM   1312  O   PRO 1 186      34.587  11.031  18.186  0.50 46.90           O  
+ATOM   1313  CB  PRO 1 186      36.310  11.288  21.003  0.50 44.34           C  
+ATOM   1314  CG  PRO 1 186      35.686  11.372  22.369  0.50 43.93           C  
+ATOM   1315  CD  PRO 1 186      35.288  12.830  22.460  0.50 43.54           C  
+ATOM   1316  N   VAL 1 187      33.207  11.125  19.949  0.50 46.83           N  
+ATOM   1317  CA  VAL 1 187      32.159  10.379  19.257  0.50 47.85           C  
+ATOM   1318  C   VAL 1 187      31.545  11.215  18.146  0.50 48.66           C  
+ATOM   1319  O   VAL 1 187      31.265  10.708  17.058  0.50 48.55           O  
+ATOM   1320  CB  VAL 1 187      31.042   9.928  20.216  0.50 48.13           C  
+ATOM   1321  CG1 VAL 1 187      29.959   9.184  19.431  0.50 49.21           C  
+ATOM   1322  CG2 VAL 1 187      31.624   9.016  21.296  0.50 47.78           C  
+ATOM   1323  N   VAL 1 188      31.325  12.495  18.422  0.50 48.40           N  
+ATOM   1324  CA  VAL 1 188      30.771  13.384  17.415  0.50 48.74           C  
+ATOM   1325  C   VAL 1 188      31.819  13.527  16.313  0.50 49.50           C  
+ATOM   1326  O   VAL 1 188      31.497  13.580  15.125  0.50 50.59           O  
+ATOM   1327  CB  VAL 1 188      30.455  14.774  18.012  0.50 48.52           C  
+ATOM   1328  CG1 VAL 1 188      30.174  15.784  16.901  0.50 47.95           C  
+ATOM   1329  CG2 VAL 1 188      29.266  14.666  18.943  0.50 46.48           C  
+ATOM   1330  N   TRP 1 189      33.079  13.576  16.722  0.50 49.19           N  
+ATOM   1331  CA  TRP 1 189      34.193  13.702  15.789  0.50 50.15           C  
+ATOM   1332  C   TRP 1 189      34.234  12.470  14.886  0.50 51.16           C  
+ATOM   1333  O   TRP 1 189      34.587  12.550  13.707  0.50 51.39           O  
+ATOM   1334  CB  TRP 1 189      35.504  13.795  16.574  0.50 49.49           C  
+ATOM   1335  CG  TRP 1 189      36.717  14.189  15.780  0.50 50.55           C  
+ATOM   1336  CD1 TRP 1 189      37.130  15.459  15.491  0.50 51.17           C  
+ATOM   1337  CD2 TRP 1 189      37.706  13.310  15.225  0.50 51.13           C  
+ATOM   1338  NE1 TRP 1 189      38.316  15.425  14.798  0.50 52.21           N  
+ATOM   1339  CE2 TRP 1 189      38.691  14.122  14.620  0.50 51.88           C  
+ATOM   1340  CE3 TRP 1 189      37.854  11.917  15.182  0.50 51.55           C  
+ATOM   1341  CZ2 TRP 1 189      39.816  13.582  13.976  0.50 52.58           C  
+ATOM   1342  CZ3 TRP 1 189      38.974  11.381  14.541  0.50 51.32           C  
+ATOM   1343  CH2 TRP 1 189      39.939  12.214  13.947  0.50 52.33           C  
+ATOM   1344  N   LEU 1 190      33.869  11.328  15.458  0.50 51.51           N  
+ATOM   1345  CA  LEU 1 190      33.874  10.059  14.748  0.50 52.67           C  
+ATOM   1346  C   LEU 1 190      32.795   9.922  13.680  0.50 53.64           C  
+ATOM   1347  O   LEU 1 190      33.016   9.285  12.652  0.50 53.92           O  
+ATOM   1348  CB  LEU 1 190      33.749   8.914  15.755  0.50 52.59           C  
+ATOM   1349  CG  LEU 1 190      35.016   8.120  16.105  0.50 52.30           C  
+ATOM   1350  CD1 LEU 1 190      36.172   9.044  16.395  0.50 51.53           C  
+ATOM   1351  CD2 LEU 1 190      34.725   7.226  17.300  0.50 52.70           C  
+ATOM   1352  N   ILE 1 191      31.632  10.516  13.916  0.50 54.08           N  
+ATOM   1353  CA  ILE 1 191      30.539  10.424  12.954  0.50 54.25           C  
+ATOM   1354  C   ILE 1 191      30.604  11.522  11.898  0.50 55.60           C  
+ATOM   1355  O   ILE 1 191      29.817  11.534  10.952  0.50 55.94           O  
+ATOM   1356  CB  ILE 1 191      29.172  10.507  13.657  0.50 53.26           C  
+ATOM   1357  CG1 ILE 1 191      29.024  11.867  14.342  0.50 53.17           C  
+ATOM   1358  CG2 ILE 1 191      29.037   9.374  14.657  0.50 52.13           C  
+ATOM   1359  CD1 ILE 1 191      27.698  12.067  15.056  0.50 52.68           C  
+ATOM   1360  N   GLY 1 192      31.544  12.445  12.069  0.50 56.91           N  
+ATOM   1361  CA  GLY 1 192      31.691  13.541  11.132  0.50 57.09           C  
+ATOM   1362  C   GLY 1 192      32.406  13.158   9.855  0.50 58.51           C  
+ATOM   1363  O   GLY 1 192      32.184  12.079   9.317  0.50 59.91           O  
+ATOM   1364  N   SER 1 193      33.281  14.038   9.377  0.50 59.03           N  
+ATOM   1365  CA  SER 1 193      34.009  13.789   8.140  0.50 59.06           C  
+ATOM   1366  C   SER 1 193      35.354  13.091   8.323  0.50 59.06           C  
+ATOM   1367  O   SER 1 193      35.932  12.590   7.356  0.50 58.90           O  
+ATOM   1368  CB  SER 1 193      34.205  15.103   7.375  0.50 58.87           C  
+ATOM   1369  OG  SER 1 193      34.934  16.045   8.142  0.50 60.65           O  
+ATOM   1370  N   GLU 1 194      35.855  13.053   9.554  0.50 58.85           N  
+ATOM   1371  CA  GLU 1 194      37.129  12.393   9.817  0.50 57.93           C  
+ATOM   1372  C   GLU 1 194      36.922  10.928  10.192  0.50 57.11           C  
+ATOM   1373  O   GLU 1 194      37.881  10.210  10.474  0.50 57.03           O  
+ATOM   1374  CB  GLU 1 194      37.887  13.101  10.941  0.50 58.92           C  
+ATOM   1375  CG  GLU 1 194      39.007  14.023  10.477  0.50 59.51           C  
+ATOM   1376  CD  GLU 1 194      38.563  15.461  10.332  0.50 59.43           C  
+ATOM   1377  OE1 GLU 1 194      37.900  15.964  11.267  0.50 59.09           O  
+ATOM   1378  OE2 GLU 1 194      38.887  16.088   9.297  0.50 59.33           O  
+ATOM   1379  N   GLY 1 195      35.668  10.490  10.197  0.50 56.48           N  
+ATOM   1380  CA  GLY 1 195      35.367   9.107  10.531  0.50 56.83           C  
+ATOM   1381  C   GLY 1 195      34.233   8.582   9.670  0.50 56.82           C  
+ATOM   1382  O   GLY 1 195      34.275   8.697   8.448  0.50 55.73           O  
+ATOM   1383  N   ALA 1 196      33.228   7.984  10.300  0.50 56.42           N  
+ATOM   1384  CA  ALA 1 196      32.077   7.490   9.564  0.50 57.58           C  
+ATOM   1385  C   ALA 1 196      31.381   8.758   9.084  0.50 58.31           C  
+ATOM   1386  O   ALA 1 196      30.713   9.433   9.866  0.50 59.72           O  
+ATOM   1387  CB  ALA 1 196      31.157   6.701  10.489  0.50 56.53           C  
+ATOM   1388  N   GLY 1 197      31.552   9.098   7.813  0.50 57.80           N  
+ATOM   1389  CA  GLY 1 197      30.935  10.310   7.301  0.50 56.97           C  
+ATOM   1390  C   GLY 1 197      29.416  10.296   7.290  0.50 56.46           C  
+ATOM   1391  O   GLY 1 197      28.804  10.622   6.276  0.50 56.96           O  
+ATOM   1392  N   ILE 1 198      28.799   9.936   8.411  0.50 55.37           N  
+ATOM   1393  CA  ILE 1 198      27.343   9.881   8.501  0.50 55.11           C  
+ATOM   1394  C   ILE 1 198      26.693  11.251   8.659  0.50 55.08           C  
+ATOM   1395  O   ILE 1 198      25.660  11.534   8.052  0.50 54.75           O  
+ATOM   1396  CB  ILE 1 198      26.887   9.025   9.690  0.50 55.21           C  
+ATOM   1397  CG1 ILE 1 198      27.480   7.619   9.589  0.50 55.93           C  
+ATOM   1398  CG2 ILE 1 198      25.367   8.972   9.728  0.50 55.25           C  
+ATOM   1399  CD1 ILE 1 198      27.215   6.761  10.816  0.50 56.31           C  
+ATOM   1400  N   VAL 1 199      27.298  12.096   9.483  0.50 55.44           N  
+ATOM   1401  CA  VAL 1 199      26.759  13.424   9.739  0.50 55.92           C  
+ATOM   1402  C   VAL 1 199      27.400  14.503   8.871  0.50 54.98           C  
+ATOM   1403  O   VAL 1 199      28.624  14.617   8.812  0.50 55.96           O  
+ATOM   1404  CB  VAL 1 199      26.939  13.796  11.229  0.50 56.64           C  
+ATOM   1405  CG1 VAL 1 199      26.483  15.227  11.485  0.50 57.88           C  
+ATOM   1406  CG2 VAL 1 199      26.148  12.828  12.094  0.50 57.04           C  
+ATOM   1407  N   PRO 1 200      26.575  15.303   8.173  0.50 54.53           N  
+ATOM   1408  CA  PRO 1 200      27.090  16.377   7.313  0.50 53.61           C  
+ATOM   1409  C   PRO 1 200      27.727  17.495   8.143  0.50 54.08           C  
+ATOM   1410  O   PRO 1 200      27.660  17.480   9.370  0.50 54.97           O  
+ATOM   1411  CB  PRO 1 200      25.849  16.835   6.545  0.50 52.85           C  
+ATOM   1412  CG  PRO 1 200      24.724  16.536   7.501  0.50 52.53           C  
+ATOM   1413  CD  PRO 1 200      25.106  15.199   8.078  0.50 52.71           C  
+ATOM   1414  N   LEU 1 201      28.345  18.458   7.472  0.50 54.20           N  
+ATOM   1415  CA  LEU 1 201      29.008  19.561   8.157  0.50 55.25           C  
+ATOM   1416  C   LEU 1 201      28.144  20.426   9.076  0.50 55.14           C  
+ATOM   1417  O   LEU 1 201      28.467  20.593  10.255  0.50 55.76           O  
+ATOM   1418  CB  LEU 1 201      29.703  20.465   7.135  0.50 56.42           C  
+ATOM   1419  CG  LEU 1 201      31.119  20.093   6.691  0.50 57.59           C  
+ATOM   1420  CD1 LEU 1 201      31.190  18.632   6.258  0.50 59.23           C  
+ATOM   1421  CD2 LEU 1 201      31.529  21.018   5.559  0.50 57.66           C  
+ATOM   1422  N   ASN 1 202      27.055  20.977   8.551  0.50 53.79           N  
+ATOM   1423  CA  ASN 1 202      26.200  21.848   9.353  0.50 54.07           C  
+ATOM   1424  C   ASN 1 202      25.728  21.190  10.648  0.50 53.23           C  
+ATOM   1425  O   ASN 1 202      25.672  21.834  11.696  0.50 53.29           O  
+ATOM   1426  CB  ASN 1 202      24.999  22.334   8.523  0.50 53.89           C  
+ATOM   1427  CG  ASN 1 202      23.801  21.411   8.622  0.50 54.53           C  
+ATOM   1428  OD1 ASN 1 202      23.031  21.470   9.583  0.50 55.71           O  
+ATOM   1429  ND2 ASN 1 202      23.641  20.545   7.633  0.50 54.73           N  
+ATOM   1430  N   ILE 1 203      25.399  19.906  10.586  0.50 52.43           N  
+ATOM   1431  CA  ILE 1 203      24.943  19.199  11.777  0.50 51.81           C  
+ATOM   1432  C   ILE 1 203      26.107  19.011  12.750  0.50 51.08           C  
+ATOM   1433  O   ILE 1 203      25.956  19.171  13.959  0.50 51.06           O  
+ATOM   1434  CB  ILE 1 203      24.363  17.819  11.410  0.50 52.34           C  
+ATOM   1435  CG1 ILE 1 203      23.272  17.983  10.349  0.50 52.86           C  
+ATOM   1436  CG2 ILE 1 203      23.818  17.137  12.655  0.50 52.07           C  
+ATOM   1437  CD1 ILE 1 203      22.125  18.873  10.786  0.50 53.45           C  
+ATOM   1438  N   GLU 1 204      27.266  18.661  12.209  0.50 49.79           N  
+ATOM   1439  CA  GLU 1 204      28.457  18.461  13.017  0.50 50.15           C  
+ATOM   1440  C   GLU 1 204      28.727  19.742  13.803  0.50 48.89           C  
+ATOM   1441  O   GLU 1 204      28.987  19.726  15.014  0.50 46.91           O  
+ATOM   1442  CB  GLU 1 204      29.643  18.142  12.109  0.50 50.81           C  
+ATOM   1443  CG  GLU 1 204      30.953  17.991  12.837  0.50 53.53           C  
+ATOM   1444  CD  GLU 1 204      31.570  16.624  12.640  0.50 55.62           C  
+ATOM   1445  OE1 GLU 1 204      30.997  15.623  13.132  0.50 57.25           O  
+ATOM   1446  OE2 GLU 1 204      32.631  16.553  11.985  0.50 56.54           O  
+ATOM   1447  N   THR 1 205      28.656  20.858  13.090  0.50 47.69           N  
+ATOM   1448  CA  THR 1 205      28.875  22.155  13.693  0.50 47.67           C  
+ATOM   1449  C   THR 1 205      27.857  22.383  14.800  0.50 47.31           C  
+ATOM   1450  O   THR 1 205      28.197  22.889  15.870  0.50 47.40           O  
+ATOM   1451  CB  THR 1 205      28.762  23.263  12.631  0.50 47.92           C  
+ATOM   1452  OG1 THR 1 205      29.884  23.172  11.741  0.50 48.46           O  
+ATOM   1453  CG2 THR 1 205      28.740  24.636  13.280  0.50 47.27           C  
+ATOM   1454  N   LEU 1 206      26.614  21.987  14.547  0.50 46.90           N  
+ATOM   1455  CA  LEU 1 206      25.543  22.152  15.520  0.50 46.10           C  
+ATOM   1456  C   LEU 1 206      25.839  21.383  16.798  0.50 45.37           C  
+ATOM   1457  O   LEU 1 206      25.849  21.949  17.888  0.50 45.57           O  
+ATOM   1458  CB  LEU 1 206      24.213  21.675  14.919  0.50 46.92           C  
+ATOM   1459  CG  LEU 1 206      22.896  21.777  15.716  0.50 48.32           C  
+ATOM   1460  CD1 LEU 1 206      22.832  20.676  16.753  0.50 49.00           C  
+ATOM   1461  CD2 LEU 1 206      22.761  23.153  16.376  0.50 47.88           C  
+ATOM   1462  N   LEU 1 207      26.087  20.087  16.654  0.50 45.17           N  
+ATOM   1463  CA  LEU 1 207      26.364  19.239  17.802  0.50 44.84           C  
+ATOM   1464  C   LEU 1 207      27.528  19.761  18.637  0.50 44.07           C  
+ATOM   1465  O   LEU 1 207      27.440  19.803  19.860  0.50 43.94           O  
+ATOM   1466  CB  LEU 1 207      26.626  17.805  17.339  0.50 45.89           C  
+ATOM   1467  CG  LEU 1 207      25.399  17.111  16.725  0.50 47.47           C  
+ATOM   1468  CD1 LEU 1 207      25.792  15.758  16.138  0.50 46.54           C  
+ATOM   1469  CD2 LEU 1 207      24.325  16.937  17.792  0.50 46.43           C  
+ATOM   1470  N   PHE 1 208      28.616  20.161  17.988  0.50 43.23           N  
+ATOM   1471  CA  PHE 1 208      29.746  20.693  18.733  0.50 43.61           C  
+ATOM   1472  C   PHE 1 208      29.324  21.970  19.472  0.50 43.28           C  
+ATOM   1473  O   PHE 1 208      29.767  22.225  20.593  0.50 42.81           O  
+ATOM   1474  CB  PHE 1 208      30.938  20.976  17.804  0.50 43.78           C  
+ATOM   1475  CG  PHE 1 208      31.798  19.759  17.520  0.50 43.18           C  
+ATOM   1476  CD1 PHE 1 208      32.250  18.953  18.563  0.50 42.94           C  
+ATOM   1477  CD2 PHE 1 208      32.182  19.441  16.216  0.50 43.92           C  
+ATOM   1478  CE1 PHE 1 208      33.076  17.848  18.317  0.50 41.74           C  
+ATOM   1479  CE2 PHE 1 208      33.008  18.339  15.953  0.50 42.63           C  
+ATOM   1480  CZ  PHE 1 208      33.457  17.542  17.007  0.50 42.49           C  
+ATOM   1481  N   MET 1 209      28.450  22.757  18.850  0.50 42.87           N  
+ATOM   1482  CA  MET 1 209      27.969  23.987  19.466  0.50 42.94           C  
+ATOM   1483  C   MET 1 209      27.180  23.659  20.721  0.50 42.45           C  
+ATOM   1484  O   MET 1 209      27.339  24.295  21.762  0.50 42.87           O  
+ATOM   1485  CB  MET 1 209      27.092  24.766  18.488  0.50 44.68           C  
+ATOM   1486  CG  MET 1 209      26.578  26.096  19.025  0.50 46.28           C  
+ATOM   1487  SD  MET 1 209      25.065  25.938  20.002  0.50 47.82           S  
+ATOM   1488  CE  MET 1 209      23.849  25.846  18.667  0.50 47.57           C  
+ATOM   1489  N   VAL 1 210      26.323  22.656  20.630  0.50 41.79           N  
+ATOM   1490  CA  VAL 1 210      25.538  22.277  21.787  0.50 40.60           C  
+ATOM   1491  C   VAL 1 210      26.484  21.780  22.888  0.50 39.65           C  
+ATOM   1492  O   VAL 1 210      26.320  22.113  24.064  0.50 40.19           O  
+ATOM   1493  CB  VAL 1 210      24.500  21.192  21.411  0.50 42.46           C  
+ATOM   1494  CG1 VAL 1 210      23.790  20.694  22.660  0.50 43.11           C  
+ATOM   1495  CG2 VAL 1 210      23.474  21.769  20.431  0.50 41.78           C  
+ATOM   1496  N   LEU 1 211      27.482  20.993  22.507  0.50 38.42           N  
+ATOM   1497  CA  LEU 1 211      28.444  20.486  23.479  0.50 38.23           C  
+ATOM   1498  C   LEU 1 211      29.214  21.659  24.114  0.50 38.39           C  
+ATOM   1499  O   LEU 1 211      29.375  21.720  25.337  0.50 39.62           O  
+ATOM   1500  CB  LEU 1 211      29.432  19.519  22.804  0.50 36.62           C  
+ATOM   1501  CG  LEU 1 211      29.210  17.997  22.661  0.50 36.94           C  
+ATOM   1502  CD1 LEU 1 211      28.022  17.515  23.477  0.50 32.21           C  
+ATOM   1503  CD2 LEU 1 211      29.045  17.648  21.189  0.50 33.67           C  
+ATOM   1504  N   ASP 1 212      29.675  22.597  23.289  0.50 38.07           N  
+ATOM   1505  CA  ASP 1 212      30.425  23.753  23.801  0.50 39.16           C  
+ATOM   1506  C   ASP 1 212      29.648  24.645  24.782  0.50 38.76           C  
+ATOM   1507  O   ASP 1 212      30.180  25.075  25.813  0.50 38.22           O  
+ATOM   1508  CB  ASP 1 212      30.949  24.622  22.644  0.50 38.42           C  
+ATOM   1509  CG  ASP 1 212      32.112  23.982  21.899  0.50 39.28           C  
+ATOM   1510  OD1 ASP 1 212      32.866  23.204  22.514  0.50 41.34           O  
+ATOM   1511  OD2 ASP 1 212      32.295  24.264  20.693  0.50 41.37           O  
+ATOM   1512  N   VAL 1 213      28.390  24.927  24.468  0.50 40.04           N  
+ATOM   1513  CA  VAL 1 213      27.584  25.780  25.333  0.50 38.91           C  
+ATOM   1514  C   VAL 1 213      27.296  25.107  26.669  0.50 39.65           C  
+ATOM   1515  O   VAL 1 213      27.364  25.730  27.739  0.50 39.44           O  
+ATOM   1516  CB  VAL 1 213      26.247  26.148  24.646  0.50 40.95           C  
+ATOM   1517  CG1 VAL 1 213      25.383  26.981  25.590  0.50 40.30           C  
+ATOM   1518  CG2 VAL 1 213      26.522  26.927  23.360  0.50 39.54           C  
+ATOM   1519  N   SER 1 214      26.984  23.821  26.605  0.50 39.55           N  
+ATOM   1520  CA  SER 1 214      26.683  23.059  27.801  0.50 40.02           C  
+ATOM   1521  C   SER 1 214      27.910  22.883  28.681  0.50 39.92           C  
+ATOM   1522  O   SER 1 214      27.846  23.083  29.894  0.50 40.74           O  
+ATOM   1523  CB  SER 1 214      26.121  21.688  27.418  0.50 39.76           C  
+ATOM   1524  OG  SER 1 214      24.900  21.819  26.725  0.50 39.41           O  
+ATOM   1525  N   ALA 1 215      29.023  22.504  28.062  0.50 41.17           N  
+ATOM   1526  CA  ALA 1 215      30.279  22.287  28.781  0.50 41.35           C  
+ATOM   1527  C   ALA 1 215      30.880  23.564  29.371  0.50 40.52           C  
+ATOM   1528  O   ALA 1 215      31.731  23.490  30.251  0.50 40.72           O  
+ATOM   1529  CB  ALA 1 215      31.299  21.630  27.852  0.50 42.18           C  
+ATOM   1530  N   LYS 1 216      30.445  24.723  28.885  0.50 40.01           N  
+ATOM   1531  CA  LYS 1 216      30.963  26.006  29.367  0.50 38.92           C  
+ATOM   1532  C   LYS 1 216      29.917  26.810  30.145  0.50 39.79           C  
+ATOM   1533  O   LYS 1 216      30.064  27.047  31.342  0.50 39.51           O  
+ATOM   1534  CB  LYS 1 216      31.481  26.813  28.172  0.50 37.39           C  
+ATOM   1535  CG  LYS 1 216      32.661  26.158  27.470  0.50 34.25           C  
+ATOM   1536  CD  LYS 1 216      33.026  26.851  26.169  0.50 33.27           C  
+ATOM   1537  CE  LYS 1 216      34.413  26.444  25.710  0.50 31.80           C  
+ATOM   1538  NZ  LYS 1 216      34.491  25.107  25.109  0.50 30.16           N  
+ATOM   1539  N   VAL 1 217      28.857  27.234  29.466  0.50 40.29           N  
+ATOM   1540  CA  VAL 1 217      27.796  27.984  30.131  0.50 39.93           C  
+ATOM   1541  C   VAL 1 217      27.030  27.094  31.120  0.50 39.76           C  
+ATOM   1542  O   VAL 1 217      26.775  27.489  32.263  0.50 40.08           O  
+ATOM   1543  CB  VAL 1 217      26.832  28.567  29.094  0.50 41.40           C  
+ATOM   1544  CG1 VAL 1 217      25.754  29.388  29.780  0.50 40.85           C  
+ATOM   1545  CG2 VAL 1 217      27.616  29.417  28.107  0.50 40.32           C  
+ATOM   1546  N   GLY 1 218      26.668  25.894  30.677  0.50 39.59           N  
+ATOM   1547  CA  GLY 1 218      25.951  24.966  31.538  0.50 38.73           C  
+ATOM   1548  C   GLY 1 218      26.719  24.717  32.823  0.50 39.19           C  
+ATOM   1549  O   GLY 1 218      26.194  24.840  33.931  0.50 39.54           O  
+ATOM   1550  N   PHE 1 219      27.987  24.366  32.656  0.50 39.50           N  
+ATOM   1551  CA  PHE 1 219      28.917  24.107  33.753  0.50 37.68           C  
+ATOM   1552  C   PHE 1 219      28.989  25.355  34.652  0.50 38.00           C  
+ATOM   1553  O   PHE 1 219      28.872  25.265  35.878  0.50 38.20           O  
+ATOM   1554  CB  PHE 1 219      30.286  23.772  33.124  0.50 38.30           C  
+ATOM   1555  CG  PHE 1 219      31.402  23.518  34.106  0.50 38.05           C  
+ATOM   1556  CD1 PHE 1 219      32.038  24.572  34.753  0.50 38.10           C  
+ATOM   1557  CD2 PHE 1 219      31.884  22.222  34.306  0.50 38.79           C  
+ATOM   1558  CE1 PHE 1 219      33.148  24.342  35.579  0.50 39.80           C  
+ATOM   1559  CE2 PHE 1 219      32.995  21.976  35.132  0.50 38.97           C  
+ATOM   1560  CZ  PHE 1 219      33.630  23.037  35.769  0.50 39.09           C  
+ATOM   1561  N   GLY 1 220      29.165  26.518  34.034  0.50 38.40           N  
+ATOM   1562  CA  GLY 1 220      29.245  27.760  34.789  0.50 37.82           C  
+ATOM   1563  C   GLY 1 220      28.026  28.045  35.645  0.50 38.91           C  
+ATOM   1564  O   GLY 1 220      28.156  28.467  36.797  0.50 37.99           O  
+ATOM   1565  N   LEU 1 221      26.837  27.835  35.081  0.50 39.47           N  
+ATOM   1566  CA  LEU 1 221      25.580  28.048  35.808  0.50 39.21           C  
+ATOM   1567  C   LEU 1 221      25.558  27.172  37.053  0.50 38.94           C  
+ATOM   1568  O   LEU 1 221      25.273  27.621  38.164  0.50 37.85           O  
+ATOM   1569  CB  LEU 1 221      24.376  27.671  34.930  0.50 41.23           C  
+ATOM   1570  CG  LEU 1 221      24.045  28.551  33.722  0.50 42.11           C  
+ATOM   1571  CD1 LEU 1 221      23.015  27.851  32.834  0.50 42.63           C  
+ATOM   1572  CD2 LEU 1 221      23.509  29.889  34.216  0.50 41.40           C  
+ATOM   1573  N   ILE 1 222      25.859  25.901  36.854  0.50 40.11           N  
+ATOM   1574  CA  ILE 1 222      25.872  24.959  37.953  0.50 41.13           C  
+ATOM   1575  C   ILE 1 222      26.823  25.385  39.065  0.50 42.12           C  
+ATOM   1576  O   ILE 1 222      26.477  25.345  40.244  0.50 43.63           O  
+ATOM   1577  CB  ILE 1 222      26.277  23.558  37.450  0.50 41.99           C  
+ATOM   1578  CG1 ILE 1 222      25.227  23.050  36.448  0.50 41.72           C  
+ATOM   1579  CG2 ILE 1 222      26.441  22.597  38.638  0.50 40.17           C  
+ATOM   1580  CD1 ILE 1 222      25.618  21.749  35.748  0.50 43.00           C  
+ATOM   1581  N   LEU 1 223      28.024  25.807  38.684  0.50 42.61           N  
+ATOM   1582  CA  LEU 1 223      29.027  26.205  39.661  0.50 41.40           C  
+ATOM   1583  C   LEU 1 223      28.781  27.571  40.300  0.50 41.05           C  
+ATOM   1584  O   LEU 1 223      28.853  27.713  41.518  0.50 41.17           O  
+ATOM   1585  CB  LEU 1 223      30.416  26.175  39.007  0.50 40.82           C  
+ATOM   1586  CG  LEU 1 223      31.619  26.516  39.900  0.50 40.56           C  
+ATOM   1587  CD1 LEU 1 223      31.654  25.564  41.081  0.50 39.04           C  
+ATOM   1588  CD2 LEU 1 223      32.915  26.404  39.106  0.50 40.11           C  
+ATOM   1589  N   LEU 1 224      28.486  28.576  39.489  0.50 41.91           N  
+ATOM   1590  CA  LEU 1 224      28.274  29.921  40.018  0.50 43.15           C  
+ATOM   1591  C   LEU 1 224      26.945  30.134  40.739  0.50 44.69           C  
+ATOM   1592  O   LEU 1 224      26.722  31.189  41.327  0.50 45.80           O  
+ATOM   1593  CB  LEU 1 224      28.439  30.951  38.894  0.50 41.10           C  
+ATOM   1594  CG  LEU 1 224      29.831  30.920  38.244  0.50 41.60           C  
+ATOM   1595  CD1 LEU 1 224      29.913  31.886  37.052  0.50 39.79           C  
+ATOM   1596  CD2 LEU 1 224      30.862  31.271  39.293  0.50 39.23           C  
+ATOM   1597  N   ARG 1 225      26.055  29.150  40.694  0.50 46.12           N  
+ATOM   1598  CA  ARG 1 225      24.783  29.295  41.393  0.50 47.03           C  
+ATOM   1599  C   ARG 1 225      24.865  28.622  42.753  0.50 47.12           C  
+ATOM   1600  O   ARG 1 225      24.116  28.954  43.668  0.50 46.90           O  
+ATOM   1601  CB  ARG 1 225      23.627  28.688  40.584  0.50 47.53           C  
+ATOM   1602  CG  ARG 1 225      23.128  29.571  39.437  0.50 50.52           C  
+ATOM   1603  CD  ARG 1 225      21.846  29.010  38.800  0.50 54.41           C  
+ATOM   1604  NE  ARG 1 225      20.636  29.781  39.110  0.50 55.36           N  
+ATOM   1605  CZ  ARG 1 225      20.110  29.924  40.324  0.50 55.51           C  
+ATOM   1606  NH1 ARG 1 225      20.682  29.355  41.377  0.50 55.46           N  
+ATOM   1607  NH2 ARG 1 225      18.996  30.623  40.477  0.50 55.48           N  
+ATOM   1608  N   SER 1 226      25.800  27.688  42.890  0.50 47.07           N  
+ATOM   1609  CA  SER 1 226      25.957  26.969  44.143  0.50 47.81           C  
+ATOM   1610  C   SER 1 226      26.707  27.813  45.162  0.50 48.16           C  
+ATOM   1611  O   SER 1 226      27.228  28.875  44.839  0.50 48.94           O  
+ATOM   1612  CB  SER 1 226      26.731  25.671  43.913  0.50 48.74           C  
+ATOM   1613  OG  SER 1 226      28.120  25.935  43.830  0.50 48.22           O  
+ATOM   1614  N   ARG 1 227      26.753  27.330  46.398  0.50 49.35           N  
+ATOM   1615  CA  ARG 1 227      27.466  28.020  47.463  0.50 50.19           C  
+ATOM   1616  C   ARG 1 227      28.885  27.480  47.525  0.50 50.07           C  
+ATOM   1617  O   ARG 1 227      29.749  28.064  48.171  0.50 50.70           O  
+ATOM   1618  CB  ARG 1 227      26.778  27.778  48.809  0.50 51.09           C  
+ATOM   1619  CG  ARG 1 227      25.560  28.665  49.070  0.50 53.70           C  
+ATOM   1620  CD  ARG 1 227      25.985  30.099  49.387  0.50 54.15           C  
+ATOM   1621  NE  ARG 1 227      26.759  30.163  50.627  0.50 53.51           N  
+ATOM   1622  CZ  ARG 1 227      27.356  31.256  51.091  0.50 53.00           C  
+ATOM   1623  NH1 ARG 1 227      27.278  32.399  50.424  0.50 53.73           N  
+ATOM   1624  NH2 ARG 1 227      28.036  31.203  52.228  0.50 53.88           N  
+ATOM   1625  N   ALA 1 228      29.113  26.359  46.843  0.50 50.11           N  
+ATOM   1626  CA  ALA 1 228      30.413  25.697  46.825  0.50 50.20           C  
+ATOM   1627  C   ALA 1 228      31.593  26.609  46.513  0.50 50.37           C  
+ATOM   1628  O   ALA 1 228      32.708  26.345  46.951  0.50 50.67           O  
+ATOM   1629  CB  ALA 1 228      30.390  24.542  45.837  0.50 49.62           C  
+ATOM   1630  N   ILE 1 229      31.354  27.675  45.756  0.50 50.22           N  
+ATOM   1631  CA  ILE 1 229      32.422  28.595  45.391  0.50 49.21           C  
+ATOM   1632  C   ILE 1 229      32.876  29.462  46.554  0.50 49.84           C  
+ATOM   1633  O   ILE 1 229      33.841  30.220  46.436  0.50 49.54           O  
+ATOM   1634  CB  ILE 1 229      31.998  29.519  44.218  0.50 48.51           C  
+ATOM   1635  CG1 ILE 1 229      30.804  30.385  44.641  0.50 48.04           C  
+ATOM   1636  CG2 ILE 1 229      31.668  28.671  42.985  0.50 47.71           C  
+ATOM   1637  CD1 ILE 1 229      30.443  31.474  43.646  0.50 47.07           C  
+ATOM   1638  N   PHE 1 230      32.187  29.357  47.680  0.50 51.26           N  
+ATOM   1639  CA  PHE 1 230      32.558  30.152  48.842  0.50 53.91           C  
+ATOM   1640  C   PHE 1 230      33.447  29.393  49.803  0.50 56.08           C  
+ATOM   1641  O   PHE 1 230      33.261  28.198  50.023  0.50 56.29           O  
+ATOM   1642  CB  PHE 1 230      31.302  30.656  49.554  0.50 52.55           C  
+ATOM   1643  CG  PHE 1 230      30.537  31.653  48.738  0.50 52.77           C  
+ATOM   1644  CD1 PHE 1 230      30.970  32.976  48.650  0.50 50.97           C  
+ATOM   1645  CD2 PHE 1 230      29.436  31.253  47.986  0.50 51.07           C  
+ATOM   1646  CE1 PHE 1 230      30.340  33.876  47.797  0.50 50.73           C  
+ATOM   1647  CE2 PHE 1 230      28.796  32.146  47.126  0.50 51.88           C  
+ATOM   1648  CZ  PHE 1 230      29.243  33.465  47.038  0.50 51.02           C  
+ATOM   1649  N   GLY 1 231      34.428  30.101  50.353  0.50 59.15           N  
+ATOM   1650  CA  GLY 1 231      35.346  29.496  51.296  0.50 62.48           C  
+ATOM   1651  C   GLY 1 231      34.565  28.808  52.394  0.50 64.81           C  
+ATOM   1652  O   GLY 1 231      33.382  29.086  52.594  0.50 65.29           O  
+ATOM   1653  N   GLU 1 232      35.221  27.908  53.113  0.50 67.06           N  
+ATOM   1654  CA  GLU 1 232      34.556  27.179  54.182  0.50 69.50           C  
+ATOM   1655  C   GLU 1 232      34.975  27.651  55.580  0.50 70.61           C  
+ATOM   1656  O   GLU 1 232      34.377  28.580  56.128  0.50 70.88           O  
+ATOM   1657  CB  GLU 1 232      34.814  25.677  53.998  0.50 70.47           C  
+ATOM   1658  CG  GLU 1 232      34.189  25.105  52.715  0.50 72.11           C  
+ATOM   1659  CD  GLU 1 232      34.870  23.827  52.221  0.50 72.94           C  
+ATOM   1660  OE1 GLU 1 232      36.046  23.903  51.800  0.50 73.79           O  
+ATOM   1661  OE2 GLU 1 232      34.230  22.752  52.249  0.50 71.69           O  
+ATOM   1662  N   ALA 1 233      35.999  27.020  56.150  0.50 70.88           N  
+ATOM   1663  CA  ALA 1 233      36.479  27.383  57.482  0.50 71.23           C  
+ATOM   1664  C   ALA 1 233      37.708  28.283  57.409  0.50 71.55           C  
+ATOM   1665  O   ALA 1 233      38.745  27.982  58.001  0.50 71.21           O  
+ATOM   1666  CB  ALA 1 233      36.803  26.124  58.284  0.50 71.40           C  
+TER    1667      ALA 1 233                                                      
+HETATM 1668  S   SO4 1 700      34.498  19.390  10.147  0.50158.02           S  
+HETATM 1669  O1  SO4 1 700      34.770  20.837  10.098  0.50157.91           O  
+HETATM 1670  O2  SO4 1 700      33.695  19.065  11.330  0.50158.00           O  
+HETATM 1671  O3  SO4 1 700      33.758  18.985   8.976  0.50157.97           O  
+HETATM 1672  O4  SO4 1 700      35.811  18.658  10.188  0.50157.95           O  
+HETATM 1673  C1  RET 1 250      38.876  15.565  19.651  0.50 31.20           C  
+HETATM 1674  C2  RET 1 250      39.441  14.688  18.439  0.50 31.85           C  
+HETATM 1675  C3  RET 1 250      39.344  13.231  18.547  0.50 31.39           C  
+HETATM 1676  C4  RET 1 250      39.858  12.701  19.871  0.50 30.17           C  
+HETATM 1677  C5  RET 1 250      39.368  13.443  21.114  0.50 30.28           C  
+HETATM 1678  C6  RET 1 250      38.880  14.789  21.075  0.50 30.64           C  
+HETATM 1679  C7  RET 1 250      38.396  15.389  22.423  0.50 29.82           C  
+HETATM 1680  C8  RET 1 250      37.915  16.611  22.729  0.50 30.52           C  
+HETATM 1681  C9  RET 1 250      37.358  17.070  24.000  0.50 30.02           C  
+HETATM 1682  C10 RET 1 250      36.950  18.378  24.002  0.50 29.42           C  
+HETATM 1683  C11 RET 1 250      36.306  19.174  25.020  0.50 28.83           C  
+HETATM 1684  C12 RET 1 250      35.982  20.443  24.708  0.50 28.92           C  
+HETATM 1685  C13 RET 1 250      35.285  21.443  25.557  0.50 25.72           C  
+HETATM 1686  C14 RET 1 250      35.161  22.731  25.074  0.50 26.29           C  
+HETATM 1687  C15 RET 1 250      34.728  23.953  25.781  0.50 26.91           C  
+HETATM 1688  C16 RET 1 250      39.762  16.820  19.726  0.50 31.06           C  
+HETATM 1689  C17 RET 1 250      37.456  15.991  19.243  0.50 31.48           C  
+HETATM 1690  C18 RET 1 250      39.428  12.605  22.385  0.50 29.29           C  
+HETATM 1691  C19 RET 1 250      37.186  16.126  25.176  0.50 25.85           C  
+HETATM 1692  C20 RET 1 250      34.843  21.049  26.947  0.50 23.85           C  
+HETATM 1693  C1  L3P 1 260      36.933  38.816  38.145  1.00 72.55           C  
+HETATM 1694  C2  L3P 1 260      36.751  40.049  39.061  1.00 79.81           C  
+HETATM 1695  C3  L3P 1 260      38.028  40.243  39.920  1.00 81.51           C  
+HETATM 1696  O1  L3P 1 260      35.774  38.567  37.273  1.00 66.01           O  
+HETATM 1697  O2  L3P 1 260      36.487  41.275  38.213  1.00 84.35           O  
+HETATM 1698  O3  L3P 1 260      37.578  40.882  41.213  1.00 85.66           O  
+HETATM 1699  O4  L3P 1 260      38.394  43.403  41.334  0.50 85.94           O  
+HETATM 1700  O1P L3P 1 260      39.644  41.722  42.505  0.50 86.26           O  
+HETATM 1701  O2P L3P 1 260      37.418  42.508  43.514  0.50 85.70           O  
+HETATM 1702  P1  L3P 1 260      38.299  42.135  42.136  0.50 86.16           P  
+HETATM 1703  C11 L3P 1 260      35.917  37.880  35.988  1.00 60.68           C  
+HETATM 1704  C12 L3P 1 260      36.069  38.940  34.890  1.00 62.73           C  
+HETATM 1705  C13 L3P 1 260      36.288  38.427  33.478  1.00 64.27           C  
+HETATM 1706  C14 L3P 1 260      37.571  37.612  33.401  1.00 65.70           C  
+HETATM 1707  C15 L3P 1 260      36.351  39.650  32.560  1.00 67.29           C  
+HETATM 1708  C16 L3P 1 260      36.571  39.343  31.109  1.00 68.39           C  
+HETATM 1709  C17 L3P 1 260      36.544  40.654  30.348  1.00 71.23           C  
+HETATM 1710  C18 L3P 1 260      36.352  40.548  28.801  1.00 72.82           C  
+HETATM 1711  C19 L3P 1 260      37.525  39.839  28.122  1.00 73.00           C  
+HETATM 1712  C20 L3P 1 260      36.274  41.932  28.160  1.00 75.32           C  
+HETATM 1713  C21 L3P 1 260      34.826  42.294  27.821  1.00 77.88           C  
+HETATM 1714  C22 L3P 1 260      34.545  42.155  26.300  1.00 78.33           C  
+HETATM 1715  C23 L3P 1 260      33.634  40.921  25.998  1.00 78.90           C  
+HETATM 1716  C24 L3P 1 260      34.411  39.828  25.267  1.00 77.82           C  
+HETATM 1717  C25 L3P 1 260      32.448  41.312  25.116  1.00 78.26           C  
+HETATM 1718  C26 L3P 1 260      31.190  40.651  25.699  1.00 76.47           C  
+HETATM 1719  C27 L3P 1 260      30.402  39.902  24.596  1.00 74.82           C  
+HETATM 1720  C28 L3P 1 260      29.133  40.695  24.202  1.00 74.02           C  
+HETATM 1721  C29 L3P 1 260      29.336  41.324  22.835  1.00 74.69           C  
+HETATM 1722  C30 L3P 1 260      27.908  39.769  24.126  1.00 73.81           C  
+HETATM 1723  C41 L3P 1 260      36.254  42.698  38.700  1.00 86.67           C  
+HETATM 1724  C42 L3P 1 260      34.816  42.990  39.327  1.00 87.44           C  
+HETATM 1725  C43 L3P 1 260      34.522  44.534  39.310  1.00 88.43           C  
+HETATM 1726  C44 L3P 1 260      34.380  45.085  40.732  1.00 88.01           C  
+HETATM 1727  C45 L3P 1 260      33.226  44.806  38.553  1.00 89.07           C  
+HETATM 1728  C46 L3P 1 260      33.593  45.020  37.094  1.00 88.89           C  
+HETATM 1729  C47 L3P 1 260      32.384  45.287  36.264  1.00 88.90           C  
+HETATM 1730  C48 L3P 1 260      32.769  45.490  34.807  1.00 89.29           C  
+HETATM 1731  C49 L3P 1 260      33.755  46.643  34.515  1.00 88.91           C  
+HETATM 1732  C50 L3P 1 260      31.525  45.729  34.050  1.00 90.08           C  
+HETATM 1733  C1  L2P 1 270      49.716  22.173  12.744  1.00110.15           C  
+HETATM 1734  O1  L2P 1 270      49.140  22.160  14.122  1.00110.75           O  
+HETATM 1735  C2  L2P 1 270      50.754  21.118  12.141  1.00109.54           C  
+HETATM 1736  O2  L2P 1 270      52.188  21.525  12.547  1.00108.71           O  
+HETATM 1737  C3  L2P 1 270      50.624  21.084  10.562  1.00110.32           C  
+HETATM 1738  O3  L2P 1 270      50.564  19.886   9.871  1.00110.54           O  
+HETATM 1739  C11 L2P 1 270      49.445  23.299  14.921  1.00110.96           C  
+HETATM 1740  C12 L2P 1 270      49.781  23.008  16.391  1.00110.61           C  
+HETATM 1741  C41 L2P 1 270      52.668  21.682  14.001  1.00107.05           C  
+HETATM 1742  C42 L2P 1 270      52.422  20.292  14.812  1.00104.49           C  
+HETATM 1743  C43 L2P 1 270      52.801  20.113  16.375  1.00102.33           C  
+HETATM 1744  C44 L2P 1 270      54.310  20.489  16.658  1.00102.04           C  
+HETATM 1745  C45 L2P 1 270      52.384  18.601  16.681  1.00 99.09           C  
+HETATM 1746  C46 L2P 1 270      52.601  18.034  18.133  1.00 95.31           C  
+HETATM 1747  C47 L2P 1 270      51.557  18.524  19.189  1.00 92.68           C  
+HETATM 1748  C48 L2P 1 270      51.523  17.970  20.758  1.00 89.48           C  
+HETATM 1749  C49 L2P 1 270      50.389  16.998  21.145  1.00 90.32           C  
+HETATM 1750  C50 L2P 1 270      51.519  19.303  21.725  1.00 88.01           C  
+HETATM 1751  C51 L2P 1 270      51.491  19.210  23.296  1.00 85.60           C  
+HETATM 1752  C52 L2P 1 270      51.021  20.636  23.706  1.00 84.90           C  
+HETATM 1753  C53 L2P 1 270      50.802  21.152  25.170  1.00 85.25           C  
+HETATM 1754  C54 L2P 1 270      50.299  22.541  24.801  1.00 85.62           C  
+HETATM 1755  C55 L2P 1 270      52.175  21.231  25.979  1.00 86.49           C  
+HETATM 1756  C56 L2P 1 270      52.208  22.076  27.313  1.00 88.82           C  
+HETATM 1757  C57 L2P 1 270      53.539  22.950  27.503  1.00 90.37           C  
+HETATM 1758  C58 L2P 1 270      53.686  23.846  28.822  1.00 91.19           C  
+HETATM 1759  C59 L2P 1 270      54.762  23.392  29.712  1.00 91.04           C  
+HETATM 1760  C60 L2P 1 270      54.003  25.330  28.514  1.00 91.23           C  
+HETATM 1761  C11 L3P 1 280      54.635   4.214  10.847  1.00 83.35           C  
+HETATM 1762  C12 L3P 1 280      53.954   3.488  12.101  1.00 84.25           C  
+HETATM 1763  C13 L3P 1 280      54.818   3.688  13.454  1.00 85.04           C  
+HETATM 1764  C14 L3P 1 280      56.269   3.090  13.278  1.00 85.17           C  
+HETATM 1765  C15 L3P 1 280      54.080   2.954  14.635  1.00 85.19           C  
+HETATM 1766  C16 L3P 1 280      53.620   3.975  15.717  1.00 84.92           C  
+HETATM 1767  C17 L3P 1 280      52.089   3.897  15.883  1.00 86.85           C  
+HETATM 1768  C18 L3P 1 280      51.660   3.044  17.234  1.00 87.69           C  
+HETATM 1769  C19 L3P 1 280      51.281   1.563  16.888  1.00 88.09           C  
+HETATM 1770  C20 L3P 1 280      50.411   3.826  17.929  1.00 87.91           C  
+HETATM 1771  C21 L3P 1 280      50.744   4.402  19.347  1.00 87.16           C  
+HETATM 1772  C22 L3P 1 280      49.445   5.112  19.879  1.00 87.14           C  
+HETATM 1773  C23 L3P 1 280      48.733   4.255  21.000  1.00 87.15           C  
+HETATM 1774  C24 L3P 1 280      47.460   3.680  20.358  1.00 88.18           C  
+HETATM 1775  C25 L3P 1 280      48.371   5.181  22.278  1.00 86.28           C  
+HETATM 1776  C26 L3P 1 280      47.664   4.352  23.426  1.00 85.88           C  
+HETATM 1777  C27 L3P 1 280      48.755   3.846  24.496  1.00 86.64           C  
+HETATM 1778  C28 L3P 1 280      48.068   2.979  25.657  1.00 85.75           C  
+HETATM 1779  C29 L3P 1 280      48.793   1.705  25.817  1.00 84.84           C  
+HETATM 1780  C30 L3P 1 280      48.097   3.744  26.997  1.00 85.94           C  
+HETATM 1781  C11 L3P 1 290      39.919  -0.148  14.420  1.00 94.03           C  
+HETATM 1782  C12 L3P 1 290      39.739  -0.884  15.720  1.00 94.75           C  
+HETATM 1783  C13 L3P 1 290      40.137  -0.005  16.877  1.00 95.74           C  
+HETATM 1784  C14 L3P 1 290      41.410  -0.568  17.464  1.00 94.93           C  
+HETATM 1785  C15 L3P 1 290      38.990   0.009  17.917  1.00 96.35           C  
+HETATM 1786  C16 L3P 1 290      39.310   0.907  19.139  1.00 96.81           C  
+HETATM 1787  C17 L3P 1 290      38.144   0.894  20.153  1.00 97.99           C  
+HETATM 1788  C18 L3P 1 290      38.664   0.933  21.673  1.00 98.85           C  
+HETATM 1789  C19 L3P 1 290      39.523  -0.315  21.954  1.00 98.42           C  
+HETATM 1790  C20 L3P 1 290      37.467   0.922  22.671  1.00 99.57           C  
+HETATM 1791  C21 L3P 1 290      37.762   1.818  23.886  1.00100.12           C  
+HETATM 1792  C22 L3P 1 290      36.510   1.785  24.893  1.00100.30           C  
+HETATM 1793  C23 L3P 1 290      36.913   2.337  26.411  1.00100.10           C  
+HETATM 1794  C24 L3P 1 290      37.724   1.216  27.162  1.00 99.69           C  
+HETATM 1795  C25 L3P 1 290      35.532   2.750  27.355  1.00 99.53           C  
+HETATM 1796  C26 L3P 1 290      35.549   4.381  27.861  1.00 99.08           C  
+HETATM 1797  C27 L3P 1 290      34.252   4.787  28.757  1.00 97.65           C  
+HETATM 1798  C28 L3P 1 290      34.214   6.355  29.259  1.00 96.22           C  
+HETATM 1799  C29 L3P 1 290      32.774   6.987  29.139  1.00 95.16           C  
+HETATM 1800  C30 L3P 1 290      34.675   6.459  30.759  1.00 96.69           C  
+HETATM 1801  O   HOH 1 601      32.870  20.936  31.003  0.50 57.04           O  
+HETATM 1802  O   HOH 1 602      32.660  28.402  32.040  0.50 61.91           O  
+HETATM 1803  O   HOH 1 603      34.874  25.348  19.711  0.50 50.32           O  
+HETATM 1804  O   HOH 1 605      30.539  24.517  16.370  0.50 45.38           O  
+HETATM 1805  O   HOH 1 606      32.642  24.702  14.742  0.50 39.50           O  
+HETATM 1806  O   HOH 1 607      37.258  18.637  12.731  0.50 69.16           O  
+HETATM 1807  O   HOH 1 608      31.930  21.665  10.190  0.50 59.66           O  
+HETATM 1808  O   HOH 1 609      37.657  20.679  11.379  0.50 46.68           O  
+HETATM 1809  O   HOH 1 610      34.575  14.553  11.874  0.50 43.36           O  
+HETATM 1810  O   HOH 1 611      40.352  11.092   4.024  0.50 78.18           O  
+HETATM 1811  O   HOH 1 612      35.255  17.150  12.896  0.50 60.89           O  
+HETATM 1812  O   HOH 1 613      38.248  17.811   6.617  0.50 96.27           O  
+HETATM 1813  O   HOH 1 621      33.757   7.731  42.161  0.50 69.36           O  
+HETATM 1814  O   HOH 1 622      35.917   7.708  43.711  0.50 58.48           O  
+HETATM 1815  O   HOH 1 623      32.117  37.093  36.474  0.50 46.35           O  
+HETATM 1816  O   HOH 1 624      32.429  40.934  37.553  0.50 47.60           O  
+HETATM 1817  O   HOH 1 625      26.320  41.045  41.375  0.50 77.78           O  
+HETATM 1818  O   HOH 1 626      31.527  37.765  48.475  0.50 62.07           O  
+HETATM 1819  O   HOH 1 627      32.843  37.570  51.612  0.50 67.42           O  
+HETATM 1820  O   HOH 1 628      38.196  32.353  50.905  0.50 62.11           O  
+HETATM 1821  O   HOH 1 631      27.065  16.040  49.258  0.50 61.34           O  
+HETATM 1822  O   HOH 1 632      27.663  12.896  47.321  0.50 81.23           O  
+HETATM 1823  O   HOH 1 633      50.207  12.947  10.604  0.50 62.78           O  
+HETATM 1824  O   HOH 1 634      33.459  39.035  41.165  0.50 23.61           O  
+HETATM 1825  O   HOH 1 635      33.856  39.030  38.884  0.50 23.66           O  
+ENDMDL                                                                          
+MODEL        2                                                                  
+ATOM      1  N   PRO 1   8      23.709  27.156   4.334  0.50 64.91           N  
+ATOM      2  CA  PRO 1   8      23.965  28.319   5.214  0.50 64.43           C  
+ATOM      3  C   PRO 1   8      24.104  27.876   6.665  0.50 64.11           C  
+ATOM      4  O   PRO 1   8      23.191  28.058   7.477  0.50 64.58           O  
+ATOM      5  CB  PRO 1   8      22.788  29.268   5.036  0.50 64.26           C  
+ATOM      6  CG  PRO 1   8      21.683  28.303   4.612  0.50 64.37           C  
+ATOM      7  CD  PRO 1   8      22.388  27.297   3.692  0.50 65.23           C  
+ATOM      8  N   GLU 1   9      25.260  27.300   6.983  0.50 63.52           N  
+ATOM      9  CA  GLU 1   9      25.543  26.802   8.327  0.50 61.59           C  
+ATOM     10  C   GLU 1   9      25.915  27.920   9.292  0.50 59.70           C  
+ATOM     11  O   GLU 1   9      26.477  27.663  10.355  0.50 58.79           O  
+ATOM     12  CB  GLU 1   9      26.691  25.796   8.272  0.50 62.53           C  
+ATOM     13  CG  GLU 1   9      26.583  24.802   7.126  0.50 65.30           C  
+ATOM     14  CD  GLU 1   9      27.709  23.791   7.125  0.50 65.61           C  
+ATOM     15  OE1 GLU 1   9      27.839  23.047   6.132  0.50 67.96           O  
+ATOM     16  OE2 GLU 1   9      28.459  23.735   8.120  0.50 67.14           O  
+ATOM     17  N   TRP 1  10      25.600  29.159   8.929  0.50 58.19           N  
+ATOM     18  CA  TRP 1  10      25.940  30.282   9.786  0.50 56.54           C  
+ATOM     19  C   TRP 1  10      25.049  30.446  11.013  0.50 54.80           C  
+ATOM     20  O   TRP 1  10      25.468  31.064  11.989  0.50 54.80           O  
+ATOM     21  CB  TRP 1  10      25.951  31.592   8.989  0.50 56.69           C  
+ATOM     22  CG  TRP 1  10      24.640  31.965   8.385  0.50 57.72           C  
+ATOM     23  CD1 TRP 1  10      24.197  31.660   7.129  0.50 58.40           C  
+ATOM     24  CD2 TRP 1  10      23.586  32.707   9.013  0.50 58.52           C  
+ATOM     25  NE1 TRP 1  10      22.932  32.166   6.934  0.50 59.27           N  
+ATOM     26  CE2 TRP 1  10      22.532  32.813   8.074  0.50 59.01           C  
+ATOM     27  CE3 TRP 1  10      23.428  33.291  10.279  0.50 58.38           C  
+ATOM     28  CZ2 TRP 1  10      21.335  33.481   8.362  0.50 58.74           C  
+ATOM     29  CZ3 TRP 1  10      22.239  33.955  10.568  0.50 58.33           C  
+ATOM     30  CH2 TRP 1  10      21.206  34.044   9.611  0.50 59.16           C  
+ATOM     31  N   ILE 1  11      23.836  29.896  10.984  0.50 52.97           N  
+ATOM     32  CA  ILE 1  11      22.946  30.048  12.129  0.50 52.30           C  
+ATOM     33  C   ILE 1  11      23.458  29.352  13.381  0.50 51.00           C  
+ATOM     34  O   ILE 1  11      23.303  29.871  14.489  0.50 51.38           O  
+ATOM     35  CB  ILE 1  11      21.498  29.559  11.834  0.50 53.07           C  
+ATOM     36  CG1 ILE 1  11      20.613  29.832  13.059  0.50 53.77           C  
+ATOM     37  CG2 ILE 1  11      21.486  28.081  11.508  0.50 53.09           C  
+ATOM     38  CD1 ILE 1  11      19.132  29.604  12.836  0.50 56.03           C  
+ATOM     39  N   TRP 1  12      24.059  28.178  13.213  0.50 48.84           N  
+ATOM     40  CA  TRP 1  12      24.607  27.455  14.354  0.50 47.15           C  
+ATOM     41  C   TRP 1  12      25.734  28.317  14.918  0.50 44.61           C  
+ATOM     42  O   TRP 1  12      25.855  28.475  16.133  0.50 43.35           O  
+ATOM     43  CB  TRP 1  12      25.155  26.096  13.917  0.50 48.56           C  
+ATOM     44  CG  TRP 1  12      24.121  25.189  13.296  0.50 50.44           C  
+ATOM     45  CD1 TRP 1  12      24.311  24.332  12.245  0.50 49.76           C  
+ATOM     46  CD2 TRP 1  12      22.748  25.041  13.690  0.50 50.32           C  
+ATOM     47  NE1 TRP 1  12      23.146  23.667  11.961  0.50 50.82           N  
+ATOM     48  CE2 TRP 1  12      22.169  24.080  12.830  0.50 51.31           C  
+ATOM     49  CE3 TRP 1  12      21.950  25.626  14.685  0.50 51.13           C  
+ATOM     50  CZ2 TRP 1  12      20.826  23.689  12.933  0.50 51.48           C  
+ATOM     51  CZ3 TRP 1  12      20.611  25.236  14.788  0.50 52.39           C  
+ATOM     52  CH2 TRP 1  12      20.066  24.276  13.915  0.50 51.79           C  
+ATOM     53  N   LEU 1  13      26.545  28.884  14.025  0.50 41.94           N  
+ATOM     54  CA  LEU 1  13      27.648  29.749  14.435  0.50 40.50           C  
+ATOM     55  C   LEU 1  13      27.121  30.995  15.142  0.50 39.76           C  
+ATOM     56  O   LEU 1  13      27.586  31.333  16.237  0.50 39.35           O  
+ATOM     57  CB  LEU 1  13      28.486  30.172  13.224  0.50 40.05           C  
+ATOM     58  CG  LEU 1  13      29.136  29.059  12.397  0.50 40.90           C  
+ATOM     59  CD1 LEU 1  13      30.002  29.681  11.311  0.50 39.85           C  
+ATOM     60  CD2 LEU 1  13      29.965  28.155  13.300  0.50 39.07           C  
+ATOM     61  N   ALA 1  14      26.155  31.675  14.518  0.50 38.75           N  
+ATOM     62  CA  ALA 1  14      25.559  32.886  15.104  0.50 37.77           C  
+ATOM     63  C   ALA 1  14      24.927  32.520  16.437  0.50 36.31           C  
+ATOM     64  O   ALA 1  14      25.012  33.272  17.403  0.50 37.47           O  
+ATOM     65  CB  ALA 1  14      24.501  33.481  14.165  0.50 38.36           C  
+ATOM     66  N   LEU 1  15      24.304  31.350  16.484  0.50 34.68           N  
+ATOM     67  CA  LEU 1  15      23.680  30.874  17.709  0.50 34.91           C  
+ATOM     68  C   LEU 1  15      24.766  30.671  18.767  0.50 34.18           C  
+ATOM     69  O   LEU 1  15      24.635  31.122  19.904  0.50 34.70           O  
+ATOM     70  CB  LEU 1  15      22.960  29.551  17.446  0.50 35.01           C  
+ATOM     71  CG  LEU 1  15      21.499  29.439  17.880  0.50 37.09           C  
+ATOM     72  CD1 LEU 1  15      20.672  30.459  17.122  0.50 36.90           C  
+ATOM     73  CD2 LEU 1  15      20.981  28.024  17.613  0.50 36.71           C  
+ATOM     74  N   GLY 1  16      25.842  29.987  18.380  0.50 33.30           N  
+ATOM     75  CA  GLY 1  16      26.935  29.742  19.306  0.50 32.56           C  
+ATOM     76  C   GLY 1  16      27.535  31.058  19.755  0.50 31.59           C  
+ATOM     77  O   GLY 1  16      27.739  31.304  20.942  0.50 30.88           O  
+ATOM     78  N   THR 1  17      27.816  31.922  18.795  0.50 31.19           N  
+ATOM     79  CA  THR 1  17      28.367  33.218  19.122  0.50 32.32           C  
+ATOM     80  C   THR 1  17      27.456  33.918  20.125  0.50 32.45           C  
+ATOM     81  O   THR 1  17      27.884  34.286  21.224  0.50 33.15           O  
+ATOM     82  CB  THR 1  17      28.502  34.075  17.863  0.50 32.18           C  
+ATOM     83  OG1 THR 1  17      29.445  33.455  16.977  0.50 33.23           O  
+ATOM     84  CG2 THR 1  17      28.993  35.464  18.210  0.50 31.99           C  
+ATOM     85  N   ALA 1  18      26.191  34.079  19.754  0.50 32.71           N  
+ATOM     86  CA  ALA 1  18      25.219  34.750  20.614  0.50 30.96           C  
+ATOM     87  C   ALA 1  18      25.135  34.134  22.000  0.50 29.70           C  
+ATOM     88  O   ALA 1  18      25.110  34.848  23.003  0.50 31.08           O  
+ATOM     89  CB  ALA 1  18      23.831  34.733  19.953  0.50 30.48           C  
+ATOM     90  N   LEU 1  19      25.096  32.810  22.068  0.50 28.91           N  
+ATOM     91  CA  LEU 1  19      24.983  32.152  23.364  0.50 28.81           C  
+ATOM     92  C   LEU 1  19      26.228  32.349  24.226  0.50 28.90           C  
+ATOM     93  O   LEU 1  19      26.124  32.582  25.436  0.50 29.35           O  
+ATOM     94  CB  LEU 1  19      24.666  30.666  23.165  0.50 28.50           C  
+ATOM     95  CG  LEU 1  19      23.313  30.437  22.457  0.50 29.74           C  
+ATOM     96  CD1 LEU 1  19      23.127  28.966  22.080  0.50 29.68           C  
+ATOM     97  CD2 LEU 1  19      22.177  30.889  23.378  0.50 30.75           C  
+ATOM     98  N   MET 1  20      27.407  32.272  23.613  0.50 27.04           N  
+ATOM     99  CA  MET 1  20      28.632  32.465  24.376  0.50 26.52           C  
+ATOM    100  C   MET 1  20      28.655  33.911  24.863  0.50 24.55           C  
+ATOM    101  O   MET 1  20      28.974  34.176  26.011  0.50 24.87           O  
+ATOM    102  CB  MET 1  20      29.876  32.174  23.506  0.50 25.71           C  
+ATOM    103  CG  MET 1  20      29.999  30.726  22.969  0.50 22.98           C  
+ATOM    104  SD  MET 1  20      30.260  29.497  24.267  0.50 25.53           S  
+ATOM    105  CE  MET 1  20      30.657  28.020  23.310  0.50 23.27           C  
+ATOM    106  N   GLY 1  21      28.298  34.846  23.989  0.50 26.51           N  
+ATOM    107  CA  GLY 1  21      28.302  36.248  24.376  0.50 26.63           C  
+ATOM    108  C   GLY 1  21      27.395  36.531  25.561  0.50 28.75           C  
+ATOM    109  O   GLY 1  21      27.819  37.144  26.539  0.50 30.46           O  
+ATOM    110  N   LEU 1  22      26.145  36.086  25.481  0.50 28.83           N  
+ATOM    111  CA  LEU 1  22      25.194  36.304  26.565  0.50 29.65           C  
+ATOM    112  C   LEU 1  22      25.674  35.630  27.841  0.50 28.90           C  
+ATOM    113  O   LEU 1  22      25.506  36.155  28.951  0.50 29.32           O  
+ATOM    114  CB  LEU 1  22      23.819  35.747  26.177  0.50 31.27           C  
+ATOM    115  CG  LEU 1  22      23.099  36.502  25.049  0.50 34.75           C  
+ATOM    116  CD1 LEU 1  22      21.893  35.696  24.577  0.50 36.07           C  
+ATOM    117  CD2 LEU 1  22      22.666  37.882  25.551  0.50 34.03           C  
+ATOM    118  N   GLY 1  23      26.268  34.450  27.678  0.50 27.47           N  
+ATOM    119  CA  GLY 1  23      26.763  33.718  28.828  0.50 24.60           C  
+ATOM    120  C   GLY 1  23      27.808  34.514  29.579  0.50 22.84           C  
+ATOM    121  O   GLY 1  23      27.795  34.554  30.808  0.50 22.58           O  
+ATOM    122  N   THR 1  24      28.715  35.166  28.859  0.50 23.40           N  
+ATOM    123  CA  THR 1  24      29.736  35.946  29.553  0.50 26.80           C  
+ATOM    124  C   THR 1  24      29.086  37.115  30.276  0.50 26.86           C  
+ATOM    125  O   THR 1  24      29.323  37.323  31.464  0.50 28.06           O  
+ATOM    126  CB  THR 1  24      30.825  36.482  28.591  0.50 26.37           C  
+ATOM    127  OG1 THR 1  24      30.315  37.622  27.885  0.50 32.38           O  
+ATOM    128  CG2 THR 1  24      31.255  35.383  27.614  0.50 19.14           C  
+ATOM    129  N   LEU 1  25      28.261  37.873  29.564  0.50 29.40           N  
+ATOM    130  CA  LEU 1  25      27.574  39.013  30.182  0.50 31.37           C  
+ATOM    131  C   LEU 1  25      26.901  38.563  31.472  0.50 29.70           C  
+ATOM    132  O   LEU 1  25      27.091  39.162  32.528  0.50 29.60           O  
+ATOM    133  CB  LEU 1  25      26.509  39.591  29.239  0.50 32.94           C  
+ATOM    134  CG  LEU 1  25      26.984  40.364  28.003  0.50 37.34           C  
+ATOM    135  CD1 LEU 1  25      25.785  41.009  27.310  0.50 38.43           C  
+ATOM    136  CD2 LEU 1  25      27.977  41.444  28.417  0.50 38.65           C  
+ATOM    137  N   TYR 1  26      26.112  37.501  31.382  0.50 30.47           N  
+ATOM    138  CA  TYR 1  26      25.430  36.992  32.559  0.50 31.18           C  
+ATOM    139  C   TYR 1  26      26.442  36.724  33.685  0.50 30.89           C  
+ATOM    140  O   TYR 1  26      26.343  37.313  34.767  0.50 31.41           O  
+ATOM    141  CB  TYR 1  26      24.660  35.721  32.204  0.50 31.05           C  
+ATOM    142  CG  TYR 1  26      23.917  35.105  33.367  0.50 35.87           C  
+ATOM    143  CD1 TYR 1  26      22.800  35.736  33.927  0.50 36.06           C  
+ATOM    144  CD2 TYR 1  26      24.339  33.890  33.920  0.50 35.61           C  
+ATOM    145  CE1 TYR 1  26      22.123  35.172  35.018  0.50 36.82           C  
+ATOM    146  CE2 TYR 1  26      23.675  33.317  35.002  0.50 36.50           C  
+ATOM    147  CZ  TYR 1  26      22.567  33.961  35.547  0.50 38.17           C  
+ATOM    148  OH  TYR 1  26      21.917  33.385  36.623  0.50 39.25           O  
+ATOM    149  N   PHE 1  27      27.424  35.858  33.440  0.50 29.46           N  
+ATOM    150  CA  PHE 1  27      28.419  35.558  34.476  0.50 30.00           C  
+ATOM    151  C   PHE 1  27      29.112  36.832  34.930  0.50 28.76           C  
+ATOM    152  O   PHE 1  27      29.345  37.051  36.121  0.50 29.35           O  
+ATOM    153  CB  PHE 1  27      29.483  34.560  33.969  0.50 28.32           C  
+ATOM    154  CG  PHE 1  27      28.930  33.206  33.610  0.50 28.77           C  
+ATOM    155  CD1 PHE 1  27      27.754  32.741  34.193  0.50 31.12           C  
+ATOM    156  CD2 PHE 1  27      29.582  32.397  32.695  0.50 28.26           C  
+ATOM    157  CE1 PHE 1  27      27.235  31.489  33.864  0.50 31.34           C  
+ATOM    158  CE2 PHE 1  27      29.073  31.149  32.361  0.50 30.53           C  
+ATOM    159  CZ  PHE 1  27      27.899  30.693  32.944  0.50 30.21           C  
+ATOM    160  N   LEU 1  28      29.436  37.675  33.965  0.50 28.94           N  
+ATOM    161  CA  LEU 1  28      30.114  38.922  34.247  0.50 32.73           C  
+ATOM    162  C   LEU 1  28      29.308  39.764  35.244  0.50 33.49           C  
+ATOM    163  O   LEU 1  28      29.799  40.129  36.317  0.50 35.06           O  
+ATOM    164  CB  LEU 1  28      30.324  39.675  32.931  0.50 34.69           C  
+ATOM    165  CG  LEU 1  28      31.434  40.718  32.837  0.50 38.20           C  
+ATOM    166  CD1 LEU 1  28      31.055  41.910  33.687  0.50 41.00           C  
+ATOM    167  CD2 LEU 1  28      32.763  40.129  33.306  0.50 39.24           C  
+ATOM    168  N   VAL 1  29      28.067  40.067  34.896  0.50 32.46           N  
+ATOM    169  CA  VAL 1  29      27.226  40.869  35.770  0.50 33.51           C  
+ATOM    170  C   VAL 1  29      27.002  40.160  37.099  0.50 33.88           C  
+ATOM    171  O   VAL 1  29      27.006  40.782  38.166  0.50 34.39           O  
+ATOM    172  CB  VAL 1  29      25.867  41.154  35.088  0.50 34.19           C  
+ATOM    173  CG1 VAL 1  29      24.871  41.719  36.087  0.50 35.36           C  
+ATOM    174  CG2 VAL 1  29      26.075  42.117  33.937  0.50 33.05           C  
+ATOM    175  N   LYS 1  30      26.817  38.849  37.028  0.50 34.89           N  
+ATOM    176  CA  LYS 1  30      26.580  38.038  38.216  0.50 35.53           C  
+ATOM    177  C   LYS 1  30      27.729  38.102  39.232  0.50 36.09           C  
+ATOM    178  O   LYS 1  30      27.496  38.080  40.437  0.50 35.55           O  
+ATOM    179  CB  LYS 1  30      26.329  36.599  37.772  0.50 36.39           C  
+ATOM    180  CG  LYS 1  30      25.918  35.653  38.863  0.50 38.12           C  
+ATOM    181  CD  LYS 1  30      25.586  34.296  38.271  0.50 38.44           C  
+ATOM    182  CE  LYS 1  30      25.695  33.214  39.320  0.50 39.70           C  
+ATOM    183  NZ  LYS 1  30      24.820  33.497  40.485  0.50 40.72           N  
+ATOM    184  N   GLY 1  31      28.964  38.203  38.743  0.50 36.97           N  
+ATOM    185  CA  GLY 1  31      30.106  38.252  39.636  0.50 39.80           C  
+ATOM    186  C   GLY 1  31      30.415  39.594  40.283  0.50 41.08           C  
+ATOM    187  O   GLY 1  31      31.416  39.727  40.987  0.50 39.23           O  
+ATOM    188  N   MET 1  32      29.576  40.596  40.047  0.50 44.29           N  
+ATOM    189  CA  MET 1  32      29.800  41.912  40.641  0.50 46.39           C  
+ATOM    190  C   MET 1  32      29.553  41.929  42.142  0.50 46.49           C  
+ATOM    191  O   MET 1  32      30.387  42.419  42.906  0.50 48.47           O  
+ATOM    192  CB  MET 1  32      28.907  42.961  39.989  0.50 48.73           C  
+ATOM    193  CG  MET 1  32      29.479  43.572  38.741  0.50 51.03           C  
+ATOM    194  SD  MET 1  32      28.459  44.954  38.232  0.50 55.38           S  
+ATOM    195  CE  MET 1  32      27.049  44.061  37.532  0.50 54.74           C  
+ATOM    196  N   GLY 1  33      28.409  41.399  42.562  0.50 46.73           N  
+ATOM    197  CA  GLY 1  33      28.086  41.382  43.978  0.50 49.16           C  
+ATOM    198  C   GLY 1  33      28.804  40.315  44.786  0.50 50.68           C  
+ATOM    199  O   GLY 1  33      28.165  39.613  45.575  0.50 51.11           O  
+ATOM    200  N   VAL 1  34      30.123  40.195  44.612  0.50 51.70           N  
+ATOM    201  CA  VAL 1  34      30.897  39.183  45.336  0.50 51.89           C  
+ATOM    202  C   VAL 1  34      32.276  39.646  45.802  0.50 52.26           C  
+ATOM    203  O   VAL 1  34      33.091  40.112  45.008  0.50 52.51           O  
+ATOM    204  CB  VAL 1  34      31.098  37.925  44.480  0.50 51.67           C  
+ATOM    205  CG1 VAL 1  34      31.711  36.823  45.327  0.50 52.70           C  
+ATOM    206  CG2 VAL 1  34      29.774  37.486  43.886  0.50 51.41           C  
+ATOM    207  N   SER 1  35      32.542  39.481  47.093  0.50 52.58           N  
+ATOM    208  CA  SER 1  35      33.821  39.892  47.662  0.50 52.90           C  
+ATOM    209  C   SER 1  35      34.699  38.743  48.162  0.50 51.67           C  
+ATOM    210  O   SER 1  35      35.859  38.950  48.518  0.50 52.60           O  
+ATOM    211  CB  SER 1  35      33.573  40.888  48.797  0.50 53.50           C  
+ATOM    212  OG  SER 1  35      32.465  40.485  49.584  0.50 54.93           O  
+ATOM    213  N   ASP 1  36      34.157  37.533  48.197  0.50 50.43           N  
+ATOM    214  CA  ASP 1  36      34.944  36.392  48.656  0.50 48.73           C  
+ATOM    215  C   ASP 1  36      36.059  36.101  47.652  0.50 47.36           C  
+ATOM    216  O   ASP 1  36      35.797  35.819  46.486  0.50 46.94           O  
+ATOM    217  CB  ASP 1  36      34.053  35.159  48.802  0.50 49.85           C  
+ATOM    218  CG  ASP 1  36      34.810  33.956  49.319  0.50 50.77           C  
+ATOM    219  OD1 ASP 1  36      35.003  33.848  50.553  0.50 50.33           O  
+ATOM    220  OD2 ASP 1  36      35.227  33.124  48.483  0.50 49.94           O  
+ATOM    221  N   PRO 1  37      37.324  36.177  48.089  0.50 46.82           N  
+ATOM    222  CA  PRO 1  37      38.436  35.909  47.171  0.50 45.36           C  
+ATOM    223  C   PRO 1  37      38.413  34.536  46.485  0.50 44.97           C  
+ATOM    224  O   PRO 1  37      38.924  34.379  45.371  0.50 46.04           O  
+ATOM    225  CB  PRO 1  37      39.678  36.121  48.050  0.50 45.39           C  
+ATOM    226  CG  PRO 1  37      39.168  35.971  49.470  0.50 45.12           C  
+ATOM    227  CD  PRO 1  37      37.820  36.629  49.403  0.50 46.29           C  
+ATOM    228  N   ASP 1  38      37.822  33.547  47.146  0.50 43.05           N  
+ATOM    229  CA  ASP 1  38      37.733  32.201  46.590  0.50 40.58           C  
+ATOM    230  C   ASP 1  38      36.686  32.204  45.475  0.50 38.44           C  
+ATOM    231  O   ASP 1  38      36.862  31.584  44.424  0.50 36.08           O  
+ATOM    232  CB  ASP 1  38      37.339  31.218  47.699  0.50 43.00           C  
+ATOM    233  CG  ASP 1  38      37.210  29.787  47.206  0.50 45.84           C  
+ATOM    234  OD1 ASP 1  38      38.173  29.270  46.602  0.50 46.41           O  
+ATOM    235  OD2 ASP 1  38      36.145  29.170  47.438  0.50 48.95           O  
+ATOM    236  N   ALA 1  39      35.599  32.931  45.708  0.50 35.31           N  
+ATOM    237  CA  ALA 1  39      34.520  33.021  44.739  0.50 32.96           C  
+ATOM    238  C   ALA 1  39      34.972  33.763  43.482  0.50 32.48           C  
+ATOM    239  O   ALA 1  39      34.715  33.317  42.356  0.50 32.05           O  
+ATOM    240  CB  ALA 1  39      33.316  33.716  45.367  0.50 31.16           C  
+ATOM    241  N   LYS 1  40      35.658  34.885  43.679  0.50 31.84           N  
+ATOM    242  CA  LYS 1  40      36.149  35.693  42.566  0.50 31.51           C  
+ATOM    243  C   LYS 1  40      37.014  34.868  41.630  0.50 30.16           C  
+ATOM    244  O   LYS 1  40      36.938  35.005  40.402  0.50 28.27           O  
+ATOM    245  CB  LYS 1  40      36.934  36.896  43.096  0.50 34.33           C  
+ATOM    246  CG  LYS 1  40      36.075  37.880  43.888  0.50 38.35           C  
+ATOM    247  CD  LYS 1  40      36.765  39.234  44.031  0.50 41.67           C  
+ATOM    248  CE  LYS 1  40      37.970  39.146  44.940  0.50 43.28           C  
+ATOM    249  NZ  LYS 1  40      37.556  38.714  46.304  0.50 45.65           N  
+ATOM    250  N   LYS 1  41      37.830  33.998  42.216  0.50 29.74           N  
+ATOM    251  CA  LYS 1  41      38.701  33.128  41.435  0.50 28.15           C  
+ATOM    252  C   LYS 1  41      37.824  32.269  40.514  0.50 24.77           C  
+ATOM    253  O   LYS 1  41      38.081  32.171  39.315  0.50 24.72           O  
+ATOM    254  CB  LYS 1  41      39.536  32.259  42.389  0.50 31.45           C  
+ATOM    255  CG  LYS 1  41      40.550  31.353  41.722  0.50 34.60           C  
+ATOM    256  CD  LYS 1  41      41.344  30.532  42.745  0.50 39.87           C  
+ATOM    257  CE  LYS 1  41      42.390  31.357  43.481  0.50 43.15           C  
+ATOM    258  NZ  LYS 1  41      43.272  30.501  44.337  0.50 45.87           N  
+ATOM    259  N   PHE 1  42      36.776  31.662  41.062  0.50 22.86           N  
+ATOM    260  CA  PHE 1  42      35.877  30.843  40.240  0.50 22.43           C  
+ATOM    261  C   PHE 1  42      35.185  31.648  39.132  0.50 21.76           C  
+ATOM    262  O   PHE 1  42      34.995  31.143  38.024  0.50 20.05           O  
+ATOM    263  CB  PHE 1  42      34.812  30.159  41.112  0.50 22.03           C  
+ATOM    264  CG  PHE 1  42      35.316  28.950  41.848  0.50 24.31           C  
+ATOM    265  CD1 PHE 1  42      35.699  27.798  41.149  0.50 24.09           C  
+ATOM    266  CD2 PHE 1  42      35.409  28.958  43.240  0.50 25.12           C  
+ATOM    267  CE1 PHE 1  42      36.170  26.666  41.827  0.50 25.52           C  
+ATOM    268  CE2 PHE 1  42      35.878  27.838  43.940  0.50 27.41           C  
+ATOM    269  CZ  PHE 1  42      36.261  26.683  43.232  0.50 27.02           C  
+ATOM    270  N   TYR 1  43      34.801  32.891  39.428  0.50 20.79           N  
+ATOM    271  CA  TYR 1  43      34.143  33.741  38.427  0.50 20.66           C  
+ATOM    272  C   TYR 1  43      35.098  34.116  37.315  0.50 19.93           C  
+ATOM    273  O   TYR 1  43      34.733  34.120  36.139  0.50 19.63           O  
+ATOM    274  CB  TYR 1  43      33.595  35.036  39.053  0.50 20.65           C  
+ATOM    275  CG  TYR 1  43      32.180  34.922  39.590  0.50 19.39           C  
+ATOM    276  CD1 TYR 1  43      31.932  34.784  40.957  0.50 20.64           C  
+ATOM    277  CD2 TYR 1  43      31.091  34.895  38.719  0.50 22.28           C  
+ATOM    278  CE1 TYR 1  43      30.626  34.619  41.445  0.50 22.32           C  
+ATOM    279  CE2 TYR 1  43      29.780  34.727  39.192  0.50 23.44           C  
+ATOM    280  CZ  TYR 1  43      29.556  34.584  40.552  0.50 24.19           C  
+ATOM    281  OH  TYR 1  43      28.268  34.368  41.004  0.50 27.53           O  
+ATOM    282  N   ALA 1  44      36.323  34.457  37.692  0.50 19.47           N  
+ATOM    283  CA  ALA 1  44      37.320  34.830  36.706  0.50 20.43           C  
+ATOM    284  C   ALA 1  44      37.528  33.677  35.723  0.50 19.54           C  
+ATOM    285  O   ALA 1  44      37.389  33.853  34.514  0.50 21.43           O  
+ATOM    286  CB  ALA 1  44      38.644  35.196  37.408  0.50 19.02           C  
+ATOM    287  N   ILE 1  45      37.841  32.495  36.246  0.50 20.61           N  
+ATOM    288  CA  ILE 1  45      38.075  31.324  35.403  0.50 20.04           C  
+ATOM    289  C   ILE 1  45      36.874  30.984  34.548  0.50 21.52           C  
+ATOM    290  O   ILE 1  45      36.984  30.836  33.326  0.50 21.24           O  
+ATOM    291  CB  ILE 1  45      38.396  30.073  36.243  0.50 21.56           C  
+ATOM    292  CG1 ILE 1  45      39.731  30.253  36.978  0.50 21.41           C  
+ATOM    293  CG2 ILE 1  45      38.452  28.836  35.335  0.50 18.45           C  
+ATOM    294  CD1 ILE 1  45      39.886  29.305  38.165  0.50 22.59           C  
+ATOM    295  N   THR 1  46      35.721  30.863  35.197  0.50 22.30           N  
+ATOM    296  CA  THR 1  46      34.485  30.496  34.513  0.50 21.53           C  
+ATOM    297  C   THR 1  46      34.007  31.537  33.507  0.50 24.19           C  
+ATOM    298  O   THR 1  46      33.430  31.186  32.475  0.50 24.28           O  
+ATOM    299  CB  THR 1  46      33.366  30.239  35.543  0.50 21.51           C  
+ATOM    300  OG1 THR 1  46      33.858  29.359  36.564  0.50 20.33           O  
+ATOM    301  CG2 THR 1  46      32.152  29.604  34.879  0.50 18.43           C  
+ATOM    302  N   THR 1  47      34.239  32.819  33.792  0.50 23.66           N  
+ATOM    303  CA  THR 1  47      33.798  33.878  32.879  0.50 22.23           C  
+ATOM    304  C   THR 1  47      34.692  33.974  31.642  0.50 23.18           C  
+ATOM    305  O   THR 1  47      34.231  34.279  30.533  0.50 21.45           O  
+ATOM    306  CB  THR 1  47      33.778  35.245  33.593  0.50 23.87           C  
+ATOM    307  OG1 THR 1  47      32.932  35.161  34.747  0.50 23.76           O  
+ATOM    308  CG2 THR 1  47      33.255  36.335  32.672  0.50 23.14           C  
+ATOM    309  N   LEU 1  48      35.979  33.719  31.825  0.50 24.08           N  
+ATOM    310  CA  LEU 1  48      36.907  33.783  30.697  0.50 23.98           C  
+ATOM    311  C   LEU 1  48      36.588  32.723  29.654  0.50 23.47           C  
+ATOM    312  O   LEU 1  48      36.935  32.875  28.483  0.50 23.41           O  
+ATOM    313  CB  LEU 1  48      38.345  33.600  31.189  0.50 24.35           C  
+ATOM    314  CG  LEU 1  48      38.942  34.881  31.791  0.50 26.85           C  
+ATOM    315  CD1 LEU 1  48      40.154  34.544  32.646  0.50 26.49           C  
+ATOM    316  CD2 LEU 1  48      39.315  35.852  30.654  0.50 24.94           C  
+ATOM    317  N   VAL 1  49      35.894  31.667  30.067  0.50 23.40           N  
+ATOM    318  CA  VAL 1  49      35.585  30.588  29.149  0.50 26.15           C  
+ATOM    319  C   VAL 1  49      34.664  30.958  27.963  0.50 29.23           C  
+ATOM    320  O   VAL 1  49      35.029  30.759  26.809  0.50 25.71           O  
+ATOM    321  CB  VAL 1  49      35.020  29.359  29.946  0.50 27.90           C  
+ATOM    322  CG1 VAL 1  49      34.482  28.302  28.997  0.50 24.43           C  
+ATOM    323  CG2 VAL 1  49      36.149  28.751  30.797  0.50 25.87           C  
+ATOM    324  N   PRO 1  50      33.472  31.545  28.234  0.50 34.17           N  
+ATOM    325  CA  PRO 1  50      32.534  31.914  27.127  0.50 34.67           C  
+ATOM    326  C   PRO 1  50      33.091  33.121  26.321  0.50 32.05           C  
+ATOM    327  O   PRO 1  50      32.851  33.231  25.060  0.50 33.03           O  
+ATOM    328  CB  PRO 1  50      31.230  32.242  27.864  0.50 33.61           C  
+ATOM    329  CG  PRO 1  50      31.705  32.826  29.195  0.50 35.86           C  
+ATOM    330  CD  PRO 1  50      33.020  32.082  29.548  0.50 37.42           C  
+ATOM    331  N   ALA 1  51      33.850  33.983  27.015  0.50 24.46           N  
+ATOM    332  CA  ALA 1  51      34.455  35.157  26.377  0.50 23.45           C  
+ATOM    333  C   ALA 1  51      35.301  34.622  25.236  0.50 22.71           C  
+ATOM    334  O   ALA 1  51      35.055  34.922  24.069  0.50 23.51           O  
+ATOM    335  CB  ALA 1  51      35.350  35.952  27.388  0.50 18.52           C  
+ATOM    336  N   ILE 1  52      36.301  33.821  25.584  0.50 22.02           N  
+ATOM    337  CA  ILE 1  52      37.163  33.209  24.579  0.50 21.54           C  
+ATOM    338  C   ILE 1  52      36.312  32.479  23.528  0.50 22.61           C  
+ATOM    339  O   ILE 1  52      36.441  32.736  22.331  0.50 22.76           O  
+ATOM    340  CB  ILE 1  52      38.157  32.230  25.250  0.50 22.07           C  
+ATOM    341  CG1 ILE 1  52      39.114  33.040  26.139  0.50 24.12           C  
+ATOM    342  CG2 ILE 1  52      38.942  31.448  24.193  0.50 20.39           C  
+ATOM    343  CD1 ILE 1  52      40.002  32.197  27.059  0.50 28.58           C  
+ATOM    344  N   ALA 1  53      35.423  31.591  23.967  0.50 22.97           N  
+ATOM    345  CA  ALA 1  53      34.577  30.868  23.020  0.50 22.89           C  
+ATOM    346  C   ALA 1  53      33.830  31.871  22.146  0.50 24.09           C  
+ATOM    347  O   ALA 1  53      33.642  31.647  20.947  0.50 23.42           O  
+ATOM    348  CB  ALA 1  53      33.581  29.979  23.763  0.50 20.98           C  
+ATOM    349  N   PHE 1  54      33.402  32.978  22.754  0.50 24.33           N  
+ATOM    350  CA  PHE 1  54      32.696  34.029  22.032  0.50 23.02           C  
+ATOM    351  C   PHE 1  54      33.533  34.548  20.874  0.50 24.19           C  
+ATOM    352  O   PHE 1  54      33.045  34.666  19.748  0.50 24.67           O  
+ATOM    353  CB  PHE 1  54      32.375  35.200  22.964  0.50 25.79           C  
+ATOM    354  CG  PHE 1  54      31.929  36.450  22.243  0.50 26.41           C  
+ATOM    355  CD1 PHE 1  54      30.721  36.479  21.547  0.50 26.76           C  
+ATOM    356  CD2 PHE 1  54      32.723  37.591  22.246  0.50 25.14           C  
+ATOM    357  CE1 PHE 1  54      30.309  37.640  20.859  0.50 26.70           C  
+ATOM    358  CE2 PHE 1  54      32.324  38.752  21.564  0.50 27.33           C  
+ATOM    359  CZ  PHE 1  54      31.113  38.775  20.870  0.50 24.97           C  
+ATOM    360  N   THR 1  55      34.795  34.880  21.143  0.50 24.84           N  
+ATOM    361  CA  THR 1  55      35.638  35.399  20.075  0.50 25.00           C  
+ATOM    362  C   THR 1  55      35.850  34.325  19.018  0.50 25.86           C  
+ATOM    363  O   THR 1  55      35.825  34.616  17.816  0.50 25.89           O  
+ATOM    364  CB  THR 1  55      37.016  35.888  20.604  0.50 25.26           C  
+ATOM    365  OG1 THR 1  55      37.713  34.793  21.208  0.50 27.56           O  
+ATOM    366  CG2 THR 1  55      36.835  37.001  21.635  0.50 24.93           C  
+ATOM    367  N   MET 1  56      36.034  33.078  19.457  0.50 25.63           N  
+ATOM    368  CA  MET 1  56      36.246  31.984  18.510  0.50 26.91           C  
+ATOM    369  C   MET 1  56      35.005  31.760  17.655  0.50 28.44           C  
+ATOM    370  O   MET 1  56      35.102  31.618  16.429  0.50 27.77           O  
+ATOM    371  CB  MET 1  56      36.609  30.683  19.239  0.50 27.98           C  
+ATOM    372  CG  MET 1  56      37.907  30.747  20.041  0.50 30.62           C  
+ATOM    373  SD  MET 1  56      39.373  31.124  19.020  0.50 34.65           S  
+ATOM    374  CE  MET 1  56      40.577  31.523  20.332  0.50 35.93           C  
+ATOM    375  N   TYR 1  57      33.835  31.714  18.289  0.50 28.13           N  
+ATOM    376  CA  TYR 1  57      32.615  31.517  17.515  0.50 29.62           C  
+ATOM    377  C   TYR 1  57      32.364  32.714  16.604  0.50 29.86           C  
+ATOM    378  O   TYR 1  57      31.886  32.556  15.480  0.50 28.06           O  
+ATOM    379  CB  TYR 1  57      31.402  31.265  18.424  0.50 29.15           C  
+ATOM    380  CG  TYR 1  57      31.135  29.794  18.614  0.50 30.79           C  
+ATOM    381  CD1 TYR 1  57      31.897  29.032  19.509  0.50 30.65           C  
+ATOM    382  CD2 TYR 1  57      30.210  29.131  17.808  0.50 30.54           C  
+ATOM    383  CE1 TYR 1  57      31.754  27.644  19.583  0.50 31.33           C  
+ATOM    384  CE2 TYR 1  57      30.059  27.746  17.872  0.50 31.34           C  
+ATOM    385  CZ  TYR 1  57      30.836  27.009  18.757  0.50 32.61           C  
+ATOM    386  OH  TYR 1  57      30.713  25.632  18.798  0.50 35.18           O  
+ATOM    387  N   LEU 1  58      32.694  33.913  17.073  0.50 31.09           N  
+ATOM    388  CA  LEU 1  58      32.499  35.085  16.227  0.50 32.86           C  
+ATOM    389  C   LEU 1  58      33.442  35.044  15.026  0.50 34.63           C  
+ATOM    390  O   LEU 1  58      33.053  35.429  13.921  0.50 34.15           O  
+ATOM    391  CB  LEU 1  58      32.716  36.384  17.015  0.50 31.46           C  
+ATOM    392  CG  LEU 1  58      32.673  37.682  16.192  0.50 32.46           C  
+ATOM    393  CD1 LEU 1  58      31.371  37.783  15.415  0.50 31.67           C  
+ATOM    394  CD2 LEU 1  58      32.817  38.877  17.122  0.50 32.75           C  
+ATOM    395  N   SER 1  59      34.676  34.574  15.224  0.50 36.51           N  
+ATOM    396  CA  SER 1  59      35.611  34.520  14.098  0.50 37.27           C  
+ATOM    397  C   SER 1  59      35.122  33.497  13.088  0.50 37.56           C  
+ATOM    398  O   SER 1  59      35.230  33.709  11.883  0.50 36.61           O  
+ATOM    399  CB  SER 1  59      37.040  34.171  14.548  0.50 37.48           C  
+ATOM    400  OG  SER 1  59      37.168  32.810  14.931  0.50 40.57           O  
+ATOM    401  N   MET 1  60      34.580  32.381  13.563  0.50 39.25           N  
+ATOM    402  CA  MET 1  60      34.080  31.386  12.621  0.50 41.42           C  
+ATOM    403  C   MET 1  60      32.855  31.957  11.900  0.50 42.17           C  
+ATOM    404  O   MET 1  60      32.708  31.788  10.692  0.50 43.21           O  
+ATOM    405  CB  MET 1  60      33.740  30.071  13.333  0.50 41.66           C  
+ATOM    406  CG  MET 1  60      34.956  29.348  13.903  0.50 43.18           C  
+ATOM    407  SD  MET 1  60      34.599  27.678  14.544  0.50 46.51           S  
+ATOM    408  CE  MET 1  60      33.588  28.062  16.005  0.50 42.54           C  
+ATOM    409  N   LEU 1  61      31.991  32.655  12.632  0.50 42.91           N  
+ATOM    410  CA  LEU 1  61      30.807  33.259  12.027  0.50 43.29           C  
+ATOM    411  C   LEU 1  61      31.199  34.294  10.968  0.50 44.79           C  
+ATOM    412  O   LEU 1  61      30.662  34.295   9.865  0.50 44.52           O  
+ATOM    413  CB  LEU 1  61      29.944  33.941  13.091  0.50 41.98           C  
+ATOM    414  CG  LEU 1  61      28.723  34.721  12.577  0.50 43.18           C  
+ATOM    415  CD1 LEU 1  61      27.724  33.765  11.929  0.50 42.50           C  
+ATOM    416  CD2 LEU 1  61      28.068  35.470  13.723  0.50 42.56           C  
+ATOM    417  N   LEU 1  62      32.129  35.183  11.302  0.50 46.59           N  
+ATOM    418  CA  LEU 1  62      32.544  36.205  10.350  0.50 49.01           C  
+ATOM    419  C   LEU 1  62      33.364  35.611   9.221  0.50 51.33           C  
+ATOM    420  O   LEU 1  62      33.564  36.248   8.189  0.50 51.50           O  
+ATOM    421  CB  LEU 1  62      33.348  37.301  11.049  0.50 47.63           C  
+ATOM    422  CG  LEU 1  62      32.589  38.094  12.114  0.50 48.31           C  
+ATOM    423  CD1 LEU 1  62      33.489  39.203  12.650  0.50 47.92           C  
+ATOM    424  CD2 LEU 1  62      31.311  38.681  11.519  0.50 47.37           C  
+ATOM    425  N   GLY 1  63      33.828  34.381   9.418  0.50 54.05           N  
+ATOM    426  CA  GLY 1  63      34.625  33.719   8.402  0.50 57.07           C  
+ATOM    427  C   GLY 1  63      33.811  33.019   7.327  0.50 59.38           C  
+ATOM    428  O   GLY 1  63      34.226  32.965   6.170  0.50 59.34           O  
+ATOM    429  N   TYR 1  64      32.648  32.487   7.700  0.50 61.50           N  
+ATOM    430  CA  TYR 1  64      31.789  31.777   6.752  0.50 63.77           C  
+ATOM    431  C   TYR 1  64      31.460  32.621   5.519  0.50 64.38           C  
+ATOM    432  O   TYR 1  64      30.749  33.625   5.606  0.50 64.38           O  
+ATOM    433  CB  TYR 1  64      30.493  31.328   7.448  0.50 65.36           C  
+ATOM    434  CG  TYR 1  64      29.640  30.375   6.626  0.50 67.18           C  
+ATOM    435  CD1 TYR 1  64      28.726  30.851   5.680  0.50 68.14           C  
+ATOM    436  CD2 TYR 1  64      29.757  28.994   6.786  0.50 67.04           C  
+ATOM    437  CE1 TYR 1  64      27.953  29.970   4.912  0.50 68.48           C  
+ATOM    438  CE2 TYR 1  64      28.993  28.108   6.023  0.50 68.22           C  
+ATOM    439  CZ  TYR 1  64      28.094  28.601   5.092  0.50 68.32           C  
+ATOM    440  OH  TYR 1  64      27.345  27.722   4.341  0.50 69.51           O  
+ATOM    441  N   GLY 1  65      31.986  32.200   4.371  0.50 64.92           N  
+ATOM    442  CA  GLY 1  65      31.750  32.917   3.130  0.50 65.01           C  
+ATOM    443  C   GLY 1  65      33.033  33.210   2.373  0.50 65.30           C  
+ATOM    444  O   GLY 1  65      34.131  32.921   2.851  0.50 65.39           O  
+ATOM    445  N   PRO 1  77      39.886  21.712   4.760  0.50 74.88           N  
+ATOM    446  CA  PRO 1  77      39.216  22.790   5.493  0.50 74.30           C  
+ATOM    447  C   PRO 1  77      39.757  22.953   6.913  0.50 73.87           C  
+ATOM    448  O   PRO 1  77      40.742  23.659   7.134  0.50 74.29           O  
+ATOM    449  CB  PRO 1  77      37.755  22.352   5.476  0.50 74.66           C  
+ATOM    450  CG  PRO 1  77      37.644  21.642   4.162  0.50 74.95           C  
+ATOM    451  CD  PRO 1  77      38.898  20.800   4.158  0.50 75.03           C  
+ATOM    452  N   ILE 1  78      39.099  22.298   7.867  0.50 72.63           N  
+ATOM    453  CA  ILE 1  78      39.498  22.345   9.271  0.50 71.38           C  
+ATOM    454  C   ILE 1  78      39.334  23.741   9.879  0.50 69.94           C  
+ATOM    455  O   ILE 1  78      39.960  24.704   9.427  0.50 70.07           O  
+ATOM    456  CB  ILE 1  78      40.972  21.904   9.446  0.50 71.47           C  
+ATOM    457  CG1 ILE 1  78      41.196  20.555   8.761  0.50 71.62           C  
+ATOM    458  CG2 ILE 1  78      41.315  21.800  10.927  0.50 71.06           C  
+ATOM    459  CD1 ILE 1  78      42.656  20.169   8.626  0.50 71.81           C  
+ATOM    460  N   TYR 1  79      38.487  23.839  10.904  0.50 67.32           N  
+ATOM    461  CA  TYR 1  79      38.247  25.106  11.592  0.50 64.16           C  
+ATOM    462  C   TYR 1  79      39.289  25.310  12.681  0.50 61.43           C  
+ATOM    463  O   TYR 1  79      39.207  24.716  13.757  0.50 61.58           O  
+ATOM    464  CB  TYR 1  79      36.855  25.123  12.228  0.50 65.71           C  
+ATOM    465  CG  TYR 1  79      35.724  25.420  11.271  0.50 66.87           C  
+ATOM    466  CD1 TYR 1  79      35.613  26.665  10.654  0.50 67.48           C  
+ATOM    467  CD2 TYR 1  79      34.747  24.464  11.004  0.50 67.24           C  
+ATOM    468  CE1 TYR 1  79      34.554  26.951   9.795  0.50 68.15           C  
+ATOM    469  CE2 TYR 1  79      33.685  24.738  10.147  0.50 68.33           C  
+ATOM    470  CZ  TYR 1  79      33.592  25.983   9.548  0.50 68.71           C  
+ATOM    471  OH  TYR 1  79      32.534  26.257   8.708  0.50 69.82           O  
+ATOM    472  N   TRP 1  80      40.268  26.158  12.399  0.50 57.95           N  
+ATOM    473  CA  TRP 1  80      41.323  26.432  13.355  0.50 53.75           C  
+ATOM    474  C   TRP 1  80      40.736  27.007  14.645  0.50 49.38           C  
+ATOM    475  O   TRP 1  80      41.163  26.653  15.737  0.50 50.14           O  
+ATOM    476  CB  TRP 1  80      42.344  27.406  12.748  0.50 55.74           C  
+ATOM    477  CG  TRP 1  80      42.709  27.067  11.329  0.50 58.51           C  
+ATOM    478  CD1 TRP 1  80      42.012  27.404  10.202  0.50 59.46           C  
+ATOM    479  CD2 TRP 1  80      43.799  26.245  10.892  0.50 59.87           C  
+ATOM    480  NE1 TRP 1  80      42.594  26.838   9.095  0.50 59.85           N  
+ATOM    481  CE2 TRP 1  80      43.692  26.120   9.488  0.50 60.41           C  
+ATOM    482  CE3 TRP 1  80      44.852  25.596  11.550  0.50 60.37           C  
+ATOM    483  CZ2 TRP 1  80      44.601  25.373   8.727  0.50 60.87           C  
+ATOM    484  CZ3 TRP 1  80      45.758  24.852  10.792  0.50 60.91           C  
+ATOM    485  CH2 TRP 1  80      45.623  24.748   9.396  0.50 60.44           C  
+ATOM    486  N   ALA 1  81      39.746  27.880  14.517  0.50 44.61           N  
+ATOM    487  CA  ALA 1  81      39.128  28.497  15.681  0.50 41.61           C  
+ATOM    488  C   ALA 1  81      38.492  27.465  16.606  0.50 38.89           C  
+ATOM    489  O   ALA 1  81      38.471  27.632  17.829  0.50 38.16           O  
+ATOM    490  CB  ALA 1  81      38.080  29.519  15.241  0.50 40.94           C  
+ATOM    491  N   ARG 1  82      37.970  26.396  16.026  0.50 36.66           N  
+ATOM    492  CA  ARG 1  82      37.343  25.365  16.828  0.50 36.51           C  
+ATOM    493  C   ARG 1  82      38.344  24.715  17.780  0.50 34.44           C  
+ATOM    494  O   ARG 1  82      38.074  24.575  18.973  0.50 34.38           O  
+ATOM    495  CB  ARG 1  82      36.714  24.310  15.918  0.50 37.58           C  
+ATOM    496  CG  ARG 1  82      36.028  23.179  16.653  0.50 39.28           C  
+ATOM    497  CD  ARG 1  82      35.526  22.131  15.665  0.50 41.22           C  
+ATOM    498  NE  ARG 1  82      34.456  22.632  14.801  0.50 40.79           N  
+ATOM    499  CZ  ARG 1  82      34.006  21.996  13.720  0.50 42.30           C  
+ATOM    500  NH1 ARG 1  82      33.028  22.527  12.997  0.50 41.77           N  
+ATOM    501  NH2 ARG 1  82      34.539  20.835  13.351  0.50 41.66           N  
+ATOM    502  N   TYR 1  83      39.502  24.325  17.263  0.50 34.27           N  
+ATOM    503  CA  TYR 1  83      40.512  23.674  18.093  0.50 33.38           C  
+ATOM    504  C   TYR 1  83      41.201  24.629  19.033  0.50 32.37           C  
+ATOM    505  O   TYR 1  83      41.545  24.257  20.171  0.50 32.74           O  
+ATOM    506  CB  TYR 1  83      41.554  22.978  17.221  0.50 35.60           C  
+ATOM    507  CG  TYR 1  83      41.006  21.747  16.544  0.50 40.04           C  
+ATOM    508  CD1 TYR 1  83      40.243  21.849  15.380  0.50 41.16           C  
+ATOM    509  CD2 TYR 1  83      41.219  20.478  17.088  0.50 40.67           C  
+ATOM    510  CE1 TYR 1  83      39.700  20.720  14.772  0.50 41.65           C  
+ATOM    511  CE2 TYR 1  83      40.678  19.339  16.491  0.50 42.73           C  
+ATOM    512  CZ  TYR 1  83      39.921  19.469  15.331  0.50 43.32           C  
+ATOM    513  OH  TYR 1  83      39.377  18.347  14.739  0.50 44.27           O  
+ATOM    514  N   ALA 1  84      41.412  25.853  18.558  0.50 28.54           N  
+ATOM    515  CA  ALA 1  84      42.047  26.883  19.372  0.50 28.57           C  
+ATOM    516  C   ALA 1  84      41.113  27.161  20.543  0.50 26.74           C  
+ATOM    517  O   ALA 1  84      41.550  27.299  21.684  0.50 26.77           O  
+ATOM    518  CB  ALA 1  84      42.259  28.157  18.542  0.50 28.33           C  
+ATOM    519  N   ASP 1  85      39.818  27.240  20.248  0.50 25.89           N  
+ATOM    520  CA  ASP 1  85      38.825  27.481  21.281  0.50 25.41           C  
+ATOM    521  C   ASP 1  85      38.980  26.389  22.325  0.50 24.60           C  
+ATOM    522  O   ASP 1  85      38.976  26.655  23.520  0.50 24.49           O  
+ATOM    523  CB  ASP 1  85      37.415  27.411  20.697  0.50 25.23           C  
+ATOM    524  CG  ASP 1  85      36.347  27.657  21.739  0.50 27.71           C  
+ATOM    525  OD1 ASP 1  85      35.190  27.242  21.529  0.50 31.01           O  
+ATOM    526  OD2 ASP 1  85      36.659  28.276  22.777  0.50 31.65           O  
+ATOM    527  N   TRP 1  86      39.118  25.151  21.865  0.50 25.32           N  
+ATOM    528  CA  TRP 1  86      39.260  24.026  22.780  0.50 27.12           C  
+ATOM    529  C   TRP 1  86      40.562  24.115  23.554  0.50 27.46           C  
+ATOM    530  O   TRP 1  86      40.585  23.951  24.777  0.50 28.33           O  
+ATOM    531  CB  TRP 1  86      39.208  22.698  22.010  0.50 27.95           C  
+ATOM    532  CG  TRP 1  86      37.878  22.415  21.339  0.50 28.52           C  
+ATOM    533  CD1 TRP 1  86      36.682  23.010  21.613  0.50 29.15           C  
+ATOM    534  CD2 TRP 1  86      37.613  21.430  20.331  0.50 29.94           C  
+ATOM    535  NE1 TRP 1  86      35.689  22.460  20.844  0.50 30.48           N  
+ATOM    536  CE2 TRP 1  86      36.231  21.486  20.046  0.50 31.74           C  
+ATOM    537  CE3 TRP 1  86      38.407  20.507  19.643  0.50 31.38           C  
+ATOM    538  CZ2 TRP 1  86      35.620  20.647  19.097  0.50 33.59           C  
+ATOM    539  CZ3 TRP 1  86      37.801  19.671  18.697  0.50 33.43           C  
+ATOM    540  CH2 TRP 1  86      36.420  19.750  18.435  0.50 32.31           C  
+ATOM    541  N   LEU 1  87      41.652  24.383  22.843  0.50 27.96           N  
+ATOM    542  CA  LEU 1  87      42.954  24.480  23.487  0.50 29.82           C  
+ATOM    543  C   LEU 1  87      43.010  25.498  24.630  0.50 29.89           C  
+ATOM    544  O   LEU 1  87      43.552  25.218  25.700  0.50 29.56           O  
+ATOM    545  CB  LEU 1  87      44.034  24.828  22.456  0.50 30.65           C  
+ATOM    546  CG  LEU 1  87      45.456  24.957  23.027  0.50 33.19           C  
+ATOM    547  CD1 LEU 1  87      45.900  23.628  23.625  0.50 30.95           C  
+ATOM    548  CD2 LEU 1  87      46.422  25.392  21.926  0.50 31.98           C  
+ATOM    549  N   PHE 1  88      42.444  26.677  24.414  0.50 30.37           N  
+ATOM    550  CA  PHE 1  88      42.497  27.708  25.441  0.50 30.90           C  
+ATOM    551  C   PHE 1  88      41.428  27.591  26.519  0.50 30.82           C  
+ATOM    552  O   PHE 1  88      41.547  28.167  27.600  0.50 32.45           O  
+ATOM    553  CB  PHE 1  88      42.402  29.088  24.789  0.50 33.64           C  
+ATOM    554  CG  PHE 1  88      43.578  29.436  23.918  0.50 35.09           C  
+ATOM    555  CD1 PHE 1  88      44.879  29.314  24.399  0.50 36.37           C  
+ATOM    556  CD2 PHE 1  88      43.381  29.917  22.626  0.50 36.94           C  
+ATOM    557  CE1 PHE 1  88      45.970  29.669  23.607  0.50 37.65           C  
+ATOM    558  CE2 PHE 1  88      44.463  30.276  21.820  0.50 38.14           C  
+ATOM    559  CZ  PHE 1  88      45.761  30.152  22.313  0.50 37.91           C  
+ATOM    560  N   THR 1  89      40.396  26.818  26.232  0.50 29.41           N  
+ATOM    561  CA  THR 1  89      39.277  26.670  27.145  0.50 30.73           C  
+ATOM    562  C   THR 1  89      39.256  25.458  28.078  0.50 28.87           C  
+ATOM    563  O   THR 1  89      38.876  25.574  29.244  0.50 28.34           O  
+ATOM    564  CB  THR 1  89      37.982  26.696  26.331  0.50 31.16           C  
+ATOM    565  OG1 THR 1  89      37.738  28.044  25.887  0.50 34.19           O  
+ATOM    566  CG2 THR 1  89      36.850  26.207  27.152  0.50 36.12           C  
+ATOM    567  N   THR 1  90      39.649  24.300  27.565  0.50 26.73           N  
+ATOM    568  CA  THR 1  90      39.646  23.091  28.374  0.50 25.46           C  
+ATOM    569  C   THR 1  90      40.533  23.169  29.610  0.50 22.81           C  
+ATOM    570  O   THR 1  90      40.210  22.585  30.639  0.50 24.46           O  
+ATOM    571  CB  THR 1  90      40.040  21.857  27.524  0.50 24.17           C  
+ATOM    572  OG1 THR 1  90      41.088  22.208  26.616  0.50 23.70           O  
+ATOM    573  CG2 THR 1  90      38.857  21.371  26.731  0.50 24.00           C  
+ATOM    574  N   PRO 1  91      41.662  23.895  29.537  0.50 23.75           N  
+ATOM    575  CA  PRO 1  91      42.512  23.965  30.737  0.50 22.72           C  
+ATOM    576  C   PRO 1  91      41.807  24.711  31.864  0.50 22.92           C  
+ATOM    577  O   PRO 1  91      41.971  24.376  33.038  0.50 24.99           O  
+ATOM    578  CB  PRO 1  91      43.755  24.711  30.246  0.50 21.03           C  
+ATOM    579  CG  PRO 1  91      43.793  24.393  28.776  0.50 21.64           C  
+ATOM    580  CD  PRO 1  91      42.338  24.509  28.381  0.50 21.14           C  
+ATOM    581  N   LEU 1  92      41.020  25.725  31.500  0.50 22.93           N  
+ATOM    582  CA  LEU 1  92      40.284  26.523  32.485  0.50 22.66           C  
+ATOM    583  C   LEU 1  92      39.180  25.709  33.128  0.50 21.59           C  
+ATOM    584  O   LEU 1  92      38.998  25.760  34.347  0.50 22.21           O  
+ATOM    585  CB  LEU 1  92      39.679  27.768  31.828  0.50 23.50           C  
+ATOM    586  CG  LEU 1  92      40.698  28.753  31.238  0.50 25.06           C  
+ATOM    587  CD1 LEU 1  92      39.975  29.942  30.606  0.50 24.79           C  
+ATOM    588  CD2 LEU 1  92      41.638  29.228  32.350  0.50 23.87           C  
+ATOM    589  N   LEU 1  93      38.428  24.960  32.326  0.50 22.32           N  
+ATOM    590  CA  LEU 1  93      37.371  24.138  32.914  0.50 23.65           C  
+ATOM    591  C   LEU 1  93      38.045  23.177  33.890  0.50 22.23           C  
+ATOM    592  O   LEU 1  93      37.571  22.961  34.998  0.50 21.34           O  
+ATOM    593  CB  LEU 1  93      36.624  23.341  31.844  0.50 22.14           C  
+ATOM    594  CG  LEU 1  93      35.359  23.856  31.132  0.50 25.55           C  
+ATOM    595  CD1 LEU 1  93      34.635  24.901  31.984  0.50 18.22           C  
+ATOM    596  CD2 LEU 1  93      35.719  24.385  29.762  0.50 23.94           C  
+ATOM    597  N   LEU 1  94      39.170  22.608  33.476  0.50 23.57           N  
+ATOM    598  CA  LEU 1  94      39.886  21.680  34.342  0.50 25.34           C  
+ATOM    599  C   LEU 1  94      40.319  22.393  35.619  0.50 25.03           C  
+ATOM    600  O   LEU 1  94      40.138  21.880  36.725  0.50 26.72           O  
+ATOM    601  CB  LEU 1  94      41.099  21.125  33.603  0.50 23.28           C  
+ATOM    602  CG  LEU 1  94      41.078  19.649  33.177  0.50 26.25           C  
+ATOM    603  CD1 LEU 1  94      39.675  19.160  32.860  0.50 22.00           C  
+ATOM    604  CD2 LEU 1  94      42.019  19.480  31.992  0.50 21.83           C  
+ATOM    605  N   LEU 1  95      40.893  23.580  35.462  0.50 24.91           N  
+ATOM    606  CA  LEU 1  95      41.339  24.366  36.608  0.50 27.44           C  
+ATOM    607  C   LEU 1  95      40.182  24.562  37.599  0.50 25.45           C  
+ATOM    608  O   LEU 1  95      40.354  24.375  38.809  0.50 26.33           O  
+ATOM    609  CB  LEU 1  95      41.878  25.720  36.131  0.50 28.80           C  
+ATOM    610  CG  LEU 1  95      42.926  26.392  37.018  0.50 32.00           C  
+ATOM    611  CD1 LEU 1  95      44.190  25.559  37.006  0.50 33.27           C  
+ATOM    612  CD2 LEU 1  95      43.211  27.804  36.523  0.50 31.74           C  
+ATOM    613  N   ASP 1  96      39.007  24.931  37.085  0.50 24.87           N  
+ATOM    614  CA  ASP 1  96      37.819  25.120  37.928  0.50 25.36           C  
+ATOM    615  C   ASP 1  96      37.552  23.866  38.750  0.50 25.52           C  
+ATOM    616  O   ASP 1  96      37.355  23.921  39.970  0.50 26.70           O  
+ATOM    617  CB  ASP 1  96      36.570  25.380  37.071  0.50 25.58           C  
+ATOM    618  CG  ASP 1  96      36.059  26.809  37.177  0.50 26.99           C  
+ATOM    619  OD1 ASP 1  96      36.500  27.559  38.077  0.50 25.29           O  
+ATOM    620  OD2 ASP 1  96      35.192  27.174  36.352  0.50 28.97           O  
+ATOM    621  N   LEU 1  97      37.513  22.729  38.069  0.50 24.81           N  
+ATOM    622  CA  LEU 1  97      37.250  21.467  38.754  0.50 26.59           C  
+ATOM    623  C   LEU 1  97      38.287  21.217  39.850  0.50 26.95           C  
+ATOM    624  O   LEU 1  97      37.942  20.807  40.959  0.50 28.26           O  
+ATOM    625  CB  LEU 1  97      37.243  20.314  37.733  0.50 24.45           C  
+ATOM    626  CG  LEU 1  97      35.898  19.706  37.302  0.50 28.73           C  
+ATOM    627  CD1 LEU 1  97      34.842  20.784  37.228  0.50 28.20           C  
+ATOM    628  CD2 LEU 1  97      36.029  18.973  35.960  0.50 25.61           C  
+ATOM    629  N   ALA 1  98      39.555  21.483  39.543  0.50 26.77           N  
+ATOM    630  CA  ALA 1  98      40.634  21.266  40.503  0.50 27.98           C  
+ATOM    631  C   ALA 1  98      40.537  22.150  41.743  0.50 27.42           C  
+ATOM    632  O   ALA 1  98      40.761  21.689  42.864  0.50 29.13           O  
+ATOM    633  CB  ALA 1  98      41.993  21.480  39.824  0.50 26.65           C  
+ATOM    634  N   LEU 1  99      40.213  23.424  41.547  0.50 28.99           N  
+ATOM    635  CA  LEU 1  99      40.112  24.348  42.672  0.50 28.53           C  
+ATOM    636  C   LEU 1  99      38.934  23.995  43.565  0.50 27.27           C  
+ATOM    637  O   LEU 1  99      39.010  24.093  44.790  0.50 27.26           O  
+ATOM    638  CB  LEU 1  99      39.971  25.788  42.168  0.50 31.33           C  
+ATOM    639  CG  LEU 1  99      41.089  26.281  41.232  0.50 34.25           C  
+ATOM    640  CD1 LEU 1  99      40.899  27.771  40.994  0.50 35.00           C  
+ATOM    641  CD2 LEU 1  99      42.475  26.025  41.832  0.50 35.01           C  
+ATOM    642  N   LEU 1 100      37.841  23.572  42.951  0.50 26.92           N  
+ATOM    643  CA  LEU 1 100      36.655  23.205  43.716  0.50 28.71           C  
+ATOM    644  C   LEU 1 100      36.949  22.061  44.678  0.50 27.64           C  
+ATOM    645  O   LEU 1 100      36.436  22.015  45.789  0.50 28.49           O  
+ATOM    646  CB  LEU 1 100      35.530  22.788  42.766  0.50 27.30           C  
+ATOM    647  CG  LEU 1 100      34.143  22.554  43.370  0.50 31.04           C  
+ATOM    648  CD1 LEU 1 100      33.623  23.837  44.025  0.50 26.49           C  
+ATOM    649  CD2 LEU 1 100      33.203  22.099  42.272  0.50 28.78           C  
+ATOM    650  N   VAL 1 101      37.809  21.150  44.252  0.50 29.33           N  
+ATOM    651  CA  VAL 1 101      38.132  19.981  45.053  0.50 30.69           C  
+ATOM    652  C   VAL 1 101      39.463  20.129  45.808  0.50 31.85           C  
+ATOM    653  O   VAL 1 101      39.885  19.230  46.540  0.50 31.02           O  
+ATOM    654  CB  VAL 1 101      38.132  18.739  44.111  0.50 30.79           C  
+ATOM    655  CG1 VAL 1 101      39.536  18.162  43.957  0.50 30.96           C  
+ATOM    656  CG2 VAL 1 101      37.137  17.732  44.592  0.50 31.14           C  
+ATOM    657  N   ASP 1 102      40.118  21.272  45.621  0.50 34.12           N  
+ATOM    658  CA  ASP 1 102      41.397  21.549  46.273  0.50 37.29           C  
+ATOM    659  C   ASP 1 102      42.460  20.495  45.958  0.50 37.94           C  
+ATOM    660  O   ASP 1 102      43.035  19.892  46.860  0.50 39.64           O  
+ATOM    661  CB  ASP 1 102      41.195  21.653  47.788  0.50 40.65           C  
+ATOM    662  CG  ASP 1 102      42.493  21.843  48.534  0.50 44.95           C  
+ATOM    663  OD1 ASP 1 102      43.322  22.665  48.081  0.50 47.60           O  
+ATOM    664  OD2 ASP 1 102      42.689  21.176  49.576  0.50 48.70           O  
+ATOM    665  N   ALA 1 103      42.726  20.290  44.671  0.50 36.27           N  
+ATOM    666  CA  ALA 1 103      43.708  19.305  44.217  0.50 35.02           C  
+ATOM    667  C   ALA 1 103      45.152  19.805  44.273  0.50 34.88           C  
+ATOM    668  O   ALA 1 103      45.396  21.006  44.230  0.50 33.54           O  
+ATOM    669  CB  ALA 1 103      43.373  18.883  42.790  0.50 34.91           C  
+ATOM    670  N   ASP 1 104      46.103  18.872  44.340  0.50 35.37           N  
+ATOM    671  CA  ASP 1 104      47.534  19.199  44.383  0.50 36.79           C  
+ATOM    672  C   ASP 1 104      48.015  19.866  43.091  0.50 35.03           C  
+ATOM    673  O   ASP 1 104      47.400  19.713  42.037  0.50 34.81           O  
+ATOM    674  CB  ASP 1 104      48.371  17.925  44.609  0.50 39.98           C  
+ATOM    675  CG  ASP 1 104      48.240  17.366  46.024  0.50 43.92           C  
+ATOM    676  OD1 ASP 1 104      48.380  18.144  46.996  0.50 44.49           O  
+ATOM    677  OD2 ASP 1 104      48.015  16.140  46.165  0.50 46.55           O  
+ATOM    678  N   GLN 1 105      49.124  20.593  43.166  0.50 34.08           N  
+ATOM    679  CA  GLN 1 105      49.660  21.248  41.974  0.50 33.65           C  
+ATOM    680  C   GLN 1 105      50.078  20.235  40.915  0.50 31.90           C  
+ATOM    681  O   GLN 1 105      49.893  20.456  39.718  0.50 31.75           O  
+ATOM    682  CB  GLN 1 105      50.857  22.124  42.331  0.50 34.65           C  
+ATOM    683  CG  GLN 1 105      50.480  23.547  42.698  0.50 39.03           C  
+ATOM    684  CD  GLN 1 105      51.687  24.456  42.815  0.50 40.37           C  
+ATOM    685  OE1 GLN 1 105      51.551  25.668  42.980  0.50 42.38           O  
+ATOM    686  NE2 GLN 1 105      52.876  23.874  42.733  0.50 41.48           N  
+ATOM    687  N   GLY 1 106      50.646  19.121  41.358  0.50 30.06           N  
+ATOM    688  CA  GLY 1 106      51.073  18.105  40.419  0.50 27.56           C  
+ATOM    689  C   GLY 1 106      49.923  17.564  39.593  0.50 26.53           C  
+ATOM    690  O   GLY 1 106      50.031  17.416  38.375  0.50 24.87           O  
+ATOM    691  N   THR 1 107      48.800  17.282  40.245  0.50 26.94           N  
+ATOM    692  CA  THR 1 107      47.663  16.744  39.520  0.50 27.56           C  
+ATOM    693  C   THR 1 107      47.178  17.789  38.517  0.50 26.86           C  
+ATOM    694  O   THR 1 107      46.916  17.475  37.360  0.50 26.64           O  
+ATOM    695  CB  THR 1 107      46.544  16.317  40.496  0.50 29.65           C  
+ATOM    696  OG1 THR 1 107      45.554  15.569  39.782  0.50 33.31           O  
+ATOM    697  CG2 THR 1 107      45.893  17.525  41.134  0.50 31.03           C  
+ATOM    698  N   ILE 1 108      47.111  19.045  38.953  0.50 26.25           N  
+ATOM    699  CA  ILE 1 108      46.689  20.132  38.081  0.50 24.76           C  
+ATOM    700  C   ILE 1 108      47.562  20.159  36.823  0.50 25.01           C  
+ATOM    701  O   ILE 1 108      47.049  20.216  35.698  0.50 24.29           O  
+ATOM    702  CB  ILE 1 108      46.788  21.503  38.811  0.50 26.85           C  
+ATOM    703  CG1 ILE 1 108      45.819  21.534  40.004  0.50 26.23           C  
+ATOM    704  CG2 ILE 1 108      46.450  22.645  37.855  0.50 26.14           C  
+ATOM    705  CD1 ILE 1 108      45.819  22.863  40.762  0.50 24.99           C  
+ATOM    706  N   LEU 1 109      48.880  20.106  37.010  0.50 25.40           N  
+ATOM    707  CA  LEU 1 109      49.812  20.117  35.879  0.50 24.54           C  
+ATOM    708  C   LEU 1 109      49.659  18.898  34.983  0.50 23.73           C  
+ATOM    709  O   LEU 1 109      49.765  19.001  33.764  0.50 21.11           O  
+ATOM    710  CB  LEU 1 109      51.269  20.174  36.360  0.50 26.97           C  
+ATOM    711  CG  LEU 1 109      52.252  20.028  35.183  0.50 29.02           C  
+ATOM    712  CD1 LEU 1 109      52.021  21.146  34.168  0.50 28.90           C  
+ATOM    713  CD2 LEU 1 109      53.680  20.066  35.678  0.50 32.05           C  
+ATOM    714  N   ALA 1 110      49.436  17.735  35.588  0.50 23.17           N  
+ATOM    715  CA  ALA 1 110      49.274  16.509  34.812  0.50 23.01           C  
+ATOM    716  C   ALA 1 110      48.021  16.635  33.945  0.50 22.77           C  
+ATOM    717  O   ALA 1 110      48.045  16.328  32.747  0.50 22.44           O  
+ATOM    718  CB  ALA 1 110      49.169  15.287  35.762  0.50 23.16           C  
+ATOM    719  N   LEU 1 111      46.929  17.103  34.543  0.50 22.63           N  
+ATOM    720  CA  LEU 1 111      45.671  17.282  33.803  0.50 23.40           C  
+ATOM    721  C   LEU 1 111      45.807  18.280  32.653  0.50 23.53           C  
+ATOM    722  O   LEU 1 111      45.429  17.990  31.513  0.50 22.19           O  
+ATOM    723  CB  LEU 1 111      44.569  17.753  34.750  0.50 25.44           C  
+ATOM    724  CG  LEU 1 111      43.830  16.677  35.547  0.50 27.71           C  
+ATOM    725  CD1 LEU 1 111      44.811  15.659  36.095  0.50 30.10           C  
+ATOM    726  CD2 LEU 1 111      43.047  17.360  36.658  0.50 26.39           C  
+ATOM    727  N   VAL 1 112      46.350  19.454  32.955  0.50 24.28           N  
+ATOM    728  CA  VAL 1 112      46.535  20.487  31.944  0.50 24.90           C  
+ATOM    729  C   VAL 1 112      47.444  20.003  30.818  0.50 24.29           C  
+ATOM    730  O   VAL 1 112      47.196  20.284  29.646  0.50 23.01           O  
+ATOM    731  CB  VAL 1 112      47.129  21.776  32.570  0.50 28.30           C  
+ATOM    732  CG1 VAL 1 112      47.492  22.784  31.475  0.50 29.68           C  
+ATOM    733  CG2 VAL 1 112      46.114  22.390  33.523  0.50 28.73           C  
+ATOM    734  N   GLY 1 113      48.503  19.280  31.171  0.50 24.36           N  
+ATOM    735  CA  GLY 1 113      49.400  18.765  30.150  0.50 23.33           C  
+ATOM    736  C   GLY 1 113      48.687  17.731  29.288  0.50 22.26           C  
+ATOM    737  O   GLY 1 113      48.748  17.766  28.057  0.50 23.49           O  
+ATOM    738  N   ALA 1 114      47.999  16.801  29.933  0.50 22.19           N  
+ATOM    739  CA  ALA 1 114      47.270  15.773  29.202  0.50 21.54           C  
+ATOM    740  C   ALA 1 114      46.296  16.451  28.252  0.50 21.43           C  
+ATOM    741  O   ALA 1 114      46.095  16.002  27.115  0.50 22.01           O  
+ATOM    742  CB  ALA 1 114      46.508  14.872  30.179  0.50 21.38           C  
+ATOM    743  N   ASP 1 115      45.699  17.543  28.719  0.50 21.80           N  
+ATOM    744  CA  ASP 1 115      44.730  18.296  27.927  0.50 21.64           C  
+ATOM    745  C   ASP 1 115      45.379  18.941  26.712  0.50 20.71           C  
+ATOM    746  O   ASP 1 115      44.858  18.869  25.595  0.50 19.92           O  
+ATOM    747  CB  ASP 1 115      44.066  19.363  28.803  0.50 24.30           C  
+ATOM    748  CG  ASP 1 115      42.876  20.013  28.128  0.50 26.77           C  
+ATOM    749  OD1 ASP 1 115      43.074  20.925  27.304  0.50 27.52           O  
+ATOM    750  OD2 ASP 1 115      41.735  19.598  28.418  0.50 27.99           O  
+ATOM    751  N   GLY 1 116      46.518  19.589  26.917  0.50 23.08           N  
+ATOM    752  CA  GLY 1 116      47.195  20.200  25.784  0.50 21.36           C  
+ATOM    753  C   GLY 1 116      47.481  19.126  24.740  0.50 24.11           C  
+ATOM    754  O   GLY 1 116      47.347  19.351  23.537  0.50 26.35           O  
+ATOM    755  N   ILE 1 117      47.869  17.941  25.201  0.50 23.84           N  
+ATOM    756  CA  ILE 1 117      48.176  16.832  24.295  0.50 24.39           C  
+ATOM    757  C   ILE 1 117      46.927  16.313  23.598  0.50 23.83           C  
+ATOM    758  O   ILE 1 117      46.961  15.953  22.415  0.50 22.64           O  
+ATOM    759  CB  ILE 1 117      48.836  15.658  25.059  0.50 26.23           C  
+ATOM    760  CG1 ILE 1 117      50.229  16.074  25.532  0.50 25.62           C  
+ATOM    761  CG2 ILE 1 117      48.894  14.409  24.169  0.50 27.63           C  
+ATOM    762  CD1 ILE 1 117      50.962  14.993  26.317  0.50 26.86           C  
+ATOM    763  N   MET 1 118      45.826  16.266  24.335  0.50 22.96           N  
+ATOM    764  CA  MET 1 118      44.564  15.797  23.774  0.50 23.75           C  
+ATOM    765  C   MET 1 118      44.134  16.662  22.592  0.50 24.69           C  
+ATOM    766  O   MET 1 118      43.831  16.165  21.505  0.50 23.08           O  
+ATOM    767  CB  MET 1 118      43.471  15.828  24.845  0.50 24.34           C  
+ATOM    768  CG  MET 1 118      42.069  15.598  24.301  0.50 23.17           C  
+ATOM    769  SD  MET 1 118      40.888  15.563  25.657  0.50 26.62           S  
+ATOM    770  CE  MET 1 118      40.648  17.325  25.924  0.50 23.59           C  
+ATOM    771  N   ILE 1 119      44.107  17.970  22.813  0.50 26.79           N  
+ATOM    772  CA  ILE 1 119      43.693  18.889  21.770  0.50 24.76           C  
+ATOM    773  C   ILE 1 119      44.721  18.958  20.656  0.50 26.02           C  
+ATOM    774  O   ILE 1 119      44.379  18.837  19.474  0.50 24.05           O  
+ATOM    775  CB  ILE 1 119      43.463  20.299  22.344  0.50 26.31           C  
+ATOM    776  CG1 ILE 1 119      42.366  20.239  23.409  0.50 24.24           C  
+ATOM    777  CG2 ILE 1 119      43.090  21.266  21.228  0.50 23.51           C  
+ATOM    778  CD1 ILE 1 119      41.076  19.587  22.926  0.50 26.17           C  
+ATOM    779  N   GLY 1 120      45.983  19.135  21.033  0.50 26.66           N  
+ATOM    780  CA  GLY 1 120      47.032  19.225  20.033  0.50 28.05           C  
+ATOM    781  C   GLY 1 120      46.999  18.041  19.083  0.50 30.14           C  
+ATOM    782  O   GLY 1 120      46.913  18.189  17.862  0.50 31.00           O  
+ATOM    783  N   THR 1 121      47.072  16.852  19.653  0.50 29.71           N  
+ATOM    784  CA  THR 1 121      47.048  15.637  18.857  0.50 31.49           C  
+ATOM    785  C   THR 1 121      45.751  15.504  18.044  0.50 31.49           C  
+ATOM    786  O   THR 1 121      45.757  14.990  16.924  0.50 30.10           O  
+ATOM    787  CB  THR 1 121      47.244  14.417  19.779  0.50 32.65           C  
+ATOM    788  OG1 THR 1 121      48.599  14.406  20.266  0.50 33.43           O  
+ATOM    789  CG2 THR 1 121      46.957  13.143  19.038  0.50 35.99           C  
+ATOM    790  N   GLY 1 122      44.636  15.970  18.596  0.50 31.52           N  
+ATOM    791  CA  GLY 1 122      43.390  15.883  17.855  0.50 32.39           C  
+ATOM    792  C   GLY 1 122      43.436  16.746  16.602  0.50 34.94           C  
+ATOM    793  O   GLY 1 122      42.950  16.350  15.542  0.50 35.25           O  
+ATOM    794  N   LEU 1 123      44.026  17.932  16.714  0.50 35.72           N  
+ATOM    795  CA  LEU 1 123      44.125  18.832  15.567  0.50 36.91           C  
+ATOM    796  C   LEU 1 123      45.069  18.255  14.516  0.50 36.83           C  
+ATOM    797  O   LEU 1 123      44.760  18.246  13.328  0.50 35.88           O  
+ATOM    798  CB  LEU 1 123      44.627  20.217  16.003  0.50 37.76           C  
+ATOM    799  CG  LEU 1 123      44.868  21.205  14.845  0.50 39.31           C  
+ATOM    800  CD1 LEU 1 123      43.539  21.531  14.169  0.50 38.93           C  
+ATOM    801  CD2 LEU 1 123      45.532  22.486  15.357  0.50 39.42           C  
+ATOM    802  N   VAL 1 124      46.229  17.782  14.952  0.50 38.20           N  
+ATOM    803  CA  VAL 1 124      47.182  17.194  14.022  0.50 39.01           C  
+ATOM    804  C   VAL 1 124      46.469  16.084  13.252  0.50 40.19           C  
+ATOM    805  O   VAL 1 124      46.612  15.964  12.038  0.50 39.84           O  
+ATOM    806  CB  VAL 1 124      48.385  16.596  14.765  0.50 39.17           C  
+ATOM    807  CG1 VAL 1 124      49.321  15.905  13.774  0.50 41.86           C  
+ATOM    808  CG2 VAL 1 124      49.118  17.692  15.518  0.50 38.30           C  
+ATOM    809  N   GLY 1 125      45.696  15.272  13.965  0.50 40.75           N  
+ATOM    810  CA  GLY 1 125      44.974  14.204  13.305  0.50 42.07           C  
+ATOM    811  C   GLY 1 125      44.110  14.800  12.215  0.50 44.11           C  
+ATOM    812  O   GLY 1 125      44.090  14.319  11.081  0.50 43.15           O  
+ATOM    813  N   ALA 1 126      43.403  15.870  12.561  0.50 45.60           N  
+ATOM    814  CA  ALA 1 126      42.532  16.542  11.614  0.50 47.09           C  
+ATOM    815  C   ALA 1 126      43.307  16.982  10.379  0.50 49.01           C  
+ATOM    816  O   ALA 1 126      42.764  17.018   9.277  0.50 49.77           O  
+ATOM    817  CB  ALA 1 126      41.879  17.739  12.275  0.50 47.21           C  
+ATOM    818  N   LEU 1 127      44.580  17.310  10.562  0.50 50.88           N  
+ATOM    819  CA  LEU 1 127      45.412  17.756   9.451  0.50 52.34           C  
+ATOM    820  C   LEU 1 127      46.229  16.648   8.789  0.50 53.76           C  
+ATOM    821  O   LEU 1 127      47.216  16.927   8.108  0.50 54.05           O  
+ATOM    822  CB  LEU 1 127      46.356  18.869   9.913  0.50 52.41           C  
+ATOM    823  CG  LEU 1 127      45.799  20.294   9.982  0.50 53.61           C  
+ATOM    824  CD1 LEU 1 127      44.945  20.462  11.213  0.50 53.63           C  
+ATOM    825  CD2 LEU 1 127      46.951  21.288  10.005  0.50 54.35           C  
+ATOM    826  N   THR 1 128      45.826  15.396   8.982  0.50 54.79           N  
+ATOM    827  CA  THR 1 128      46.548  14.276   8.388  0.50 55.98           C  
+ATOM    828  C   THR 1 128      45.734  13.653   7.256  0.50 57.39           C  
+ATOM    829  O   THR 1 128      44.553  13.332   7.428  0.50 57.83           O  
+ATOM    830  CB  THR 1 128      46.881  13.202   9.452  0.50 56.40           C  
+ATOM    831  OG1 THR 1 128      47.778  13.756  10.423  0.50 56.10           O  
+ATOM    832  CG2 THR 1 128      47.538  11.989   8.811  0.50 57.27           C  
+ATOM    833  N   LYS 1 129      46.370  13.484   6.098  0.50 58.30           N  
+ATOM    834  CA  LYS 1 129      45.695  12.923   4.932  0.50 58.77           C  
+ATOM    835  C   LYS 1 129      45.408  11.430   5.057  0.50 58.32           C  
+ATOM    836  O   LYS 1 129      44.323  10.969   4.706  0.50 58.74           O  
+ATOM    837  CB  LYS 1 129      46.518  13.183   3.662  0.50 60.63           C  
+ATOM    838  CG  LYS 1 129      47.938  12.624   3.705  0.50 62.86           C  
+ATOM    839  CD  LYS 1 129      48.574  12.504   2.311  0.50 63.50           C  
+ATOM    840  CE  LYS 1 129      48.890  13.856   1.677  0.50 64.25           C  
+ATOM    841  NZ  LYS 1 129      47.676  14.615   1.268  0.50 64.00           N  
+ATOM    842  N   VAL 1 130      46.380  10.681   5.566  0.50 58.40           N  
+ATOM    843  CA  VAL 1 130      46.237   9.236   5.723  0.50 57.81           C  
+ATOM    844  C   VAL 1 130      45.288   8.853   6.857  0.50 57.27           C  
+ATOM    845  O   VAL 1 130      45.358   9.406   7.953  0.50 56.47           O  
+ATOM    846  CB  VAL 1 130      47.611   8.576   5.981  0.50 57.89           C  
+ATOM    847  CG1 VAL 1 130      47.468   7.065   6.037  0.50 57.92           C  
+ATOM    848  CG2 VAL 1 130      48.591   8.981   4.892  0.50 58.24           C  
+ATOM    849  N   TYR 1 131      44.404   7.899   6.585  0.50 56.90           N  
+ATOM    850  CA  TYR 1 131      43.453   7.436   7.584  0.50 56.55           C  
+ATOM    851  C   TYR 1 131      44.184   6.694   8.697  0.50 55.20           C  
+ATOM    852  O   TYR 1 131      43.868   6.842   9.880  0.50 55.50           O  
+ATOM    853  CB  TYR 1 131      42.418   6.504   6.947  0.50 58.12           C  
+ATOM    854  CG  TYR 1 131      41.532   7.165   5.912  0.50 60.86           C  
+ATOM    855  CD1 TYR 1 131      42.023   7.498   4.647  0.50 62.77           C  
+ATOM    856  CD2 TYR 1 131      40.199   7.453   6.194  0.50 61.66           C  
+ATOM    857  CE1 TYR 1 131      41.201   8.098   3.689  0.50 62.94           C  
+ATOM    858  CE2 TYR 1 131      39.373   8.050   5.248  0.50 62.63           C  
+ATOM    859  CZ  TYR 1 131      39.878   8.371   4.001  0.50 62.71           C  
+ATOM    860  OH  TYR 1 131      39.059   8.973   3.073  0.50 62.62           O  
+ATOM    861  N   SER 1 132      45.162   5.890   8.303  0.50 53.29           N  
+ATOM    862  CA  SER 1 132      45.955   5.108   9.241  0.50 50.94           C  
+ATOM    863  C   SER 1 132      46.521   5.997  10.352  0.50 49.49           C  
+ATOM    864  O   SER 1 132      46.250   5.788  11.534  0.50 48.81           O  
+ATOM    865  CB  SER 1 132      47.099   4.422   8.487  0.50 50.04           C  
+ATOM    866  OG  SER 1 132      47.866   3.608   9.352  0.50 50.80           O  
+ATOM    867  N   TYR 1 133      47.316   6.984   9.957  0.50 48.24           N  
+ATOM    868  CA  TYR 1 133      47.915   7.903  10.908  0.50 48.03           C  
+ATOM    869  C   TYR 1 133      46.814   8.664  11.641  0.50 47.04           C  
+ATOM    870  O   TYR 1 133      46.909   8.925  12.843  0.50 47.45           O  
+ATOM    871  CB  TYR 1 133      48.844   8.871  10.172  0.50 49.48           C  
+ATOM    872  CG  TYR 1 133      49.955   8.179   9.402  0.50 49.56           C  
+ATOM    873  CD1 TYR 1 133      50.380   6.895   9.753  0.50 50.76           C  
+ATOM    874  CD2 TYR 1 133      50.593   8.812   8.338  0.50 49.87           C  
+ATOM    875  CE1 TYR 1 133      51.410   6.260   9.068  0.50 50.95           C  
+ATOM    876  CE2 TYR 1 133      51.629   8.186   7.644  0.50 51.24           C  
+ATOM    877  CZ  TYR 1 133      52.028   6.909   8.014  0.50 51.49           C  
+ATOM    878  OH  TYR 1 133      53.045   6.279   7.337  0.50 52.58           O  
+ATOM    879  N   ARG 1 134      45.761   8.996  10.909  0.50 45.43           N  
+ATOM    880  CA  ARG 1 134      44.629   9.712  11.469  0.50 45.32           C  
+ATOM    881  C   ARG 1 134      44.166   9.008  12.734  0.50 44.19           C  
+ATOM    882  O   ARG 1 134      44.073   9.617  13.802  0.50 44.24           O  
+ATOM    883  CB  ARG 1 134      43.485   9.740  10.461  0.50 46.26           C  
+ATOM    884  CG  ARG 1 134      42.202  10.347  10.983  0.50 49.48           C  
+ATOM    885  CD  ARG 1 134      42.337  11.846  11.142  0.50 51.15           C  
+ATOM    886  NE  ARG 1 134      42.549  12.523   9.865  0.50 52.76           N  
+ATOM    887  CZ  ARG 1 134      41.649  12.592   8.889  0.50 54.14           C  
+ATOM    888  NH1 ARG 1 134      40.460  12.020   9.031  0.50 55.13           N  
+ATOM    889  NH2 ARG 1 134      41.938  13.245   7.772  0.50 54.69           N  
+ATOM    890  N   PHE 1 135      43.872   7.716  12.603  0.50 42.86           N  
+ATOM    891  CA  PHE 1 135      43.415   6.924  13.735  0.50 41.27           C  
+ATOM    892  C   PHE 1 135      44.465   6.924  14.845  0.50 38.41           C  
+ATOM    893  O   PHE 1 135      44.130   6.890  16.025  0.50 38.04           O  
+ATOM    894  CB  PHE 1 135      43.120   5.479  13.310  0.50 41.63           C  
+ATOM    895  CG  PHE 1 135      42.668   4.600  14.444  0.50 43.62           C  
+ATOM    896  CD1 PHE 1 135      41.363   4.673  14.924  0.50 44.99           C  
+ATOM    897  CD2 PHE 1 135      43.564   3.748  15.077  0.50 44.57           C  
+ATOM    898  CE1 PHE 1 135      40.957   3.915  16.022  0.50 44.61           C  
+ATOM    899  CE2 PHE 1 135      43.171   2.984  16.177  0.50 46.27           C  
+ATOM    900  CZ  PHE 1 135      41.863   3.070  16.650  0.50 45.94           C  
+ATOM    901  N   VAL 1 136      45.737   6.952  14.469  0.50 36.59           N  
+ATOM    902  CA  VAL 1 136      46.786   6.959  15.475  0.50 35.20           C  
+ATOM    903  C   VAL 1 136      46.668   8.206  16.341  0.50 33.89           C  
+ATOM    904  O   VAL 1 136      46.679   8.123  17.573  0.50 34.07           O  
+ATOM    905  CB  VAL 1 136      48.184   6.926  14.842  0.50 35.95           C  
+ATOM    906  CG1 VAL 1 136      49.245   7.111  15.931  0.50 36.24           C  
+ATOM    907  CG2 VAL 1 136      48.394   5.597  14.115  0.50 34.24           C  
+ATOM    908  N   TRP 1 137      46.548   9.366  15.706  0.50 31.34           N  
+ATOM    909  CA  TRP 1 137      46.425  10.598  16.474  0.50 31.97           C  
+ATOM    910  C   TRP 1 137      45.158  10.581  17.309  0.50 31.74           C  
+ATOM    911  O   TRP 1 137      45.170  10.994  18.469  0.50 32.13           O  
+ATOM    912  CB  TRP 1 137      46.451  11.810  15.542  0.50 30.08           C  
+ATOM    913  CG  TRP 1 137      47.776  11.938  14.875  0.50 29.26           C  
+ATOM    914  CD1 TRP 1 137      48.045  11.797  13.545  0.50 28.09           C  
+ATOM    915  CD2 TRP 1 137      49.032  12.187  15.518  0.50 28.89           C  
+ATOM    916  NE1 TRP 1 137      49.390  11.944  13.319  0.50 27.52           N  
+ATOM    917  CE2 TRP 1 137      50.021  12.186  14.511  0.50 27.93           C  
+ATOM    918  CE3 TRP 1 137      49.418  12.414  16.851  0.50 27.42           C  
+ATOM    919  CZ2 TRP 1 137      51.376  12.407  14.790  0.50 27.23           C  
+ATOM    920  CZ3 TRP 1 137      50.766  12.633  17.129  0.50 25.32           C  
+ATOM    921  CH2 TRP 1 137      51.725  12.629  16.102  0.50 27.48           C  
+ATOM    922  N   TRP 1 138      44.070  10.083  16.726  0.50 32.06           N  
+ATOM    923  CA  TRP 1 138      42.801   9.998  17.438  0.50 32.15           C  
+ATOM    924  C   TRP 1 138      42.958   9.134  18.675  0.50 31.03           C  
+ATOM    925  O   TRP 1 138      42.402   9.442  19.730  0.50 33.25           O  
+ATOM    926  CB  TRP 1 138      41.718   9.383  16.549  0.50 34.68           C  
+ATOM    927  CG  TRP 1 138      40.395   9.186  17.260  0.50 36.80           C  
+ATOM    928  CD1 TRP 1 138      39.397  10.110  17.411  0.50 37.21           C  
+ATOM    929  CD2 TRP 1 138      39.945   7.999  17.931  0.50 37.63           C  
+ATOM    930  NE1 TRP 1 138      38.353   9.569  18.132  0.50 38.44           N  
+ATOM    931  CE2 TRP 1 138      38.665   8.278  18.465  0.50 38.70           C  
+ATOM    932  CE3 TRP 1 138      40.500   6.729  18.134  0.50 39.67           C  
+ATOM    933  CZ2 TRP 1 138      37.930   7.329  19.191  0.50 40.13           C  
+ATOM    934  CZ3 TRP 1 138      39.769   5.782  18.857  0.50 39.97           C  
+ATOM    935  CH2 TRP 1 138      38.497   6.091  19.376  0.50 40.61           C  
+ATOM    936  N   ALA 1 139      43.716   8.047  18.542  0.50 29.88           N  
+ATOM    937  CA  ALA 1 139      43.940   7.122  19.655  0.50 28.34           C  
+ATOM    938  C   ALA 1 139      44.715   7.779  20.792  0.50 26.42           C  
+ATOM    939  O   ALA 1 139      44.362   7.630  21.967  0.50 28.60           O  
+ATOM    940  CB  ALA 1 139      44.686   5.883  19.155  0.50 29.31           C  
+ATOM    941  N   ILE 1 140      45.785   8.489  20.441  0.50 24.94           N  
+ATOM    942  CA  ILE 1 140      46.601   9.187  21.437  0.50 25.30           C  
+ATOM    943  C   ILE 1 140      45.756  10.265  22.121  0.50 23.56           C  
+ATOM    944  O   ILE 1 140      45.752  10.389  23.342  0.50 23.54           O  
+ATOM    945  CB  ILE 1 140      47.832   9.865  20.776  0.50 25.33           C  
+ATOM    946  CG1 ILE 1 140      48.791   8.793  20.254  0.50 25.98           C  
+ATOM    947  CG2 ILE 1 140      48.544  10.778  21.788  0.50 25.11           C  
+ATOM    948  CD1 ILE 1 140      49.697   9.278  19.114  0.50 23.24           C  
+ATOM    949  N   SER 1 141      45.039  11.040  21.317  0.50 23.12           N  
+ATOM    950  CA  SER 1 141      44.191  12.100  21.848  0.50 24.71           C  
+ATOM    951  C   SER 1 141      43.095  11.529  22.743  0.50 24.17           C  
+ATOM    952  O   SER 1 141      42.775  12.086  23.795  0.50 24.99           O  
+ATOM    953  CB  SER 1 141      43.559  12.888  20.700  0.50 23.48           C  
+ATOM    954  OG  SER 1 141      42.750  13.936  21.200  0.50 25.70           O  
+ATOM    955  N   THR 1 142      42.517  10.412  22.321  0.50 24.65           N  
+ATOM    956  CA  THR 1 142      41.458   9.779  23.087  0.50 23.18           C  
+ATOM    957  C   THR 1 142      42.033   9.169  24.354  0.50 22.65           C  
+ATOM    958  O   THR 1 142      41.408   9.206  25.420  0.50 24.42           O  
+ATOM    959  CB  THR 1 142      40.768   8.693  22.238  0.50 25.28           C  
+ATOM    960  OG1 THR 1 142      40.154   9.313  21.099  0.50 22.88           O  
+ATOM    961  CG2 THR 1 142      39.708   7.951  23.061  0.50 24.41           C  
+ATOM    962  N   ALA 1 143      43.230   8.602  24.248  0.50 21.85           N  
+ATOM    963  CA  ALA 1 143      43.852   8.013  25.423  0.50 22.10           C  
+ATOM    964  C   ALA 1 143      44.062   9.105  26.466  0.50 21.84           C  
+ATOM    965  O   ALA 1 143      43.843   8.884  27.658  0.50 21.65           O  
+ATOM    966  CB  ALA 1 143      45.198   7.358  25.053  0.50 20.82           C  
+ATOM    967  N   ALA 1 144      44.475  10.288  26.021  0.50 21.74           N  
+ATOM    968  CA  ALA 1 144      44.717  11.392  26.950  0.50 22.07           C  
+ATOM    969  C   ALA 1 144      43.422  11.852  27.606  0.50 21.71           C  
+ATOM    970  O   ALA 1 144      43.406  12.217  28.787  0.50 22.31           O  
+ATOM    971  CB  ALA 1 144      45.394  12.561  26.223  0.50 20.35           C  
+ATOM    972  N   MET 1 145      42.332  11.846  26.850  0.50 21.97           N  
+ATOM    973  CA  MET 1 145      41.055  12.257  27.423  0.50 23.43           C  
+ATOM    974  C   MET 1 145      40.658  11.287  28.537  0.50 24.53           C  
+ATOM    975  O   MET 1 145      40.232  11.697  29.618  0.50 25.53           O  
+ATOM    976  CB  MET 1 145      39.959  12.269  26.355  0.50 23.51           C  
+ATOM    977  CG  MET 1 145      38.622  12.796  26.866  0.50 24.82           C  
+ATOM    978  SD  MET 1 145      37.271  12.445  25.708  0.50 26.74           S  
+ATOM    979  CE  MET 1 145      37.051  10.651  25.993  0.50 22.72           C  
+ATOM    980  N   LEU 1 146      40.796   9.990  28.270  0.50 25.13           N  
+ATOM    981  CA  LEU 1 146      40.435   8.997  29.266  0.50 25.32           C  
+ATOM    982  C   LEU 1 146      41.225   9.203  30.555  0.50 25.67           C  
+ATOM    983  O   LEU 1 146      40.682   9.046  31.654  0.50 26.97           O  
+ATOM    984  CB  LEU 1 146      40.658   7.589  28.711  0.50 25.87           C  
+ATOM    985  CG  LEU 1 146      39.763   7.248  27.511  0.50 27.44           C  
+ATOM    986  CD1 LEU 1 146      40.151   5.869  26.970  0.50 27.79           C  
+ATOM    987  CD2 LEU 1 146      38.281   7.261  27.928  0.50 26.09           C  
+ATOM    988  N   TYR 1 147      42.505   9.546  30.427  0.50 24.95           N  
+ATOM    989  CA  TYR 1 147      43.335   9.793  31.607  0.50 25.19           C  
+ATOM    990  C   TYR 1 147      42.700  10.911  32.427  0.50 23.31           C  
+ATOM    991  O   TYR 1 147      42.562  10.814  33.648  0.50 24.11           O  
+ATOM    992  CB  TYR 1 147      44.746  10.249  31.207  0.50 26.25           C  
+ATOM    993  CG  TYR 1 147      45.624  10.518  32.411  0.50 27.21           C  
+ATOM    994  CD1 TYR 1 147      46.194   9.461  33.126  0.50 29.85           C  
+ATOM    995  CD2 TYR 1 147      45.835  11.821  32.876  0.50 27.36           C  
+ATOM    996  CE1 TYR 1 147      46.941   9.691  34.276  0.50 29.45           C  
+ATOM    997  CE2 TYR 1 147      46.579  12.066  34.030  0.50 27.23           C  
+ATOM    998  CZ  TYR 1 147      47.132  10.995  34.717  0.50 29.06           C  
+ATOM    999  OH  TYR 1 147      47.888  11.209  35.843  0.50 33.58           O  
+ATOM   1000  N   ILE 1 148      42.337  11.987  31.738  0.50 24.24           N  
+ATOM   1001  CA  ILE 1 148      41.714  13.144  32.377  0.50 24.06           C  
+ATOM   1002  C   ILE 1 148      40.397  12.735  33.036  0.50 22.89           C  
+ATOM   1003  O   ILE 1 148      40.207  12.933  34.235  0.50 25.15           O  
+ATOM   1004  CB  ILE 1 148      41.451  14.273  31.334  0.50 24.57           C  
+ATOM   1005  CG1 ILE 1 148      42.785  14.863  30.862  0.50 25.17           C  
+ATOM   1006  CG2 ILE 1 148      40.568  15.368  31.943  0.50 25.10           C  
+ATOM   1007  CD1 ILE 1 148      42.683  15.716  29.589  0.50 23.74           C  
+ATOM   1008  N   LEU 1 149      39.492  12.154  32.258  0.50 22.12           N  
+ATOM   1009  CA  LEU 1 149      38.205  11.743  32.805  0.50 24.95           C  
+ATOM   1010  C   LEU 1 149      38.368  10.755  33.944  0.50 24.64           C  
+ATOM   1011  O   LEU 1 149      37.535  10.692  34.838  0.50 25.98           O  
+ATOM   1012  CB  LEU 1 149      37.324  11.136  31.712  0.50 23.37           C  
+ATOM   1013  CG  LEU 1 149      37.029  12.075  30.536  0.50 23.66           C  
+ATOM   1014  CD1 LEU 1 149      35.881  11.519  29.716  0.50 20.22           C  
+ATOM   1015  CD2 LEU 1 149      36.674  13.474  31.055  0.50 23.66           C  
+ATOM   1016  N   TYR 1 150      39.450   9.988  33.911  0.50 27.61           N  
+ATOM   1017  CA  TYR 1 150      39.717   9.012  34.955  0.50 28.62           C  
+ATOM   1018  C   TYR 1 150      40.049   9.740  36.264  0.50 28.76           C  
+ATOM   1019  O   TYR 1 150      39.498   9.423  37.322  0.50 28.50           O  
+ATOM   1020  CB  TYR 1 150      40.892   8.118  34.546  0.50 30.71           C  
+ATOM   1021  CG  TYR 1 150      41.192   7.034  35.557  0.50 33.27           C  
+ATOM   1022  CD1 TYR 1 150      40.725   5.726  35.375  0.50 35.00           C  
+ATOM   1023  CD2 TYR 1 150      41.880   7.328  36.734  0.50 33.66           C  
+ATOM   1024  CE1 TYR 1 150      40.939   4.742  36.346  0.50 35.05           C  
+ATOM   1025  CE2 TYR 1 150      42.094   6.354  37.709  0.50 35.92           C  
+ATOM   1026  CZ  TYR 1 150      41.617   5.066  37.507  0.50 36.43           C  
+ATOM   1027  OH  TYR 1 150      41.818   4.115  38.479  0.50 39.26           O  
+ATOM   1028  N   VAL 1 151      40.968  10.704  36.193  0.50 29.51           N  
+ATOM   1029  CA  VAL 1 151      41.357  11.468  37.379  0.50 29.29           C  
+ATOM   1030  C   VAL 1 151      40.171  12.244  37.939  0.50 28.00           C  
+ATOM   1031  O   VAL 1 151      39.972  12.287  39.152  0.50 28.48           O  
+ATOM   1032  CB  VAL 1 151      42.512  12.483  37.076  0.50 31.20           C  
+ATOM   1033  CG1 VAL 1 151      42.794  13.346  38.313  0.50 27.92           C  
+ATOM   1034  CG2 VAL 1 151      43.780  11.728  36.674  0.50 30.02           C  
+ATOM   1035  N   LEU 1 152      39.386  12.861  37.063  0.50 26.81           N  
+ATOM   1036  CA  LEU 1 152      38.231  13.631  37.523  0.50 28.13           C  
+ATOM   1037  C   LEU 1 152      37.178  12.737  38.173  0.50 28.69           C  
+ATOM   1038  O   LEU 1 152      36.700  13.009  39.273  0.50 27.53           O  
+ATOM   1039  CB  LEU 1 152      37.577  14.395  36.364  0.50 24.95           C  
+ATOM   1040  CG  LEU 1 152      38.386  15.473  35.634  0.50 26.91           C  
+ATOM   1041  CD1 LEU 1 152      37.500  16.117  34.582  0.50 23.40           C  
+ATOM   1042  CD2 LEU 1 152      38.884  16.535  36.624  0.50 24.62           C  
+ATOM   1043  N   PHE 1 153      36.820  11.660  37.491  0.50 31.16           N  
+ATOM   1044  CA  PHE 1 153      35.806  10.771  38.016  0.50 32.23           C  
+ATOM   1045  C   PHE 1 153      36.216  10.010  39.274  0.50 32.07           C  
+ATOM   1046  O   PHE 1 153      35.486  10.002  40.256  0.50 33.80           O  
+ATOM   1047  CB  PHE 1 153      35.365   9.781  36.940  0.50 34.03           C  
+ATOM   1048  CG  PHE 1 153      34.126   9.031  37.307  0.50 35.92           C  
+ATOM   1049  CD1 PHE 1 153      32.896   9.678  37.333  0.50 36.14           C  
+ATOM   1050  CD2 PHE 1 153      34.195   7.704  37.710  0.50 35.99           C  
+ATOM   1051  CE1 PHE 1 153      31.749   9.012  37.764  0.50 37.37           C  
+ATOM   1052  CE2 PHE 1 153      33.053   7.029  38.144  0.50 36.60           C  
+ATOM   1053  CZ  PHE 1 153      31.830   7.684  38.173  0.50 35.60           C  
+ATOM   1054  N   PHE 1 154      37.388   9.390  39.261  0.50 33.67           N  
+ATOM   1055  CA  PHE 1 154      37.831   8.601  40.410  0.50 34.97           C  
+ATOM   1056  C   PHE 1 154      38.737   9.282  41.426  0.50 34.70           C  
+ATOM   1057  O   PHE 1 154      38.640   9.011  42.621  0.50 36.98           O  
+ATOM   1058  CB  PHE 1 154      38.496   7.317  39.915  0.50 35.25           C  
+ATOM   1059  CG  PHE 1 154      37.541   6.358  39.272  0.50 35.61           C  
+ATOM   1060  CD1 PHE 1 154      36.572   5.710  40.031  0.50 37.52           C  
+ATOM   1061  CD2 PHE 1 154      37.597   6.112  37.901  0.50 37.41           C  
+ATOM   1062  CE1 PHE 1 154      35.666   4.827  39.436  0.50 38.19           C  
+ATOM   1063  CE2 PHE 1 154      36.698   5.233  37.290  0.50 37.48           C  
+ATOM   1064  CZ  PHE 1 154      35.730   4.589  38.059  0.50 38.13           C  
+ATOM   1065  N   GLY 1 155      39.623  10.153  40.963  0.50 33.63           N  
+ATOM   1066  CA  GLY 1 155      40.511  10.838  41.884  0.50 32.07           C  
+ATOM   1067  C   GLY 1 155      39.898  12.078  42.520  0.50 31.78           C  
+ATOM   1068  O   GLY 1 155      40.062  12.306  43.713  0.50 32.84           O  
+ATOM   1069  N   PHE 1 156      39.188  12.888  41.746  0.50 30.37           N  
+ATOM   1070  CA  PHE 1 156      38.607  14.097  42.321  0.50 30.70           C  
+ATOM   1071  C   PHE 1 156      37.415  13.807  43.228  0.50 32.26           C  
+ATOM   1072  O   PHE 1 156      37.179  14.542  44.199  0.50 33.30           O  
+ATOM   1073  CB  PHE 1 156      38.205  15.085  41.219  0.50 26.23           C  
+ATOM   1074  CG  PHE 1 156      39.351  15.925  40.698  0.50 24.51           C  
+ATOM   1075  CD1 PHE 1 156      40.660  15.457  40.743  0.50 24.15           C  
+ATOM   1076  CD2 PHE 1 156      39.109  17.159  40.103  0.50 24.44           C  
+ATOM   1077  CE1 PHE 1 156      41.711  16.200  40.198  0.50 23.49           C  
+ATOM   1078  CE2 PHE 1 156      40.154  17.909  39.553  0.50 25.25           C  
+ATOM   1079  CZ  PHE 1 156      41.458  17.424  39.603  0.50 23.75           C  
+ATOM   1080  N   THR 1 157      36.661  12.751  42.922  0.50 32.34           N  
+ATOM   1081  CA  THR 1 157      35.515  12.406  43.755  0.50 34.23           C  
+ATOM   1082  C   THR 1 157      35.990  12.109  45.176  0.50 35.78           C  
+ATOM   1083  O   THR 1 157      35.289  12.395  46.142  0.50 36.54           O  
+ATOM   1084  CB  THR 1 157      34.756  11.178  43.214  0.50 34.84           C  
+ATOM   1085  OG1 THR 1 157      34.217  11.484  41.924  0.50 33.79           O  
+ATOM   1086  CG2 THR 1 157      33.612  10.799  44.153  0.50 33.69           C  
+ATOM   1087  N   SER 1 158      37.184  11.538  45.302  0.50 37.68           N  
+ATOM   1088  CA  SER 1 158      37.732  11.237  46.620  0.50 40.70           C  
+ATOM   1089  C   SER 1 158      38.064  12.550  47.329  0.50 41.19           C  
+ATOM   1090  O   SER 1 158      37.806  12.714  48.523  0.50 40.77           O  
+ATOM   1091  CB  SER 1 158      39.003  10.401  46.484  0.50 41.21           C  
+ATOM   1092  OG  SER 1 158      38.787   9.296  45.623  0.50 46.07           O  
+ATOM   1093  N   LYS 1 159      38.642  13.477  46.572  0.50 40.93           N  
+ATOM   1094  CA  LYS 1 159      39.030  14.789  47.080  0.50 41.89           C  
+ATOM   1095  C   LYS 1 159      37.787  15.546  47.569  0.50 41.84           C  
+ATOM   1096  O   LYS 1 159      37.783  16.140  48.648  0.50 41.51           O  
+ATOM   1097  CB  LYS 1 159      39.705  15.576  45.952  0.50 43.25           C  
+ATOM   1098  CG  LYS 1 159      41.023  16.233  46.304  0.50 46.13           C  
+ATOM   1099  CD  LYS 1 159      42.119  15.221  46.566  0.50 46.25           C  
+ATOM   1100  CE  LYS 1 159      43.374  15.918  47.072  0.50 47.26           C  
+ATOM   1101  NZ  LYS 1 159      44.411  14.956  47.555  0.50 49.78           N  
+ATOM   1102  N   ALA 1 160      36.730  15.507  46.764  0.50 41.01           N  
+ATOM   1103  CA  ALA 1 160      35.481  16.187  47.085  0.50 42.05           C  
+ATOM   1104  C   ALA 1 160      34.859  15.664  48.371  0.50 42.19           C  
+ATOM   1105  O   ALA 1 160      34.291  16.426  49.154  0.50 41.45           O  
+ATOM   1106  CB  ALA 1 160      34.494  16.024  45.937  0.50 41.47           C  
+ATOM   1107  N   GLU 1 161      34.965  14.359  48.577  0.50 43.46           N  
+ATOM   1108  CA  GLU 1 161      34.405  13.718  49.758  0.50 45.93           C  
+ATOM   1109  C   GLU 1 161      35.025  14.256  51.046  0.50 45.07           C  
+ATOM   1110  O   GLU 1 161      34.532  13.981  52.138  0.50 46.19           O  
+ATOM   1111  CB  GLU 1 161      34.601  12.198  49.670  0.50 48.13           C  
+ATOM   1112  CG  GLU 1 161      33.342  11.379  49.335  0.50 51.38           C  
+ATOM   1113  CD  GLU 1 161      32.746  11.668  47.958  0.50 52.91           C  
+ATOM   1114  OE1 GLU 1 161      31.964  10.821  47.462  0.50 51.74           O  
+ATOM   1115  OE2 GLU 1 161      33.041  12.734  47.377  0.50 52.36           O  
+ATOM   1116  N   SER 1 162      36.101  15.024  50.923  0.50 44.80           N  
+ATOM   1117  CA  SER 1 162      36.748  15.590  52.100  0.50 44.56           C  
+ATOM   1118  C   SER 1 162      36.269  17.024  52.363  0.50 43.61           C  
+ATOM   1119  O   SER 1 162      36.629  17.632  53.373  0.50 43.63           O  
+ATOM   1120  CB  SER 1 162      38.269  15.581  51.930  0.50 45.65           C  
+ATOM   1121  OG  SER 1 162      38.678  16.541  50.969  0.50 50.09           O  
+ATOM   1122  N   MET 1 163      35.461  17.556  51.450  0.50 42.38           N  
+ATOM   1123  CA  MET 1 163      34.931  18.913  51.575  0.50 41.67           C  
+ATOM   1124  C   MET 1 163      33.548  18.870  52.226  0.50 40.93           C  
+ATOM   1125  O   MET 1 163      33.062  17.798  52.595  0.50 40.66           O  
+ATOM   1126  CB  MET 1 163      34.815  19.564  50.190  0.50 42.97           C  
+ATOM   1127  CG  MET 1 163      36.081  19.489  49.337  0.50 44.76           C  
+ATOM   1128  SD  MET 1 163      37.403  20.573  49.904  0.50 48.36           S  
+ATOM   1129  CE  MET 1 163      37.050  22.057  48.964  0.50 48.59           C  
+ATOM   1130  N   ARG 1 164      32.913  20.033  52.355  0.50 39.11           N  
+ATOM   1131  CA  ARG 1 164      31.585  20.108  52.948  0.50 37.96           C  
+ATOM   1132  C   ARG 1 164      30.593  19.557  51.915  0.50 36.65           C  
+ATOM   1133  O   ARG 1 164      30.886  19.545  50.720  0.50 35.74           O  
+ATOM   1134  CB  ARG 1 164      31.244  21.564  53.322  0.50 39.30           C  
+ATOM   1135  CG  ARG 1 164      30.683  22.423  52.189  0.50 39.78           C  
+ATOM   1136  CD  ARG 1 164      30.208  23.772  52.713  0.50 40.97           C  
+ATOM   1137  NE  ARG 1 164      31.282  24.761  52.716  0.50 44.10           N  
+ATOM   1138  CZ  ARG 1 164      31.626  25.495  51.662  0.50 42.81           C  
+ATOM   1139  NH1 ARG 1 164      30.976  25.363  50.514  0.50 45.17           N  
+ATOM   1140  NH2 ARG 1 164      32.631  26.349  51.749  0.50 40.72           N  
+ATOM   1141  N   PRO 1 165      29.411  19.093  52.363  0.50 35.20           N  
+ATOM   1142  CA  PRO 1 165      28.385  18.535  51.465  0.50 33.84           C  
+ATOM   1143  C   PRO 1 165      28.067  19.337  50.199  0.50 32.94           C  
+ATOM   1144  O   PRO 1 165      28.019  18.778  49.099  0.50 31.74           O  
+ATOM   1145  CB  PRO 1 165      27.166  18.344  52.382  0.50 33.75           C  
+ATOM   1146  CG  PRO 1 165      27.440  19.251  53.566  0.50 36.83           C  
+ATOM   1147  CD  PRO 1 165      28.931  19.138  53.756  0.50 34.53           C  
+ATOM   1148  N   GLU 1 166      27.862  20.639  50.345  0.50 32.66           N  
+ATOM   1149  CA  GLU 1 166      27.566  21.492  49.197  0.50 33.39           C  
+ATOM   1150  C   GLU 1 166      28.638  21.374  48.109  0.50 33.21           C  
+ATOM   1151  O   GLU 1 166      28.322  21.391  46.917  0.50 33.24           O  
+ATOM   1152  CB  GLU 1 166      27.429  22.958  49.641  0.50 35.29           C  
+ATOM   1153  CG  GLU 1 166      27.595  23.978  48.512  0.50 38.23           C  
+ATOM   1154  CD  GLU 1 166      26.563  23.815  47.406  0.50 42.23           C  
+ATOM   1155  OE1 GLU 1 166      26.777  24.366  46.301  0.50 42.75           O  
+ATOM   1156  OE2 GLU 1 166      25.532  23.145  47.642  0.50 42.64           O  
+ATOM   1157  N   VAL 1 167      29.900  21.248  48.522  0.50 32.12           N  
+ATOM   1158  CA  VAL 1 167      31.011  21.122  47.585  0.50 29.87           C  
+ATOM   1159  C   VAL 1 167      30.982  19.756  46.889  0.50 30.77           C  
+ATOM   1160  O   VAL 1 167      31.081  19.667  45.658  0.50 31.62           O  
+ATOM   1161  CB  VAL 1 167      32.383  21.306  48.307  0.50 32.37           C  
+ATOM   1162  CG1 VAL 1 167      33.535  21.004  47.346  0.50 31.83           C  
+ATOM   1163  CG2 VAL 1 167      32.521  22.738  48.824  0.50 31.76           C  
+ATOM   1164  N   ALA 1 168      30.835  18.691  47.669  0.50 28.62           N  
+ATOM   1165  CA  ALA 1 168      30.803  17.346  47.096  0.50 27.67           C  
+ATOM   1166  C   ALA 1 168      29.665  17.205  46.096  0.50 27.58           C  
+ATOM   1167  O   ALA 1 168      29.873  16.786  44.954  0.50 25.93           O  
+ATOM   1168  CB  ALA 1 168      30.663  16.302  48.207  0.50 26.43           C  
+ATOM   1169  N   SER 1 169      28.459  17.578  46.513  0.50 28.05           N  
+ATOM   1170  CA  SER 1 169      27.313  17.464  45.620  0.50 27.83           C  
+ATOM   1171  C   SER 1 169      27.457  18.344  44.375  0.50 26.80           C  
+ATOM   1172  O   SER 1 169      27.093  17.938  43.279  0.50 26.71           O  
+ATOM   1173  CB  SER 1 169      26.018  17.798  46.369  0.50 27.53           C  
+ATOM   1174  OG  SER 1 169      26.017  19.143  46.793  0.50 36.50           O  
+ATOM   1175  N   THR 1 170      27.988  19.550  44.518  0.50 26.38           N  
+ATOM   1176  CA  THR 1 170      28.135  20.379  43.333  0.50 25.15           C  
+ATOM   1177  C   THR 1 170      29.222  19.767  42.453  0.50 24.97           C  
+ATOM   1178  O   THR 1 170      29.091  19.693  41.232  0.50 25.27           O  
+ATOM   1179  CB  THR 1 170      28.505  21.819  43.690  0.50 26.34           C  
+ATOM   1180  OG1 THR 1 170      27.489  22.363  44.536  0.50 26.68           O  
+ATOM   1181  CG2 THR 1 170      28.617  22.670  42.431  0.50 23.71           C  
+ATOM   1182  N   PHE 1 171      30.298  19.306  43.066  0.50 25.56           N  
+ATOM   1183  CA  PHE 1 171      31.338  18.696  42.266  0.50 25.48           C  
+ATOM   1184  C   PHE 1 171      30.807  17.476  41.520  0.50 25.58           C  
+ATOM   1185  O   PHE 1 171      31.088  17.294  40.329  0.50 26.27           O  
+ATOM   1186  CB  PHE 1 171      32.522  18.251  43.118  0.50 24.56           C  
+ATOM   1187  CG  PHE 1 171      33.453  17.357  42.374  0.50 24.47           C  
+ATOM   1188  CD1 PHE 1 171      34.270  17.872  41.372  0.50 24.09           C  
+ATOM   1189  CD2 PHE 1 171      33.430  15.982  42.586  0.50 24.83           C  
+ATOM   1190  CE1 PHE 1 171      35.046  17.027  40.586  0.50 25.75           C  
+ATOM   1191  CE2 PHE 1 171      34.201  15.131  41.806  0.50 24.09           C  
+ATOM   1192  CZ  PHE 1 171      35.010  15.651  40.805  0.50 22.86           C  
+ATOM   1193  N   LYS 1 172      30.054  16.631  42.222  0.50 27.10           N  
+ATOM   1194  CA  LYS 1 172      29.506  15.421  41.610  0.50 27.98           C  
+ATOM   1195  C   LYS 1 172      28.702  15.703  40.353  0.50 27.46           C  
+ATOM   1196  O   LYS 1 172      28.783  14.954  39.378  0.50 27.50           O  
+ATOM   1197  CB  LYS 1 172      28.642  14.647  42.609  0.50 31.22           C  
+ATOM   1198  CG  LYS 1 172      29.442  13.848  43.623  0.50 36.43           C  
+ATOM   1199  CD  LYS 1 172      28.559  12.823  44.331  0.50 40.11           C  
+ATOM   1200  CE  LYS 1 172      29.368  11.941  45.274  0.50 42.88           C  
+ATOM   1201  NZ  LYS 1 172      29.913  12.701  46.436  0.50 45.01           N  
+ATOM   1202  N   VAL 1 173      27.932  16.788  40.373  0.50 26.21           N  
+ATOM   1203  CA  VAL 1 173      27.131  17.170  39.215  0.50 25.62           C  
+ATOM   1204  C   VAL 1 173      28.017  17.673  38.071  0.50 24.85           C  
+ATOM   1205  O   VAL 1 173      27.812  17.312  36.912  0.50 23.26           O  
+ATOM   1206  CB  VAL 1 173      26.104  18.279  39.581  0.50 27.31           C  
+ATOM   1207  CG1 VAL 1 173      25.296  18.674  38.350  0.50 29.18           C  
+ATOM   1208  CG2 VAL 1 173      25.166  17.786  40.675  0.50 26.92           C  
+ATOM   1209  N   LEU 1 174      28.992  18.520  38.393  0.50 25.33           N  
+ATOM   1210  CA  LEU 1 174      29.899  19.055  37.373  0.50 24.14           C  
+ATOM   1211  C   LEU 1 174      30.702  17.909  36.769  0.50 24.41           C  
+ATOM   1212  O   LEU 1 174      30.945  17.865  35.564  0.50 22.85           O  
+ATOM   1213  CB  LEU 1 174      30.842  20.092  37.997  0.50 23.01           C  
+ATOM   1214  CG  LEU 1 174      30.160  21.413  38.376  0.50 24.77           C  
+ATOM   1215  CD1 LEU 1 174      31.100  22.256  39.234  0.50 25.74           C  
+ATOM   1216  CD2 LEU 1 174      29.757  22.171  37.106  0.50 23.49           C  
+ATOM   1217  N   ARG 1 175      31.103  16.977  37.625  0.50 25.44           N  
+ATOM   1218  CA  ARG 1 175      31.864  15.807  37.198  0.50 26.16           C  
+ATOM   1219  C   ARG 1 175      31.086  15.020  36.136  0.50 28.40           C  
+ATOM   1220  O   ARG 1 175      31.593  14.762  35.036  0.50 29.23           O  
+ATOM   1221  CB  ARG 1 175      32.133  14.910  38.404  0.50 24.67           C  
+ATOM   1222  CG  ARG 1 175      32.828  13.592  38.075  0.50 28.09           C  
+ATOM   1223  CD  ARG 1 175      32.642  12.569  39.203  0.50 26.62           C  
+ATOM   1224  NE  ARG 1 175      31.248  12.144  39.306  0.50 25.76           N  
+ATOM   1225  CZ  ARG 1 175      30.746  11.397  40.290  0.50 27.32           C  
+ATOM   1226  NH1 ARG 1 175      31.512  10.970  41.285  0.50 27.66           N  
+ATOM   1227  NH2 ARG 1 175      29.461  11.081  40.286  0.50 25.45           N  
+ATOM   1228  N   ASN 1 176      29.853  14.647  36.475  0.50 27.74           N  
+ATOM   1229  CA  ASN 1 176      28.993  13.889  35.566  0.50 28.50           C  
+ATOM   1230  C   ASN 1 176      28.777  14.623  34.252  0.50 28.09           C  
+ATOM   1231  O   ASN 1 176      28.748  14.011  33.177  0.50 28.40           O  
+ATOM   1232  CB  ASN 1 176      27.626  13.621  36.214  0.50 27.73           C  
+ATOM   1233  CG  ASN 1 176      27.720  12.709  37.422  0.50 30.16           C  
+ATOM   1234  OD1 ASN 1 176      28.763  12.094  37.673  0.50 30.34           O  
+ATOM   1235  ND2 ASN 1 176      26.625  12.607  38.178  0.50 30.61           N  
+ATOM   1236  N   VAL 1 177      28.600  15.936  34.345  0.50 27.52           N  
+ATOM   1237  CA  VAL 1 177      28.391  16.755  33.164  0.50 26.28           C  
+ATOM   1238  C   VAL 1 177      29.614  16.735  32.249  0.50 26.17           C  
+ATOM   1239  O   VAL 1 177      29.488  16.450  31.057  0.50 26.46           O  
+ATOM   1240  CB  VAL 1 177      28.054  18.230  33.551  0.50 28.58           C  
+ATOM   1241  CG1 VAL 1 177      28.134  19.136  32.319  0.50 27.07           C  
+ATOM   1242  CG2 VAL 1 177      26.636  18.300  34.152  0.50 27.46           C  
+ATOM   1243  N   THR 1 178      30.802  17.005  32.785  0.50 26.03           N  
+ATOM   1244  CA  THR 1 178      31.965  17.016  31.906  0.50 24.77           C  
+ATOM   1245  C   THR 1 178      32.269  15.630  31.338  0.50 24.73           C  
+ATOM   1246  O   THR 1 178      32.609  15.512  30.163  0.50 24.64           O  
+ATOM   1247  CB  THR 1 178      33.235  17.625  32.592  0.50 24.94           C  
+ATOM   1248  OG1 THR 1 178      34.103  16.587  33.044  0.50 29.51           O  
+ATOM   1249  CG2 THR 1 178      32.842  18.526  33.747  0.50 21.49           C  
+ATOM   1250  N   VAL 1 179      32.118  14.583  32.146  0.50 26.53           N  
+ATOM   1251  CA  VAL 1 179      32.375  13.215  31.676  0.50 26.97           C  
+ATOM   1252  C   VAL 1 179      31.553  12.871  30.430  0.50 27.90           C  
+ATOM   1253  O   VAL 1 179      32.082  12.374  29.435  0.50 28.36           O  
+ATOM   1254  CB  VAL 1 179      32.057  12.170  32.782  0.50 28.65           C  
+ATOM   1255  CG1 VAL 1 179      31.891  10.779  32.172  0.50 28.91           C  
+ATOM   1256  CG2 VAL 1 179      33.187  12.148  33.810  0.50 29.32           C  
+ATOM   1257  N   VAL 1 180      30.257  13.136  30.494  0.50 27.45           N  
+ATOM   1258  CA  VAL 1 180      29.367  12.857  29.380  0.50 26.62           C  
+ATOM   1259  C   VAL 1 180      29.626  13.775  28.187  0.50 27.14           C  
+ATOM   1260  O   VAL 1 180      29.811  13.309  27.066  0.50 27.95           O  
+ATOM   1261  CB  VAL 1 180      27.872  13.018  29.807  0.50 29.50           C  
+ATOM   1262  CG1 VAL 1 180      26.971  13.018  28.578  0.50 28.38           C  
+ATOM   1263  CG2 VAL 1 180      27.468  11.892  30.767  0.50 27.98           C  
+ATOM   1264  N   LEU 1 181      29.626  15.082  28.414  0.50 26.92           N  
+ATOM   1265  CA  LEU 1 181      29.841  16.008  27.309  0.50 26.32           C  
+ATOM   1266  C   LEU 1 181      31.198  15.824  26.658  0.50 27.04           C  
+ATOM   1267  O   LEU 1 181      31.303  15.783  25.431  0.50 25.69           O  
+ATOM   1268  CB  LEU 1 181      29.693  17.452  27.787  0.50 27.31           C  
+ATOM   1269  CG  LEU 1 181      28.272  17.851  28.193  0.50 28.27           C  
+ATOM   1270  CD1 LEU 1 181      28.262  19.299  28.675  0.50 25.01           C  
+ATOM   1271  CD2 LEU 1 181      27.337  17.666  27.001  0.50 25.90           C  
+ATOM   1272  N   TRP 1 182      32.243  15.712  27.473  0.50 26.06           N  
+ATOM   1273  CA  TRP 1 182      33.581  15.544  26.916  0.50 28.09           C  
+ATOM   1274  C   TRP 1 182      33.736  14.262  26.094  0.50 28.30           C  
+ATOM   1275  O   TRP 1 182      34.345  14.284  25.026  0.50 26.74           O  
+ATOM   1276  CB  TRP 1 182      34.642  15.598  28.032  0.50 28.06           C  
+ATOM   1277  CG  TRP 1 182      34.906  17.000  28.555  0.50 27.47           C  
+ATOM   1278  CD1 TRP 1 182      33.970  17.954  28.855  0.50 28.39           C  
+ATOM   1279  CD2 TRP 1 182      36.177  17.569  28.903  0.50 27.79           C  
+ATOM   1280  NE1 TRP 1 182      34.578  19.075  29.370  0.50 28.84           N  
+ATOM   1281  CE2 TRP 1 182      35.932  18.866  29.410  0.50 27.84           C  
+ATOM   1282  CE3 TRP 1 182      37.499  17.108  28.838  0.50 27.96           C  
+ATOM   1283  CZ2 TRP 1 182      36.958  19.705  29.850  0.50 28.25           C  
+ATOM   1284  CZ3 TRP 1 182      38.525  17.945  29.277  0.50 28.68           C  
+ATOM   1285  CH2 TRP 1 182      38.249  19.227  29.776  0.50 28.21           C  
+ATOM   1286  N   SER 1 183      33.181  13.152  26.578  0.50 29.39           N  
+ATOM   1287  CA  SER 1 183      33.289  11.882  25.853  0.50 29.89           C  
+ATOM   1288  C   SER 1 183      32.575  11.912  24.498  0.50 29.65           C  
+ATOM   1289  O   SER 1 183      32.896  11.132  23.605  0.50 29.98           O  
+ATOM   1290  CB  SER 1 183      32.716  10.736  26.691  0.50 28.53           C  
+ATOM   1291  OG  SER 1 183      33.489  10.515  27.852  0.50 29.08           O  
+ATOM   1292  N   ALA 1 184      31.611  12.813  24.350  0.50 28.94           N  
+ATOM   1293  CA  ALA 1 184      30.864  12.922  23.104  0.50 28.13           C  
+ATOM   1294  C   ALA 1 184      31.672  13.529  21.960  0.50 30.11           C  
+ATOM   1295  O   ALA 1 184      31.375  13.280  20.788  0.50 30.96           O  
+ATOM   1296  CB  ALA 1 184      29.603  13.734  23.335  0.50 28.15           C  
+ATOM   1297  N   TYR 1 185      32.698  14.316  22.285  0.50 28.72           N  
+ATOM   1298  CA  TYR 1 185      33.507  14.946  21.248  0.50 27.78           C  
+ATOM   1299  C   TYR 1 185      34.203  13.953  20.318  0.50 29.05           C  
+ATOM   1300  O   TYR 1 185      34.027  14.006  19.106  0.50 29.72           O  
+ATOM   1301  CB  TYR 1 185      34.545  15.899  21.869  0.50 28.17           C  
+ATOM   1302  CG  TYR 1 185      33.974  17.235  22.312  0.50 28.25           C  
+ATOM   1303  CD1 TYR 1 185      33.365  17.384  23.562  0.50 28.74           C  
+ATOM   1304  CD2 TYR 1 185      34.044  18.353  21.478  0.50 27.95           C  
+ATOM   1305  CE1 TYR 1 185      32.841  18.618  23.972  0.50 27.22           C  
+ATOM   1306  CE2 TYR 1 185      33.523  19.584  21.879  0.50 27.00           C  
+ATOM   1307  CZ  TYR 1 185      32.927  19.711  23.128  0.50 26.75           C  
+ATOM   1308  OH  TYR 1 185      32.442  20.943  23.535  0.50 26.43           O  
+ATOM   1309  N   PRO 1 186      35.018  13.044  20.867  0.50 29.98           N  
+ATOM   1310  CA  PRO 1 186      35.667  12.100  19.956  0.50 32.08           C  
+ATOM   1311  C   PRO 1 186      34.659  11.308  19.104  0.50 34.69           C  
+ATOM   1312  O   PRO 1 186      34.944  10.985  17.950  0.50 35.83           O  
+ATOM   1313  CB  PRO 1 186      36.486  11.209  20.898  0.50 30.46           C  
+ATOM   1314  CG  PRO 1 186      35.750  11.290  22.203  0.50 29.52           C  
+ATOM   1315  CD  PRO 1 186      35.372  12.757  22.271  0.50 28.71           C  
+ATOM   1316  N   VAL 1 187      33.484  11.010  19.655  0.50 36.51           N  
+ATOM   1317  CA  VAL 1 187      32.477  10.266  18.901  0.50 38.74           C  
+ATOM   1318  C   VAL 1 187      31.973  11.110  17.735  0.50 40.77           C  
+ATOM   1319  O   VAL 1 187      31.994  10.666  16.582  0.50 41.10           O  
+ATOM   1320  CB  VAL 1 187      31.277   9.862  19.786  0.50 39.18           C  
+ATOM   1321  CG1 VAL 1 187      30.251   9.107  18.945  0.50 39.86           C  
+ATOM   1322  CG2 VAL 1 187      31.754   8.979  20.944  0.50 38.91           C  
+ATOM   1323  N   VAL 1 188      31.514  12.323  18.036  0.50 41.21           N  
+ATOM   1324  CA  VAL 1 188      31.043  13.229  16.997  0.50 41.32           C  
+ATOM   1325  C   VAL 1 188      32.152  13.371  15.958  0.50 42.54           C  
+ATOM   1326  O   VAL 1 188      31.908  13.329  14.754  0.50 43.25           O  
+ATOM   1327  CB  VAL 1 188      30.727  14.631  17.568  0.50 41.42           C  
+ATOM   1328  CG1 VAL 1 188      30.533  15.635  16.424  0.50 39.04           C  
+ATOM   1329  CG2 VAL 1 188      29.490  14.568  18.448  0.50 38.36           C  
+ATOM   1330  N   TRP 1 189      33.374  13.542  16.443  0.50 42.72           N  
+ATOM   1331  CA  TRP 1 189      34.532  13.685  15.574  0.50 44.29           C  
+ATOM   1332  C   TRP 1 189      34.629  12.455  14.675  0.50 45.88           C  
+ATOM   1333  O   TRP 1 189      34.769  12.557  13.455  0.50 45.44           O  
+ATOM   1334  CB  TRP 1 189      35.797  13.775  16.427  0.50 43.04           C  
+ATOM   1335  CG  TRP 1 189      37.016  14.313  15.738  0.50 44.12           C  
+ATOM   1336  CD1 TRP 1 189      37.386  15.626  15.639  0.50 44.60           C  
+ATOM   1337  CD2 TRP 1 189      38.076  13.553  15.144  0.50 44.03           C  
+ATOM   1338  NE1 TRP 1 189      38.616  15.729  15.034  0.50 44.90           N  
+ATOM   1339  CE2 TRP 1 189      39.062  14.472  14.717  0.50 45.07           C  
+ATOM   1340  CE3 TRP 1 189      38.291  12.182  14.933  0.50 44.51           C  
+ATOM   1341  CZ2 TRP 1 189      40.250  14.066  14.090  0.50 45.10           C  
+ATOM   1342  CZ3 TRP 1 189      39.472  11.775  14.308  0.50 44.57           C  
+ATOM   1343  CH2 TRP 1 189      40.436  12.718  13.894  0.50 45.79           C  
+ATOM   1344  N   LEU 1 190      34.544  11.293  15.309  0.50 46.79           N  
+ATOM   1345  CA  LEU 1 190      34.648  10.014  14.631  0.50 48.35           C  
+ATOM   1346  C   LEU 1 190      33.547   9.764  13.604  0.50 49.64           C  
+ATOM   1347  O   LEU 1 190      33.779   9.090  12.603  0.50 50.24           O  
+ATOM   1348  CB  LEU 1 190      34.655   8.893  15.674  0.50 48.40           C  
+ATOM   1349  CG  LEU 1 190      35.528   7.674  15.373  0.50 48.35           C  
+ATOM   1350  CD1 LEU 1 190      36.971   8.101  15.209  0.50 46.02           C  
+ATOM   1351  CD2 LEU 1 190      35.395   6.660  16.502  0.50 49.65           C  
+ATOM   1352  N   ILE 1 191      32.356  10.305  13.841  0.50 50.81           N  
+ATOM   1353  CA  ILE 1 191      31.247  10.105  12.910  0.50 51.16           C  
+ATOM   1354  C   ILE 1 191      31.080  11.250  11.919  0.50 51.63           C  
+ATOM   1355  O   ILE 1 191      30.254  11.175  11.012  0.50 51.56           O  
+ATOM   1356  CB  ILE 1 191      29.904   9.928  13.652  0.50 51.37           C  
+ATOM   1357  CG1 ILE 1 191      29.586  11.187  14.458  0.50 51.98           C  
+ATOM   1358  CG2 ILE 1 191      29.961   8.703  14.548  0.50 50.90           C  
+ATOM   1359  CD1 ILE 1 191      28.234  11.152  15.139  0.50 52.93           C  
+ATOM   1360  N   GLY 1 192      31.857  12.311  12.100  0.50 52.88           N  
+ATOM   1361  CA  GLY 1 192      31.762  13.453  11.211  0.50 52.62           C  
+ATOM   1362  C   GLY 1 192      32.664  13.319  10.002  0.50 54.01           C  
+ATOM   1363  O   GLY 1 192      33.200  12.246   9.735  0.50 53.49           O  
+ATOM   1364  N   SER 1 193      32.854  14.418   9.280  0.50 55.28           N  
+ATOM   1365  CA  SER 1 193      33.677  14.410   8.076  0.50 55.88           C  
+ATOM   1366  C   SER 1 193      35.145  14.073   8.326  0.50 56.55           C  
+ATOM   1367  O   SER 1 193      35.988  14.296   7.457  0.50 56.93           O  
+ATOM   1368  CB  SER 1 193      33.598  15.764   7.375  0.50 55.33           C  
+ATOM   1369  OG  SER 1 193      34.454  16.701   8.002  0.50 58.08           O  
+ATOM   1370  N   GLU 1 194      35.460  13.547   9.503  0.50 56.84           N  
+ATOM   1371  CA  GLU 1 194      36.843  13.194   9.801  0.50 56.84           C  
+ATOM   1372  C   GLU 1 194      36.956  11.685   9.990  0.50 56.16           C  
+ATOM   1373  O   GLU 1 194      38.040  11.119   9.888  0.50 55.89           O  
+ATOM   1374  CB  GLU 1 194      37.317  13.912  11.063  0.50 57.96           C  
+ATOM   1375  CG  GLU 1 194      38.811  14.157  11.106  0.50 59.03           C  
+ATOM   1376  CD  GLU 1 194      39.199  15.487  10.489  0.50 58.60           C  
+ATOM   1377  OE1 GLU 1 194      38.691  16.525  10.966  0.50 59.22           O  
+ATOM   1378  OE2 GLU 1 194      40.011  15.498   9.541  0.50 57.57           O  
+ATOM   1379  N   GLY 1 195      35.825  11.045  10.270  0.50 55.97           N  
+ATOM   1380  CA  GLY 1 195      35.808   9.606  10.453  0.50 56.95           C  
+ATOM   1381  C   GLY 1 195      34.913   8.981   9.401  0.50 57.66           C  
+ATOM   1382  O   GLY 1 195      35.304   8.849   8.244  0.50 55.92           O  
+ATOM   1383  N   ALA 1 196      33.714   8.585   9.814  0.50 58.53           N  
+ATOM   1384  CA  ALA 1 196      32.728   8.011   8.913  0.50 59.75           C  
+ATOM   1385  C   ALA 1 196      31.893   9.215   8.486  0.50 60.81           C  
+ATOM   1386  O   ALA 1 196      31.818  10.198   9.217  0.50 61.98           O  
+ATOM   1387  CB  ALA 1 196      31.864   7.002   9.657  0.50 59.78           C  
+ATOM   1388  N   GLY 1 197      31.265   9.156   7.322  0.50 61.29           N  
+ATOM   1389  CA  GLY 1 197      30.475  10.299   6.890  0.50 61.32           C  
+ATOM   1390  C   GLY 1 197      29.056  10.342   7.429  0.50 61.13           C  
+ATOM   1391  O   GLY 1 197      28.223  11.098   6.930  0.50 62.01           O  
+ATOM   1392  N   ILE 1 198      28.778   9.542   8.451  0.50 60.51           N  
+ATOM   1393  CA  ILE 1 198      27.446   9.478   9.046  0.50 60.35           C  
+ATOM   1394  C   ILE 1 198      26.826  10.848   9.310  0.50 60.14           C  
+ATOM   1395  O   ILE 1 198      25.604  10.991   9.328  0.50 59.56           O  
+ATOM   1396  CB  ILE 1 198      27.481   8.722  10.387  0.50 61.20           C  
+ATOM   1397  CG1 ILE 1 198      28.259   7.416  10.229  0.50 61.65           C  
+ATOM   1398  CG2 ILE 1 198      26.061   8.435  10.865  0.50 61.21           C  
+ATOM   1399  CD1 ILE 1 198      28.524   6.713  11.542  0.50 62.17           C  
+ATOM   1400  N   VAL 1 199      27.671  11.853   9.513  0.50 59.90           N  
+ATOM   1401  CA  VAL 1 199      27.194  13.196   9.817  0.50 59.70           C  
+ATOM   1402  C   VAL 1 199      27.781  14.281   8.916  0.50 58.55           C  
+ATOM   1403  O   VAL 1 199      28.998  14.452   8.850  0.50 59.62           O  
+ATOM   1404  CB  VAL 1 199      27.515  13.547  11.288  0.50 60.16           C  
+ATOM   1405  CG1 VAL 1 199      26.927  14.897  11.652  0.50 60.98           C  
+ATOM   1406  CG2 VAL 1 199      26.977  12.462  12.202  0.50 60.66           C  
+ATOM   1407  N   PRO 1 200      26.916  15.033   8.208  0.50 57.74           N  
+ATOM   1408  CA  PRO 1 200      27.376  16.107   7.315  0.50 56.64           C  
+ATOM   1409  C   PRO 1 200      27.946  17.292   8.100  0.50 56.84           C  
+ATOM   1410  O   PRO 1 200      27.532  17.553   9.229  0.50 57.53           O  
+ATOM   1411  CB  PRO 1 200      26.117  16.468   6.526  0.50 56.10           C  
+ATOM   1412  CG  PRO 1 200      25.006  16.153   7.488  0.50 55.91           C  
+ATOM   1413  CD  PRO 1 200      25.451  14.864   8.130  0.50 56.43           C  
+ATOM   1414  N   LEU 1 201      28.896  18.000   7.498  0.50 56.63           N  
+ATOM   1415  CA  LEU 1 201      29.532  19.138   8.147  0.50 56.61           C  
+ATOM   1416  C   LEU 1 201      28.566  20.005   8.955  0.50 56.05           C  
+ATOM   1417  O   LEU 1 201      28.809  20.287  10.131  0.50 56.25           O  
+ATOM   1418  CB  LEU 1 201      30.258  20.000   7.108  0.50 58.23           C  
+ATOM   1419  CG  LEU 1 201      31.652  19.542   6.657  0.50 59.94           C  
+ATOM   1420  CD1 LEU 1 201      31.588  18.170   5.994  0.50 60.72           C  
+ATOM   1421  CD2 LEU 1 201      32.218  20.574   5.691  0.50 61.15           C  
+ATOM   1422  N   ASN 1 202      27.472  20.420   8.327  0.50 54.22           N  
+ATOM   1423  CA  ASN 1 202      26.481  21.258   8.985  0.50 53.04           C  
+ATOM   1424  C   ASN 1 202      25.992  20.664  10.303  0.50 51.50           C  
+ATOM   1425  O   ASN 1 202      25.952  21.354  11.323  0.50 51.25           O  
+ATOM   1426  CB  ASN 1 202      25.307  21.494   8.034  0.50 54.58           C  
+ATOM   1427  CG  ASN 1 202      24.905  20.235   7.295  0.50 55.35           C  
+ATOM   1428  OD1 ASN 1 202      24.138  19.422   7.809  0.50 56.64           O  
+ATOM   1429  ND2 ASN 1 202      25.446  20.055   6.089  0.50 54.71           N  
+ATOM   1430  N   ILE 1 203      25.620  19.390  10.290  0.50 49.77           N  
+ATOM   1431  CA  ILE 1 203      25.152  18.740  11.512  0.50 48.79           C  
+ATOM   1432  C   ILE 1 203      26.305  18.618  12.517  0.50 47.09           C  
+ATOM   1433  O   ILE 1 203      26.102  18.698  13.726  0.50 45.91           O  
+ATOM   1434  CB  ILE 1 203      24.597  17.326  11.220  0.50 49.27           C  
+ATOM   1435  CG1 ILE 1 203      23.487  17.407  10.170  0.50 49.71           C  
+ATOM   1436  CG2 ILE 1 203      24.071  16.699  12.502  0.50 48.82           C  
+ATOM   1437  CD1 ILE 1 203      22.338  18.319  10.547  0.50 51.04           C  
+ATOM   1438  N   GLU 1 204      27.514  18.418  12.008  0.50 45.37           N  
+ATOM   1439  CA  GLU 1 204      28.676  18.291  12.872  0.50 45.29           C  
+ATOM   1440  C   GLU 1 204      28.853  19.609  13.626  0.50 43.54           C  
+ATOM   1441  O   GLU 1 204      29.035  19.640  14.854  0.50 41.31           O  
+ATOM   1442  CB  GLU 1 204      29.927  17.999  12.042  0.50 45.92           C  
+ATOM   1443  CG  GLU 1 204      31.131  17.630  12.879  0.50 49.69           C  
+ATOM   1444  CD  GLU 1 204      31.154  16.158  13.266  0.50 52.25           C  
+ATOM   1445  OE1 GLU 1 204      30.071  15.539  13.366  0.50 53.07           O  
+ATOM   1446  OE2 GLU 1 204      32.265  15.624  13.481  0.50 52.78           O  
+ATOM   1447  N   THR 1 205      28.791  20.700  12.871  0.50 41.41           N  
+ATOM   1448  CA  THR 1 205      28.934  22.024  13.441  0.50 40.82           C  
+ATOM   1449  C   THR 1 205      27.917  22.256  14.543  0.50 40.20           C  
+ATOM   1450  O   THR 1 205      28.264  22.721  15.630  0.50 39.97           O  
+ATOM   1451  CB  THR 1 205      28.766  23.096  12.361  0.50 41.14           C  
+ATOM   1452  OG1 THR 1 205      29.877  23.026  11.458  0.50 41.50           O  
+ATOM   1453  CG2 THR 1 205      28.706  24.486  12.986  0.50 39.52           C  
+ATOM   1454  N   LEU 1 206      26.664  21.922  14.257  0.50 39.65           N  
+ATOM   1455  CA  LEU 1 206      25.580  22.091  15.214  0.50 38.89           C  
+ATOM   1456  C   LEU 1 206      25.863  21.298  16.478  0.50 37.69           C  
+ATOM   1457  O   LEU 1 206      25.650  21.777  17.590  0.50 37.07           O  
+ATOM   1458  CB  LEU 1 206      24.263  21.630  14.580  0.50 40.35           C  
+ATOM   1459  CG  LEU 1 206      22.947  21.565  15.376  0.50 42.57           C  
+ATOM   1460  CD1 LEU 1 206      22.882  20.251  16.114  0.50 44.35           C  
+ATOM   1461  CD2 LEU 1 206      22.812  22.748  16.338  0.50 42.62           C  
+ATOM   1462  N   LEU 1 207      26.358  20.081  16.301  0.50 37.11           N  
+ATOM   1463  CA  LEU 1 207      26.656  19.222  17.433  0.50 36.85           C  
+ATOM   1464  C   LEU 1 207      27.754  19.809  18.323  0.50 35.49           C  
+ATOM   1465  O   LEU 1 207      27.583  19.899  19.537  0.50 34.35           O  
+ATOM   1466  CB  LEU 1 207      27.032  17.824  16.932  0.50 38.03           C  
+ATOM   1467  CG  LEU 1 207      25.860  17.122  16.221  0.50 40.24           C  
+ATOM   1468  CD1 LEU 1 207      26.287  15.739  15.736  0.50 39.32           C  
+ATOM   1469  CD2 LEU 1 207      24.668  17.009  17.183  0.50 40.68           C  
+ATOM   1470  N   PHE 1 208      28.871  20.215  17.729  0.50 34.16           N  
+ATOM   1471  CA  PHE 1 208      29.940  20.802  18.523  0.50 34.74           C  
+ATOM   1472  C   PHE 1 208      29.447  22.079  19.213  0.50 33.92           C  
+ATOM   1473  O   PHE 1 208      29.830  22.362  20.350  0.50 33.50           O  
+ATOM   1474  CB  PHE 1 208      31.172  21.096  17.652  0.50 34.68           C  
+ATOM   1475  CG  PHE 1 208      31.999  19.869  17.331  0.50 34.54           C  
+ATOM   1476  CD1 PHE 1 208      32.433  19.019  18.347  0.50 34.59           C  
+ATOM   1477  CD2 PHE 1 208      32.364  19.578  16.015  0.50 35.89           C  
+ATOM   1478  CE1 PHE 1 208      33.223  17.894  18.061  0.50 33.57           C  
+ATOM   1479  CE2 PHE 1 208      33.153  18.461  15.713  0.50 33.78           C  
+ATOM   1480  CZ  PHE 1 208      33.585  17.618  16.736  0.50 33.52           C  
+ATOM   1481  N   MET 1 209      28.579  22.827  18.537  0.50 33.10           N  
+ATOM   1482  CA  MET 1 209      28.024  24.058  19.093  0.50 33.39           C  
+ATOM   1483  C   MET 1 209      27.214  23.743  20.337  0.50 32.45           C  
+ATOM   1484  O   MET 1 209      27.307  24.440  21.348  0.50 33.49           O  
+ATOM   1485  CB  MET 1 209      27.135  24.757  18.059  0.50 34.99           C  
+ATOM   1486  CG  MET 1 209      26.662  26.158  18.449  0.50 35.95           C  
+ATOM   1487  SD  MET 1 209      25.185  26.180  19.492  0.50 37.81           S  
+ATOM   1488  CE  MET 1 209      23.904  25.902  18.259  0.50 36.76           C  
+ATOM   1489  N   VAL 1 210      26.418  22.686  20.273  0.50 32.28           N  
+ATOM   1490  CA  VAL 1 210      25.616  22.311  21.426  0.50 31.50           C  
+ATOM   1491  C   VAL 1 210      26.531  21.815  22.543  0.50 30.17           C  
+ATOM   1492  O   VAL 1 210      26.311  22.109  23.717  0.50 31.34           O  
+ATOM   1493  CB  VAL 1 210      24.590  21.223  21.054  0.50 33.75           C  
+ATOM   1494  CG1 VAL 1 210      23.827  20.773  22.297  0.50 34.74           C  
+ATOM   1495  CG2 VAL 1 210      23.615  21.772  20.013  0.50 33.24           C  
+ATOM   1496  N   LEU 1 211      27.562  21.064  22.180  0.50 29.26           N  
+ATOM   1497  CA  LEU 1 211      28.503  20.555  23.172  0.50 29.83           C  
+ATOM   1498  C   LEU 1 211      29.267  21.723  23.811  0.50 27.92           C  
+ATOM   1499  O   LEU 1 211      29.312  21.860  25.037  0.50 29.55           O  
+ATOM   1500  CB  LEU 1 211      29.484  19.576  22.512  0.50 30.60           C  
+ATOM   1501  CG  LEU 1 211      29.112  18.087  22.477  0.50 33.98           C  
+ATOM   1502  CD1 LEU 1 211      27.732  17.904  21.895  0.50 34.27           C  
+ATOM   1503  CD2 LEU 1 211      30.152  17.312  21.667  0.50 32.60           C  
+ATOM   1504  N   ASP 1 212      29.848  22.580  22.981  0.50 25.48           N  
+ATOM   1505  CA  ASP 1 212      30.595  23.725  23.500  0.50 26.04           C  
+ATOM   1506  C   ASP 1 212      29.766  24.578  24.479  0.50 24.90           C  
+ATOM   1507  O   ASP 1 212      30.189  24.835  25.616  0.50 24.64           O  
+ATOM   1508  CB  ASP 1 212      31.111  24.604  22.347  0.50 22.61           C  
+ATOM   1509  CG  ASP 1 212      32.217  23.931  21.530  0.50 24.04           C  
+ATOM   1510  OD1 ASP 1 212      32.927  23.049  22.061  0.50 24.20           O  
+ATOM   1511  OD2 ASP 1 212      32.397  24.297  20.342  0.50 25.01           O  
+ATOM   1512  N   VAL 1 213      28.582  25.004  24.056  0.50 26.60           N  
+ATOM   1513  CA  VAL 1 213      27.739  25.832  24.917  0.50 25.36           C  
+ATOM   1514  C   VAL 1 213      27.396  25.149  26.229  0.50 24.74           C  
+ATOM   1515  O   VAL 1 213      27.466  25.760  27.301  0.50 26.64           O  
+ATOM   1516  CB  VAL 1 213      26.431  26.226  24.194  0.50 27.55           C  
+ATOM   1517  CG1 VAL 1 213      25.516  27.008  25.141  0.50 26.62           C  
+ATOM   1518  CG2 VAL 1 213      26.759  27.071  22.974  0.50 24.68           C  
+ATOM   1519  N   SER 1 214      27.032  23.876  26.153  0.50 24.57           N  
+ATOM   1520  CA  SER 1 214      26.677  23.123  27.350  0.50 24.63           C  
+ATOM   1521  C   SER 1 214      27.894  22.907  28.236  0.50 23.86           C  
+ATOM   1522  O   SER 1 214      27.824  23.058  29.454  0.50 24.80           O  
+ATOM   1523  CB  SER 1 214      26.090  21.764  26.964  0.50 23.96           C  
+ATOM   1524  OG  SER 1 214      25.077  21.907  25.989  0.50 24.13           O  
+ATOM   1525  N   ALA 1 215      29.008  22.532  27.617  0.50 25.88           N  
+ATOM   1526  CA  ALA 1 215      30.246  22.278  28.349  0.50 26.76           C  
+ATOM   1527  C   ALA 1 215      30.827  23.530  29.008  0.50 25.36           C  
+ATOM   1528  O   ALA 1 215      31.587  23.423  29.969  0.50 24.86           O  
+ATOM   1529  CB  ALA 1 215      31.286  21.663  27.411  0.50 26.80           C  
+ATOM   1530  N   LYS 1 216      30.468  24.705  28.494  0.50 24.93           N  
+ATOM   1531  CA  LYS 1 216      30.981  25.971  29.034  0.50 25.69           C  
+ATOM   1532  C   LYS 1 216      29.962  26.799  29.806  0.50 25.44           C  
+ATOM   1533  O   LYS 1 216      30.107  27.007  31.013  0.50 25.35           O  
+ATOM   1534  CB  LYS 1 216      31.552  26.804  27.894  0.50 25.12           C  
+ATOM   1535  CG  LYS 1 216      32.723  26.124  27.242  0.50 24.68           C  
+ATOM   1536  CD  LYS 1 216      33.028  26.690  25.879  0.50 26.69           C  
+ATOM   1537  CE  LYS 1 216      34.396  26.218  25.462  0.50 29.45           C  
+ATOM   1538  NZ  LYS 1 216      34.394  25.310  24.318  0.50 30.50           N  
+ATOM   1539  N   VAL 1 217      28.941  27.290  29.112  0.50 24.93           N  
+ATOM   1540  CA  VAL 1 217      27.901  28.079  29.772  0.50 24.60           C  
+ATOM   1541  C   VAL 1 217      27.058  27.185  30.686  0.50 24.01           C  
+ATOM   1542  O   VAL 1 217      26.787  27.536  31.837  0.50 25.78           O  
+ATOM   1543  CB  VAL 1 217      27.009  28.757  28.728  0.50 26.33           C  
+ATOM   1544  CG1 VAL 1 217      25.913  29.575  29.408  0.50 24.86           C  
+ATOM   1545  CG2 VAL 1 217      27.872  29.632  27.834  0.50 21.89           C  
+ATOM   1546  N   GLY 1 218      26.650  26.026  30.175  0.50 24.46           N  
+ATOM   1547  CA  GLY 1 218      25.874  25.102  30.987  0.50 23.15           C  
+ATOM   1548  C   GLY 1 218      26.653  24.769  32.246  0.50 23.80           C  
+ATOM   1549  O   GLY 1 218      26.168  24.939  33.371  0.50 24.59           O  
+ATOM   1550  N   PHE 1 219      27.880  24.297  32.051  0.50 24.93           N  
+ATOM   1551  CA  PHE 1 219      28.782  23.948  33.153  0.50 22.90           C  
+ATOM   1552  C   PHE 1 219      28.950  25.158  34.067  0.50 22.89           C  
+ATOM   1553  O   PHE 1 219      28.890  25.036  35.288  0.50 23.21           O  
+ATOM   1554  CB  PHE 1 219      30.138  23.514  32.563  0.50 23.12           C  
+ATOM   1555  CG  PHE 1 219      31.240  23.335  33.572  0.50 22.32           C  
+ATOM   1556  CD1 PHE 1 219      31.810  24.431  34.211  0.50 22.19           C  
+ATOM   1557  CD2 PHE 1 219      31.762  22.068  33.824  0.50 23.46           C  
+ATOM   1558  CE1 PHE 1 219      32.890  24.273  35.078  0.50 23.93           C  
+ATOM   1559  CE2 PHE 1 219      32.843  21.892  34.690  0.50 23.28           C  
+ATOM   1560  CZ  PHE 1 219      33.412  22.994  35.318  0.50 24.62           C  
+ATOM   1561  N   GLY 1 220      29.161  26.330  33.475  0.50 23.73           N  
+ATOM   1562  CA  GLY 1 220      29.339  27.535  34.272  0.50 24.73           C  
+ATOM   1563  C   GLY 1 220      28.114  27.928  35.075  0.50 25.37           C  
+ATOM   1564  O   GLY 1 220      28.234  28.386  36.218  0.50 25.63           O  
+ATOM   1565  N   LEU 1 221      26.934  27.762  34.478  0.50 25.54           N  
+ATOM   1566  CA  LEU 1 221      25.681  28.086  35.160  0.50 26.98           C  
+ATOM   1567  C   LEU 1 221      25.560  27.249  36.420  0.50 25.28           C  
+ATOM   1568  O   LEU 1 221      25.256  27.749  37.499  0.50 24.83           O  
+ATOM   1569  CB  LEU 1 221      24.483  27.793  34.248  0.50 29.96           C  
+ATOM   1570  CG  LEU 1 221      24.173  28.790  33.129  0.50 31.01           C  
+ATOM   1571  CD1 LEU 1 221      23.176  28.177  32.156  0.50 32.73           C  
+ATOM   1572  CD2 LEU 1 221      23.604  30.074  33.739  0.50 32.26           C  
+ATOM   1573  N   ILE 1 222      25.793  25.955  36.277  0.50 26.34           N  
+ATOM   1574  CA  ILE 1 222      25.708  25.075  37.426  0.50 27.46           C  
+ATOM   1575  C   ILE 1 222      26.687  25.496  38.505  0.50 27.14           C  
+ATOM   1576  O   ILE 1 222      26.332  25.554  39.679  0.50 28.79           O  
+ATOM   1577  CB  ILE 1 222      25.989  23.617  37.022  0.50 28.67           C  
+ATOM   1578  CG1 ILE 1 222      24.805  23.086  36.208  0.50 27.37           C  
+ATOM   1579  CG2 ILE 1 222      26.248  22.750  38.277  0.50 27.64           C  
+ATOM   1580  CD1 ILE 1 222      25.074  21.752  35.536  0.50 30.41           C  
+ATOM   1581  N   LEU 1 223      27.920  25.806  38.113  0.50 27.01           N  
+ATOM   1582  CA  LEU 1 223      28.933  26.197  39.090  0.50 26.43           C  
+ATOM   1583  C   LEU 1 223      28.663  27.517  39.815  0.50 25.15           C  
+ATOM   1584  O   LEU 1 223      28.526  27.543  41.032  0.50 25.75           O  
+ATOM   1585  CB  LEU 1 223      30.318  26.254  38.420  0.50 24.54           C  
+ATOM   1586  CG  LEU 1 223      31.477  26.849  39.238  0.50 26.21           C  
+ATOM   1587  CD1 LEU 1 223      31.739  25.999  40.483  0.50 24.05           C  
+ATOM   1588  CD2 LEU 1 223      32.731  26.908  38.376  0.50 26.77           C  
+ATOM   1589  N   LEU 1 224      28.582  28.614  39.071  0.50 27.15           N  
+ATOM   1590  CA  LEU 1 224      28.389  29.931  39.686  0.50 28.95           C  
+ATOM   1591  C   LEU 1 224      27.078  30.161  40.424  0.50 31.02           C  
+ATOM   1592  O   LEU 1 224      26.929  31.154  41.130  0.50 31.91           O  
+ATOM   1593  CB  LEU 1 224      28.578  31.021  38.631  0.50 26.43           C  
+ATOM   1594  CG  LEU 1 224      29.949  30.946  37.942  0.50 27.68           C  
+ATOM   1595  CD1 LEU 1 224      30.068  32.011  36.847  0.50 23.82           C  
+ATOM   1596  CD2 LEU 1 224      31.034  31.106  38.999  0.50 24.19           C  
+ATOM   1597  N   ARG 1 225      26.120  29.260  40.263  0.50 33.02           N  
+ATOM   1598  CA  ARG 1 225      24.850  29.426  40.955  0.50 36.13           C  
+ATOM   1599  C   ARG 1 225      24.817  28.561  42.204  0.50 36.19           C  
+ATOM   1600  O   ARG 1 225      23.755  28.302  42.760  0.50 37.43           O  
+ATOM   1601  CB  ARG 1 225      23.690  29.059  40.031  0.50 37.41           C  
+ATOM   1602  CG  ARG 1 225      23.567  29.983  38.825  0.50 40.23           C  
+ATOM   1603  CD  ARG 1 225      22.420  29.561  37.919  0.50 45.06           C  
+ATOM   1604  NE  ARG 1 225      21.146  29.584  38.631  0.50 50.80           N  
+ATOM   1605  CZ  ARG 1 225      19.978  29.265  38.092  0.50 51.80           C  
+ATOM   1606  NH1 ARG 1 225      19.912  28.894  36.818  0.50 52.66           N  
+ATOM   1607  NH2 ARG 1 225      18.877  29.320  38.833  0.50 53.72           N  
+ATOM   1608  N   SER 1 226      25.989  28.116  42.643  0.50 35.89           N  
+ATOM   1609  CA  SER 1 226      26.069  27.273  43.822  0.50 36.56           C  
+ATOM   1610  C   SER 1 226      26.871  27.974  44.903  0.50 37.49           C  
+ATOM   1611  O   SER 1 226      27.702  28.827  44.612  0.50 39.27           O  
+ATOM   1612  CB  SER 1 226      26.747  25.947  43.474  0.50 37.38           C  
+ATOM   1613  OG  SER 1 226      28.136  26.135  43.265  0.50 35.32           O  
+ATOM   1614  N   ARG 1 227      26.623  27.614  46.154  0.50 39.34           N  
+ATOM   1615  CA  ARG 1 227      27.357  28.207  47.258  0.50 41.13           C  
+ATOM   1616  C   ARG 1 227      28.694  27.497  47.385  0.50 40.63           C  
+ATOM   1617  O   ARG 1 227      29.485  27.811  48.267  0.50 41.79           O  
+ATOM   1618  CB  ARG 1 227      26.573  28.052  48.559  0.50 43.98           C  
+ATOM   1619  CG  ARG 1 227      25.172  28.661  48.512  0.50 47.86           C  
+ATOM   1620  CD  ARG 1 227      25.207  30.149  48.158  0.50 49.60           C  
+ATOM   1621  NE  ARG 1 227      25.829  30.952  49.207  0.50 53.08           N  
+ATOM   1622  CZ  ARG 1 227      25.841  32.284  49.229  0.50 54.30           C  
+ATOM   1623  NH1 ARG 1 227      25.260  32.974  48.256  0.50 53.78           N  
+ATOM   1624  NH2 ARG 1 227      26.441  32.926  50.223  0.50 54.47           N  
+ATOM   1625  N   ALA 1 228      28.939  26.542  46.491  0.50 39.92           N  
+ATOM   1626  CA  ALA 1 228      30.169  25.763  46.509  0.50 39.74           C  
+ATOM   1627  C   ALA 1 228      31.417  26.586  46.208  0.50 39.61           C  
+ATOM   1628  O   ALA 1 228      32.523  26.180  46.548  0.50 38.43           O  
+ATOM   1629  CB  ALA 1 228      30.067  24.609  45.522  0.50 39.76           C  
+ATOM   1630  N   ILE 1 229      31.241  27.740  45.573  0.50 39.25           N  
+ATOM   1631  CA  ILE 1 229      32.372  28.592  45.234  0.50 38.14           C  
+ATOM   1632  C   ILE 1 229      32.870  29.422  46.410  0.50 39.11           C  
+ATOM   1633  O   ILE 1 229      33.855  30.158  46.291  0.50 38.57           O  
+ATOM   1634  CB  ILE 1 229      32.032  29.538  44.046  0.50 36.94           C  
+ATOM   1635  CG1 ILE 1 229      30.833  30.429  44.400  0.50 36.60           C  
+ATOM   1636  CG2 ILE 1 229      31.765  28.703  42.789  0.50 35.48           C  
+ATOM   1637  CD1 ILE 1 229      30.420  31.390  43.288  0.50 35.79           C  
+ATOM   1638  N   PHE 1 230      32.204  29.310  47.549  0.50 41.24           N  
+ATOM   1639  CA  PHE 1 230      32.635  30.064  48.723  0.50 45.37           C  
+ATOM   1640  C   PHE 1 230      33.519  29.234  49.630  0.50 48.32           C  
+ATOM   1641  O   PHE 1 230      33.201  28.089  49.943  0.50 48.49           O  
+ATOM   1642  CB  PHE 1 230      31.419  30.597  49.482  0.50 43.77           C  
+ATOM   1643  CG  PHE 1 230      30.719  31.709  48.755  0.50 44.53           C  
+ATOM   1644  CD1 PHE 1 230      31.224  33.009  48.797  0.50 41.83           C  
+ATOM   1645  CD2 PHE 1 230      29.624  31.438  47.937  0.50 42.06           C  
+ATOM   1646  CE1 PHE 1 230      30.654  34.020  48.031  0.50 41.54           C  
+ATOM   1647  CE2 PHE 1 230      29.044  32.445  47.163  0.50 43.58           C  
+ATOM   1648  CZ  PHE 1 230      29.562  33.739  47.208  0.50 42.14           C  
+ATOM   1649  N   GLY 1 231      34.649  29.817  50.023  0.50 52.45           N  
+ATOM   1650  CA  GLY 1 231      35.577  29.127  50.895  0.50 57.03           C  
+ATOM   1651  C   GLY 1 231      34.856  28.687  52.150  0.50 60.38           C  
+ATOM   1652  O   GLY 1 231      33.890  29.322  52.573  0.50 61.33           O  
+ATOM   1653  N   GLU 1 232      35.317  27.596  52.747  0.50 63.79           N  
+ATOM   1654  CA  GLU 1 232      34.688  27.078  53.952  0.50 67.46           C  
+ATOM   1655  C   GLU 1 232      34.952  27.988  55.154  0.50 68.98           C  
+ATOM   1656  O   GLU 1 232      34.026  28.611  55.684  0.50 69.19           O  
+ATOM   1657  CB  GLU 1 232      35.183  25.646  54.215  0.50 69.13           C  
+ATOM   1658  CG  GLU 1 232      34.857  24.688  53.056  0.50 72.34           C  
+ATOM   1659  CD  GLU 1 232      35.411  23.273  53.228  0.50 73.42           C  
+ATOM   1660  OE1 GLU 1 232      36.645  23.118  53.368  0.50 74.77           O  
+ATOM   1661  OE2 GLU 1 232      34.609  22.314  53.207  0.50 73.33           O  
+ATOM   1662  N   ALA 1 233      36.213  28.073  55.570  0.50 69.94           N  
+ATOM   1663  CA  ALA 1 233      36.597  28.908  56.705  0.50 70.40           C  
+ATOM   1664  C   ALA 1 233      37.514  30.033  56.242  0.50 70.32           C  
+ATOM   1665  O   ALA 1 233      37.953  30.053  55.091  0.50 70.27           O  
+ATOM   1666  CB  ALA 1 233      37.301  28.059  57.762  0.50 71.27           C  
+TER    1667      ALA 1 233                                                      
+HETATM 1668  S   SO4 1 700      33.775  18.416  10.762  0.50136.99           S  
+HETATM 1669  O1  SO4 1 700      32.829  17.494  10.113  0.50136.98           O  
+HETATM 1670  O2  SO4 1 700      34.798  18.852   9.804  0.50137.29           O  
+HETATM 1671  O3  SO4 1 700      33.077  19.582  11.239  0.50137.24           O  
+HETATM 1672  O4  SO4 1 700      34.413  17.709  11.926  0.50137.47           O  
+HETATM 1673  C1  RET 1 250      39.074  15.736  19.806  0.50 39.49           C  
+HETATM 1674  C2  RET 1 250      39.779  14.775  18.748  0.50 40.10           C  
+HETATM 1675  C3  RET 1 250      39.525  13.338  18.876  0.50 39.77           C  
+HETATM 1676  C4  RET 1 250      39.907  12.850  20.267  0.50 38.41           C  
+HETATM 1677  C5  RET 1 250      39.264  13.649  21.414  0.50 38.87           C  
+HETATM 1678  C6  RET 1 250      38.883  15.024  21.259  0.50 38.74           C  
+HETATM 1679  C7  RET 1 250      38.306  15.786  22.505  0.50 38.62           C  
+HETATM 1680  C8  RET 1 250      37.860  17.074  22.553  0.50 37.91           C  
+HETATM 1681  C9  RET 1 250      37.269  17.717  23.729  0.50 37.77           C  
+HETATM 1682  C10 RET 1 250      36.838  19.018  23.572  0.50 36.11           C  
+HETATM 1683  C11 RET 1 250      36.252  19.805  24.647  0.50 37.38           C  
+HETATM 1684  C12 RET 1 250      35.798  21.072  24.490  0.50 34.31           C  
+HETATM 1685  C13 RET 1 250      35.185  21.818  25.624  0.50 33.16           C  
+HETATM 1686  C14 RET 1 250      34.783  23.149  25.573  0.50 32.08           C  
+HETATM 1687  C15 RET 1 250      34.710  23.978  24.367  0.50 30.50           C  
+HETATM 1688  C16 RET 1 250      39.970  16.988  19.876  0.50 38.63           C  
+HETATM 1689  C17 RET 1 250      37.695  16.122  19.219  0.50 39.80           C  
+HETATM 1690  C18 RET 1 250      39.113  12.925  22.760  0.50 36.82           C  
+HETATM 1691  C19 RET 1 250      37.110  16.937  25.028  0.50 37.00           C  
+HETATM 1692  C20 RET 1 250      34.963  21.118  26.944  0.50 31.32           C  
+HETATM 1693  C1  L3P 1 260      36.933  38.816  38.145  1.00 72.55           C  
+HETATM 1694  C2  L3P 1 260      36.751  40.049  39.061  1.00 79.81           C  
+HETATM 1695  C3  L3P 1 260      38.028  40.243  39.920  1.00 81.51           C  
+HETATM 1696  O1  L3P 1 260      35.774  38.567  37.273  1.00 66.01           O  
+HETATM 1697  O2  L3P 1 260      36.487  41.275  38.213  1.00 84.35           O  
+HETATM 1698  O3  L3P 1 260      37.578  40.882  41.213  1.00 85.66           O  
+HETATM 1699  O4  L3P 1 260      38.394  43.403  41.334  0.50 85.94           O  
+HETATM 1700  O1P L3P 1 260      39.644  41.722  42.505  0.50 86.26           O  
+HETATM 1701  O2P L3P 1 260      37.418  42.508  43.514  0.50 85.70           O  
+HETATM 1702  P1  L3P 1 260      38.299  42.135  42.136  0.50 86.16           P  
+HETATM 1703  C11 L3P 1 260      35.917  37.880  35.988  1.00 60.68           C  
+HETATM 1704  C12 L3P 1 260      36.069  38.940  34.890  1.00 62.73           C  
+HETATM 1705  C13 L3P 1 260      36.288  38.427  33.478  1.00 64.27           C  
+HETATM 1706  C14 L3P 1 260      37.571  37.612  33.401  1.00 65.70           C  
+HETATM 1707  C15 L3P 1 260      36.351  39.650  32.560  1.00 67.29           C  
+HETATM 1708  C16 L3P 1 260      36.571  39.343  31.109  1.00 68.39           C  
+HETATM 1709  C17 L3P 1 260      36.544  40.654  30.348  1.00 71.23           C  
+HETATM 1710  C18 L3P 1 260      36.352  40.548  28.801  1.00 72.82           C  
+HETATM 1711  C19 L3P 1 260      37.525  39.839  28.122  1.00 73.00           C  
+HETATM 1712  C20 L3P 1 260      36.274  41.932  28.160  1.00 75.32           C  
+HETATM 1713  C21 L3P 1 260      34.826  42.294  27.821  1.00 77.88           C  
+HETATM 1714  C22 L3P 1 260      34.545  42.155  26.300  1.00 78.33           C  
+HETATM 1715  C23 L3P 1 260      33.634  40.921  25.998  1.00 78.90           C  
+HETATM 1716  C24 L3P 1 260      34.411  39.828  25.267  1.00 77.82           C  
+HETATM 1717  C25 L3P 1 260      32.448  41.312  25.116  1.00 78.26           C  
+HETATM 1718  C26 L3P 1 260      31.190  40.651  25.699  1.00 76.47           C  
+HETATM 1719  C27 L3P 1 260      30.402  39.902  24.596  1.00 74.82           C  
+HETATM 1720  C28 L3P 1 260      29.133  40.695  24.202  1.00 74.02           C  
+HETATM 1721  C29 L3P 1 260      29.336  41.324  22.835  1.00 74.69           C  
+HETATM 1722  C30 L3P 1 260      27.908  39.769  24.126  1.00 73.81           C  
+HETATM 1723  C41 L3P 1 260      36.254  42.698  38.700  1.00 86.67           C  
+HETATM 1724  C42 L3P 1 260      34.816  42.990  39.327  1.00 87.44           C  
+HETATM 1725  C43 L3P 1 260      34.522  44.534  39.310  1.00 88.43           C  
+HETATM 1726  C44 L3P 1 260      34.380  45.085  40.732  1.00 88.01           C  
+HETATM 1727  C45 L3P 1 260      33.226  44.806  38.553  1.00 89.07           C  
+HETATM 1728  C46 L3P 1 260      33.593  45.020  37.094  1.00 88.89           C  
+HETATM 1729  C47 L3P 1 260      32.384  45.287  36.264  1.00 88.90           C  
+HETATM 1730  C48 L3P 1 260      32.769  45.490  34.807  1.00 89.29           C  
+HETATM 1731  C49 L3P 1 260      33.755  46.643  34.515  1.00 88.91           C  
+HETATM 1732  C50 L3P 1 260      31.525  45.729  34.050  1.00 90.08           C  
+HETATM 1733  C1  L2P 1 270      49.716  22.173  12.744  1.00110.15           C  
+HETATM 1734  O1  L2P 1 270      49.140  22.160  14.122  1.00110.75           O  
+HETATM 1735  C2  L2P 1 270      50.754  21.118  12.141  1.00109.54           C  
+HETATM 1736  O2  L2P 1 270      52.188  21.525  12.547  1.00108.71           O  
+HETATM 1737  C3  L2P 1 270      50.624  21.084  10.562  1.00110.32           C  
+HETATM 1738  O3  L2P 1 270      50.564  19.886   9.871  1.00110.54           O  
+HETATM 1739  C11 L2P 1 270      49.445  23.299  14.921  1.00110.96           C  
+HETATM 1740  C12 L2P 1 270      49.781  23.008  16.391  1.00110.61           C  
+HETATM 1741  C41 L2P 1 270      52.668  21.682  14.001  1.00107.05           C  
+HETATM 1742  C42 L2P 1 270      52.422  20.292  14.812  1.00104.49           C  
+HETATM 1743  C43 L2P 1 270      52.801  20.113  16.375  1.00102.33           C  
+HETATM 1744  C44 L2P 1 270      54.310  20.489  16.658  1.00102.04           C  
+HETATM 1745  C45 L2P 1 270      52.384  18.601  16.681  1.00 99.09           C  
+HETATM 1746  C46 L2P 1 270      52.601  18.034  18.133  1.00 95.31           C  
+HETATM 1747  C47 L2P 1 270      51.557  18.524  19.189  1.00 92.68           C  
+HETATM 1748  C48 L2P 1 270      51.523  17.970  20.758  1.00 89.48           C  
+HETATM 1749  C49 L2P 1 270      50.389  16.998  21.145  1.00 90.32           C  
+HETATM 1750  C50 L2P 1 270      51.519  19.303  21.725  1.00 88.01           C  
+HETATM 1751  C51 L2P 1 270      51.491  19.210  23.296  1.00 85.60           C  
+HETATM 1752  C52 L2P 1 270      51.021  20.636  23.706  1.00 84.90           C  
+HETATM 1753  C53 L2P 1 270      50.802  21.152  25.170  1.00 85.25           C  
+HETATM 1754  C54 L2P 1 270      50.299  22.541  24.801  1.00 85.62           C  
+HETATM 1755  C55 L2P 1 270      52.175  21.231  25.979  1.00 86.49           C  
+HETATM 1756  C56 L2P 1 270      52.208  22.076  27.313  1.00 88.82           C  
+HETATM 1757  C57 L2P 1 270      53.539  22.950  27.503  1.00 90.37           C  
+HETATM 1758  C58 L2P 1 270      53.686  23.846  28.822  1.00 91.19           C  
+HETATM 1759  C59 L2P 1 270      54.762  23.392  29.712  1.00 91.04           C  
+HETATM 1760  C60 L2P 1 270      54.003  25.330  28.514  1.00 91.23           C  
+HETATM 1761  C11 L3P 1 280      54.635   4.214  10.847  1.00 83.35           C  
+HETATM 1762  C12 L3P 1 280      53.954   3.488  12.101  1.00 84.25           C  
+HETATM 1763  C13 L3P 1 280      54.818   3.688  13.454  1.00 85.04           C  
+HETATM 1764  C14 L3P 1 280      56.269   3.090  13.278  1.00 85.17           C  
+HETATM 1765  C15 L3P 1 280      54.080   2.954  14.635  1.00 85.19           C  
+HETATM 1766  C16 L3P 1 280      53.620   3.975  15.717  1.00 84.92           C  
+HETATM 1767  C17 L3P 1 280      52.089   3.897  15.883  1.00 86.85           C  
+HETATM 1768  C18 L3P 1 280      51.660   3.044  17.234  1.00 87.69           C  
+HETATM 1769  C19 L3P 1 280      51.281   1.563  16.888  1.00 88.09           C  
+HETATM 1770  C20 L3P 1 280      50.411   3.826  17.929  1.00 87.91           C  
+HETATM 1771  C21 L3P 1 280      50.744   4.402  19.347  1.00 87.16           C  
+HETATM 1772  C22 L3P 1 280      49.445   5.112  19.879  1.00 87.14           C  
+HETATM 1773  C23 L3P 1 280      48.733   4.255  21.000  1.00 87.15           C  
+HETATM 1774  C24 L3P 1 280      47.460   3.680  20.358  1.00 88.18           C  
+HETATM 1775  C25 L3P 1 280      48.371   5.181  22.278  1.00 86.28           C  
+HETATM 1776  C26 L3P 1 280      47.664   4.352  23.426  1.00 85.88           C  
+HETATM 1777  C27 L3P 1 280      48.755   3.846  24.496  1.00 86.64           C  
+HETATM 1778  C28 L3P 1 280      48.068   2.979  25.657  1.00 85.75           C  
+HETATM 1779  C29 L3P 1 280      48.793   1.705  25.817  1.00 84.84           C  
+HETATM 1780  C30 L3P 1 280      48.097   3.744  26.997  1.00 85.94           C  
+HETATM 1781  C11 L3P 1 290      39.919  -0.148  14.420  1.00 94.03           C  
+HETATM 1782  C12 L3P 1 290      39.739  -0.884  15.720  1.00 94.75           C  
+HETATM 1783  C13 L3P 1 290      40.137  -0.005  16.877  1.00 95.74           C  
+HETATM 1784  C14 L3P 1 290      41.410  -0.568  17.464  1.00 94.93           C  
+HETATM 1785  C15 L3P 1 290      38.990   0.009  17.917  1.00 96.35           C  
+HETATM 1786  C16 L3P 1 290      39.310   0.907  19.139  1.00 96.81           C  
+HETATM 1787  C17 L3P 1 290      38.144   0.894  20.153  1.00 97.99           C  
+HETATM 1788  C18 L3P 1 290      38.664   0.933  21.673  1.00 98.85           C  
+HETATM 1789  C19 L3P 1 290      39.523  -0.315  21.954  1.00 98.42           C  
+HETATM 1790  C20 L3P 1 290      37.467   0.922  22.671  1.00 99.57           C  
+HETATM 1791  C21 L3P 1 290      37.762   1.818  23.886  1.00100.12           C  
+HETATM 1792  C22 L3P 1 290      36.510   1.785  24.893  1.00100.30           C  
+HETATM 1793  C23 L3P 1 290      36.913   2.337  26.411  1.00100.10           C  
+HETATM 1794  C24 L3P 1 290      37.724   1.216  27.162  1.00 99.69           C  
+HETATM 1795  C25 L3P 1 290      35.532   2.750  27.355  1.00 99.53           C  
+HETATM 1796  C26 L3P 1 290      35.549   4.381  27.861  1.00 99.08           C  
+HETATM 1797  C27 L3P 1 290      34.252   4.787  28.757  1.00 97.65           C  
+HETATM 1798  C28 L3P 1 290      34.214   6.355  29.259  1.00 96.22           C  
+HETATM 1799  C29 L3P 1 290      32.774   6.987  29.139  1.00 95.16           C  
+HETATM 1800  C30 L3P 1 290      34.675   6.459  30.759  1.00 96.69           C  
+HETATM 1801  O   HOH 1 601      32.849  20.969  30.754  0.50 15.84           O  
+HETATM 1802  O   HOH 1 602      32.633  28.383  31.966  0.50 46.89           O  
+HETATM 1803  O   HOH 1 603      34.965  25.256  19.646  0.50 43.85           O  
+HETATM 1804  O   HOH 1 605      30.472  24.394  16.168  0.50 26.00           O  
+HETATM 1805  O   HOH 1 606      32.612  24.807  14.604  0.50 58.58           O  
+HETATM 1806  O   HOH 1 607      37.269  18.755  12.627  0.50 59.81           O  
+HETATM 1807  O   HOH 1 608      31.850  21.801  10.119  0.50 62.63           O  
+HETATM 1808  O   HOH 1 609      37.657  20.679  11.379  0.50 46.68           O  
+HETATM 1809  O   HOH 1 610      34.563  14.614  11.948  0.50 41.47           O  
+HETATM 1810  O   HOH 1 611      40.423  11.189   3.942  0.50 83.17           O  
+HETATM 1811  O   HOH 1 612      35.255  17.150  12.896  0.50 60.89           O  
+HETATM 1812  O   HOH 1 613      38.253  17.930   6.657  0.50 98.38           O  
+HETATM 1813  O   HOH 1 621      33.699   7.845  42.110  0.50 66.86           O  
+HETATM 1814  O   HOH 1 622      35.976   7.831  43.650  0.50 61.86           O  
+HETATM 1815  O   HOH 1 623      32.143  37.049  36.394  0.50 24.93           O  
+HETATM 1816  O   HOH 1 624      32.438  40.876  37.313  0.50 32.81           O  
+HETATM 1817  O   HOH 1 625      26.043  41.042  41.071  0.50 56.81           O  
+HETATM 1818  O   HOH 1 626      31.442  37.751  48.417  0.50 65.85           O  
+HETATM 1819  O   HOH 1 627      32.763  37.569  51.458  0.50 72.55           O  
+HETATM 1820  O   HOH 1 628      38.491  32.389  50.721  0.50 54.89           O  
+HETATM 1821  O   HOH 1 631      27.145  15.959  48.961  0.50 70.64           O  
+HETATM 1822  O   HOH 1 632      27.405  12.783  47.225  0.50 86.62           O  
+HETATM 1823  O   HOH 1 633      50.442  12.936  10.601  0.50 62.26           O  
+HETATM 1824  O   HOH 1 634      34.269  38.991  40.450  0.50 54.88           O  
+HETATM 1825  O   HOH 1 635      32.793  38.582  38.105  0.50 26.66           O  
+ENDMDL                                                                          
+CONECT 1538 1687                                                                
+CONECT 1668 1669 1670 1671 1672                                                 
+CONECT 1669 1668                                                                
+CONECT 1670 1668                                                                
+CONECT 1671 1668                                                                
+CONECT 1672 1668                                                                
+CONECT 1673 1674 1678 1688 1689                                                 
+CONECT 1674 1673 1675                                                           
+CONECT 1675 1674 1676                                                           
+CONECT 1676 1675 1677                                                           
+CONECT 1677 1676 1678 1690                                                      
+CONECT 1678 1673 1677 1679                                                      
+CONECT 1679 1678 1680                                                           
+CONECT 1680 1679 1681                                                           
+CONECT 1681 1680 1682 1691                                                      
+CONECT 1682 1681 1683                                                           
+CONECT 1683 1682 1684                                                           
+CONECT 1684 1683 1685                                                           
+CONECT 1685 1684 1686 1692                                                      
+CONECT 1686 1685 1687                                                           
+CONECT 1687 1538 1686                                                           
+CONECT 1688 1673                                                                
+CONECT 1689 1673                                                                
+CONECT 1690 1677                                                                
+CONECT 1691 1681                                                                
+CONECT 1692 1685                                                                
+CONECT 1693 1694 1696                                                           
+CONECT 1694 1693 1695 1697                                                      
+CONECT 1695 1694 1698                                                           
+CONECT 1696 1693 1703                                                           
+CONECT 1697 1694 1723                                                           
+CONECT 1698 1695 1702                                                           
+CONECT 1699 1702                                                                
+CONECT 1700 1702                                                                
+CONECT 1701 1702                                                                
+CONECT 1702 1698 1699 1700 1701                                                 
+CONECT 1703 1696 1704                                                           
+CONECT 1704 1703 1705                                                           
+CONECT 1705 1704 1706 1707                                                      
+CONECT 1706 1705                                                                
+CONECT 1707 1705 1708                                                           
+CONECT 1708 1707 1709                                                           
+CONECT 1709 1708 1710                                                           
+CONECT 1710 1709 1711 1712                                                      
+CONECT 1711 1710                                                                
+CONECT 1712 1710 1713                                                           
+CONECT 1713 1712 1714                                                           
+CONECT 1714 1713 1715                                                           
+CONECT 1715 1714 1716 1717                                                      
+CONECT 1716 1715                                                                
+CONECT 1717 1715 1718                                                           
+CONECT 1718 1717 1719                                                           
+CONECT 1719 1718 1720                                                           
+CONECT 1720 1719 1721 1722                                                      
+CONECT 1721 1720                                                                
+CONECT 1722 1720                                                                
+CONECT 1723 1697 1724                                                           
+CONECT 1724 1723 1725                                                           
+CONECT 1725 1724 1726 1727                                                      
+CONECT 1726 1725                                                                
+CONECT 1727 1725 1728                                                           
+CONECT 1728 1727 1729                                                           
+CONECT 1729 1728 1730                                                           
+CONECT 1730 1729 1731 1732                                                      
+CONECT 1731 1730                                                                
+CONECT 1732 1730                                                                
+CONECT 1733 1734 1735                                                           
+CONECT 1734 1733 1739                                                           
+CONECT 1735 1733 1736 1737                                                      
+CONECT 1736 1735 1741                                                           
+CONECT 1737 1735 1738                                                           
+CONECT 1738 1737                                                                
+CONECT 1739 1734 1740                                                           
+CONECT 1740 1739                                                                
+CONECT 1741 1736 1742                                                           
+CONECT 1742 1741 1743                                                           
+CONECT 1743 1742 1744 1745                                                      
+CONECT 1744 1743                                                                
+CONECT 1745 1743 1746                                                           
+CONECT 1746 1745 1747                                                           
+CONECT 1747 1746 1748                                                           
+CONECT 1748 1747 1749 1750                                                      
+CONECT 1749 1748                                                                
+CONECT 1750 1748 1751                                                           
+CONECT 1751 1750 1752                                                           
+CONECT 1752 1751 1753                                                           
+CONECT 1753 1752 1754 1755                                                      
+CONECT 1754 1753                                                                
+CONECT 1755 1753 1756                                                           
+CONECT 1756 1755 1757                                                           
+CONECT 1757 1756 1758                                                           
+CONECT 1758 1757 1759 1760                                                      
+CONECT 1759 1758                                                                
+CONECT 1760 1758                                                                
+CONECT 1761 1762                                                                
+CONECT 1762 1761 1763                                                           
+CONECT 1763 1762 1764 1765                                                      
+CONECT 1764 1763                                                                
+CONECT 1765 1763 1766                                                           
+CONECT 1766 1765 1767                                                           
+CONECT 1767 1766 1768                                                           
+CONECT 1768 1767 1769 1770                                                      
+CONECT 1769 1768                                                                
+CONECT 1770 1768 1771                                                           
+CONECT 1771 1770 1772                                                           
+CONECT 1772 1771 1773                                                           
+CONECT 1773 1772 1774 1775                                                      
+CONECT 1774 1773                                                                
+CONECT 1775 1773 1776                                                           
+CONECT 1776 1775 1777                                                           
+CONECT 1777 1776 1778                                                           
+CONECT 1778 1777 1779 1780                                                      
+CONECT 1779 1778                                                                
+CONECT 1780 1778                                                                
+CONECT 1781 1782                                                                
+CONECT 1782 1781 1783                                                           
+CONECT 1783 1782 1784 1785                                                      
+CONECT 1784 1783                                                                
+CONECT 1785 1783 1786                                                           
+CONECT 1786 1785 1787                                                           
+CONECT 1787 1786 1788                                                           
+CONECT 1788 1787 1789 1790                                                      
+CONECT 1789 1788                                                                
+CONECT 1790 1788 1791                                                           
+CONECT 1791 1790 1792                                                           
+CONECT 1792 1791 1793                                                           
+CONECT 1793 1792 1794 1795                                                      
+CONECT 1794 1793                                                                
+CONECT 1795 1793 1796                                                           
+CONECT 1796 1795 1797                                                           
+CONECT 1797 1796 1798                                                           
+CONECT 1798 1797 1799 1800                                                      
+CONECT 1799 1798                                                                
+CONECT 1800 1798                                                                
+MASTER      400    0    6    8    0    0   12    6 1824    1  134   20          
+END                                                                             


### PR DESCRIPTION
This PR allows to set a current `frame_id` in the given system. This avoids repeatedly using the `frame_id` keyword argument in component accessor calls (esp. `atoms()`) when multiple operations need to performed for a frame ID other than 1.

Also, this effectively allows to switch between different models (e.g., read from a PDB file).

### Example: PDB-ID 2ICY (2 models)
```julia
julia> sys = load_pdb("2ICY.pdb");

julia> natoms(sys)
8076

julia> natoms(sys; frame_id = 2)
8039

julia> select_frame!(sys, 2); natoms(sys)
8039
```