### PR TITLE
Backports v0.7.4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,17 +30,13 @@ jobs:
       matrix:
         version:
           - 'lts'
-          - '1.12'
-          - 'pre'
+          - '1.13'
         os:
           - ubuntu-latest
         arch:
           - x64
           # Broken by dependency, cf. https://github.com/BioJulia/IndexableBitVectors.jl/issues/9
           # - x86
-        include:
-          - version: 'pre'
-            experimental: true
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -23,14 +23,10 @@ jobs:
       matrix:
         version:
           - '1.10'
-          - '1.12'
         os:
           - ubuntu-latest
         arch:
           - x64
-        include:
-          - version: '1.12'
-            experimental: true
     env:
       RESOLVER_PATH: "/tmp/resolver"
     steps:


### PR DESCRIPTION
- [x] [CI: remove experimental 1.12 from downgrade checks](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/commit/a817e131b197795708896b27e87f3402fe95f294)
- [x] [CI: bump Julia version to 1.13, drop 1.12](https://github.com/hildebrandtlab/BiochemicalAlgorithms.jl/commit/9f6185e937ce8656e2e981a70766919ce160089f)
